### PR TITLE
style: theme-aware combobox in AddAlertWindow

### DIFF
--- a/Windows/AddAlertWindow.xaml
+++ b/Windows/AddAlertWindow.xaml
@@ -30,7 +30,26 @@
 
         <!-- Koşul -->
         <TextBlock Text="Koşul:" Grid.Row="1" Grid.Column="0" Margin="0,0,12,8" VerticalAlignment="Center"/>
-        <ComboBox x:Name="TypeBox" Grid.Row="1" Grid.Column="1" Margin="0,0,0,8" SelectedIndex="0">
+        <ComboBox x:Name="TypeBox"
+                  Grid.Row="1"
+                  Grid.Column="1"
+                  Margin="0,0,0,8"
+                  SelectedIndex="0"
+                  Background="{DynamicResource SurfaceAlt}"
+                  Foreground="{DynamicResource OnSurface}"
+                  BorderBrush="{DynamicResource Divider}">
+            <ComboBox.ItemContainerStyle>
+                <Style TargetType="ComboBoxItem">
+                    <Setter Property="Background" Value="{DynamicResource SurfaceAlt}"/>
+                    <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
+                    <Style.Triggers>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource SelectionBg}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource SelectionFg}"/>
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </ComboBox.ItemContainerStyle>
             <ComboBoxItem Content="Fiyat ≥" Tag="PriceAtOrAbove" />
             <ComboBoxItem Content="Fiyat ≤" Tag="PriceAtOrBelow" />
             <ComboBoxItem Content="Fiyat [min,max]" Tag="PriceBetween" />


### PR DESCRIPTION
## Summary
- ensure AddAlertWindow's condition combobox uses theme brushes for background, foreground and selection state

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa47193d54833392b2bf1fa0639a1e