### PR TITLE
style: color-code top movers by move magnitude

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -613,12 +613,14 @@
                                                                 <Setter Property="Background" Value="{DynamicResource SurfaceAlt}"/>
                                                                 <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
                                                                 <Style.Triggers>
+                                                                        <!-- 3%+ moves: dark green with white text -->
                                                                         <DataTrigger Binding="{Binding IsMove3Plus}" Value="True">
-                                                                                <Setter Property="Background" Value="DarkGreen"/>
+                                                                                <Setter Property="Background" Value="{DynamicResource Up3Bg}"/>
                                                                                 <Setter Property="Foreground" Value="White"/>
                                                                         </DataTrigger>
+                                                                        <!-- 1-3% moves: light green with black text -->
                                                                         <DataTrigger Binding="{Binding IsMove1Plus}" Value="True">
-                                                                                <Setter Property="Background" Value="LightGreen"/>
+                                                                                <Setter Property="Background" Value="{DynamicResource Up1Bg}"/>
                                                                                 <Setter Property="Foreground" Value="Black"/>
                                                                         </DataTrigger>
                                                                 </Style.Triggers>
@@ -649,12 +651,14 @@
                                                                 <Setter Property="Background" Value="{DynamicResource SurfaceAlt}"/>
                                                                 <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
                                                                 <Style.Triggers>
+                                                                        <!-- -3% or worse: dark red with white text -->
                                                                         <DataTrigger Binding="{Binding IsMoveMinus3}" Value="True">
-                                                                                <Setter Property="Background" Value="DarkRed"/>
+                                                                                <Setter Property="Background" Value="{DynamicResource Down3Bg}"/>
                                                                                 <Setter Property="Foreground" Value="White"/>
                                                                         </DataTrigger>
+                                                                        <!-- -1% to -3%: light red with black text -->
                                                                         <DataTrigger Binding="{Binding IsMoveMinus1}" Value="True">
-                                                                                <Setter Property="Background" Value="LightCoral"/>
+                                                                                <Setter Property="Background" Value="{DynamicResource Down1Bg}"/>
                                                                                 <Setter Property="Foreground" Value="Black"/>
                                                                         </DataTrigger>
                                                                 </Style.Triggers>

--- a/Themes/Dark.xaml
+++ b/Themes/Dark.xaml
@@ -34,12 +34,10 @@
     <SolidColorBrush x:Key="RowHoverBg"      Color="#FF20252C"/>
 
     <!-- Top Movers tokens (dark) -->
-    <SolidColorBrush x:Key="Up1Bg"          Color="#FF10251B"/>
-    <SolidColorBrush x:Key="Up3Bg"          Color="#FF0F3A28"/>
-    <SolidColorBrush x:Key="UpFg"           Color="#FFE6FCEF"/>
-    <SolidColorBrush x:Key="Down1Bg"        Color="#FF251212"/>
-    <SolidColorBrush x:Key="Down3Bg"        Color="#FF421818"/>
-    <SolidColorBrush x:Key="DownFg"         Color="#FFFFEDED"/>
+    <SolidColorBrush x:Key="Up1Bg"          Color="#FF90EE90"/>
+    <SolidColorBrush x:Key="Up3Bg"          Color="#FF006400"/>
+    <SolidColorBrush x:Key="Down1Bg"        Color="#FFF08080"/>
+    <SolidColorBrush x:Key="Down3Bg"        Color="#FF8B0000"/>
 
     <!-- System colors for controls -->
     <SolidColorBrush x:Key="{x:Static SystemColors.WindowBrushKey}"       Color="#FF181A20"/>

--- a/Themes/Light.xaml
+++ b/Themes/Light.xaml
@@ -34,12 +34,10 @@
     <SolidColorBrush x:Key="RowHoverBg"      Color="#FFEFF1F5"/>
 
     <!-- Top Movers tokens (light) -->
-    <SolidColorBrush x:Key="Up1Bg"          Color="#FFE6F4EA"/>
-    <SolidColorBrush x:Key="Up3Bg"          Color="#FFC7E7D3"/>
-    <SolidColorBrush x:Key="UpFg"           Color="#FF065F46"/>
-    <SolidColorBrush x:Key="Down1Bg"        Color="#FFFDEAEA"/>
-    <SolidColorBrush x:Key="Down3Bg"        Color="#FFF8DADA"/>
-    <SolidColorBrush x:Key="DownFg"         Color="#FF7F1D1D"/>
+    <SolidColorBrush x:Key="Up1Bg"          Color="#FF90EE90"/>
+    <SolidColorBrush x:Key="Up3Bg"          Color="#FF006400"/>
+    <SolidColorBrush x:Key="Down1Bg"        Color="#FFF08080"/>
+    <SolidColorBrush x:Key="Down3Bg"        Color="#FF8B0000"/>
 
     <!-- System colors for controls -->
     <SolidColorBrush x:Key="{x:Static SystemColors.WindowBrushKey}"       Color="#FFFFFFFF"/>


### PR DESCRIPTION
## Summary
- highlight top gainers and losers using light or dark green/red depending on change magnitude
- centralize mover colors in theme resources

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository ... not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4c164c688333997d2b6f9c9d5396