### PR TITLE
Align Top Movers percentages with monospaced font

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -629,8 +629,9 @@
 						<ListBox.ItemTemplate>
 							<DataTemplate>
 								<DockPanel LastChildFill="True">
-									<TextBlock Text="{Binding Metric, StringFormat={}{0:N2}%}"
-                                               Width="70" TextAlignment="Right" DockPanel.Dock="Right"/>
+                                                                        <TextBlock Text="{Binding Metric, StringFormat={}{0:N2}%}"
+                                               Width="70" TextAlignment="Right" DockPanel.Dock="Right"
+                                               FontFamily="Consolas"/>
 									<TextBlock>
 										<Run Text="{Binding BaseSymbol, Mode=OneWay}"/>
 										<Run Text="/USDT" Foreground="Gray"/>
@@ -667,8 +668,9 @@
 						<ListBox.ItemTemplate>
 							<DataTemplate>
 								<DockPanel LastChildFill="True">
-									<TextBlock Text="{Binding Metric, StringFormat={}{0:N2}%}"
-                                               Width="70" TextAlignment="Right" DockPanel.Dock="Right"/>
+                                                                        <TextBlock Text="{Binding Metric, StringFormat={}{0:N2}%}"
+                                               Width="70" TextAlignment="Right" DockPanel.Dock="Right"
+                                               FontFamily="Consolas"/>
 									<TextBlock>
 										<Run Text="{Binding BaseSymbol, Mode=OneWay}"/>
 										<Run Text="/USDT" Foreground="Gray"/>


### PR DESCRIPTION
## Summary
- use a monospaced font for Top Movers metrics so percentage columns align cleanly

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4e444558833381d91c302b5ba61b