### PR TITLE
Fix alarm history to fixed screen proportion

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -72,7 +72,14 @@ namespace BinanceUsdtTicker
 
             // alarm geçmişi bağla
             var alertList = FindName("AlertList") as ListView;
-            if (alertList != null) alertList.ItemsSource = _alertLog;
+            if (alertList != null)
+            {
+                alertList.ItemsSource = _alertLog;
+                var screenHeight = SystemParameters.PrimaryScreenHeight / 10;
+                alertList.Height = screenHeight;
+                alertList.MinHeight = screenHeight;
+                alertList.MaxHeight = screenHeight;
+            }
 
             // servis
             _service.OnTickersUpdated += OnServiceTickersUpdated;


### PR DESCRIPTION
## Summary
- Keep alarm history list at a fixed size equal to one tenth of the primary screen height

## Testing
- ❌ `dotnet build` *(command not found)*
- ❌ `apt-get update` *(403 Forbidden when attempting to install build tools)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3dae1fdc8333834b1cee75998413