### PR TITLE
Center Top Movers toggle

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -600,7 +600,7 @@
                                                       Content="Top Movers: Snapshot"
                                                       Checked="btnSnapshot_Checked"
                                                       Unchecked="btnSnapshot_Unchecked"
-                                                      Margin="0,0,0,4" HorizontalAlignment="Right"/>
+                                                      Margin="0,0,0,4" HorizontalAlignment="Center"/>
 
                                         <TextBlock Grid.Row="1" Text="Yükselenler" FontWeight="Bold" Margin="0,0,0,4"/>
                                         <ListView Grid.Row="2" x:Name="TopGainersList"


### PR DESCRIPTION
## Summary
- Center the Top Movers toggle button for balanced layout

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa53631a4483338a60e81f7973b249