### PR TITLE
Fix combobox background in dark theme

### DIFF
--- a/Themes/Dark.xaml
+++ b/Themes/Dark.xaml
@@ -41,6 +41,12 @@
     <SolidColorBrush x:Key="Down3Bg"        Color="#FF421818"/>
     <SolidColorBrush x:Key="DownFg"         Color="#FFFFEDED"/>
 
+    <!-- System colors for controls -->
+    <SolidColorBrush x:Key="{x:Static SystemColors.WindowBrushKey}"       Color="#FF0A0F19"/>
+    <SolidColorBrush x:Key="{x:Static SystemColors.WindowTextBrushKey}"   Color="#FFE5E7EB"/>
+    <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}"      Color="#FF0A0F19"/>
+    <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}"  Color="#FFE5E7EB"/>
+
     <!-- ===== ScrollViewer with visible scrollbars ===== -->
     <Style TargetType="{x:Type ScrollViewer}">
         <Setter Property="Background" Value="{DynamicResource SurfaceAlt}"/>

--- a/Themes/Light.xaml
+++ b/Themes/Light.xaml
@@ -41,6 +41,12 @@
     <SolidColorBrush x:Key="Down3Bg"        Color="#FFF8DADA"/>
     <SolidColorBrush x:Key="DownFg"         Color="#FF7F1D1D"/>
 
+    <!-- System colors for controls -->
+    <SolidColorBrush x:Key="{x:Static SystemColors.WindowBrushKey}"       Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="{x:Static SystemColors.WindowTextBrushKey}"   Color="#FF1F2937"/>
+    <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}"      Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}"  Color="#FF1F2937"/>
+
     <!-- ===== ScrollViewer with visible scrollbars ===== -->
     <Style TargetType="{x:Type ScrollViewer}">
         <Setter Property="Background" Value="{DynamicResource SurfaceAlt}"/>


### PR DESCRIPTION
## Summary
- update system color resources so combobox backgrounds follow the active theme

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa456f2fb483338e2801de1c559f50