### PR TITLE
feat: color top movers rows by change

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -614,12 +614,12 @@
                                                                        <!-- 3%+ moves: dark green with white text -->
                                                                        <DataTrigger Binding="{Binding IsMove3Plus}" Value="True">
                                                                                <Setter Property="Background" Value="{DynamicResource Up3Bg}"/>
-                                                                               <Setter Property="Foreground" Value="White"/>
+                                                                               <Setter Property="Foreground" Value="{DynamicResource Up3Fg}"/>
                                                                        </DataTrigger>
                                                                        <!-- 1-3% moves: light green with black text -->
                                                                        <DataTrigger Binding="{Binding IsMove1Plus}" Value="True">
                                                                                <Setter Property="Background" Value="{DynamicResource Up1Bg}"/>
-                                                                               <Setter Property="Foreground" Value="Black"/>
+                                                                               <Setter Property="Foreground" Value="{DynamicResource Up1Fg}"/>
                                                                        </DataTrigger>
                                                                        <!-- Hover: highlight row -->
                                                                        <Trigger Property="IsMouseOver" Value="True">
@@ -665,12 +665,12 @@
                                                                        <!-- -3% or worse: dark red with white text -->
                                                                        <DataTrigger Binding="{Binding IsMoveMinus3}" Value="True">
                                                                                <Setter Property="Background" Value="{DynamicResource Down3Bg}"/>
-                                                                               <Setter Property="Foreground" Value="White"/>
+                                                                               <Setter Property="Foreground" Value="{DynamicResource Down3Fg}"/>
                                                                        </DataTrigger>
                                                                        <!-- -1% to -3%: light red with black text -->
                                                                        <DataTrigger Binding="{Binding IsMoveMinus1}" Value="True">
                                                                                <Setter Property="Background" Value="{DynamicResource Down1Bg}"/>
-                                                                               <Setter Property="Foreground" Value="Black"/>
+                                                                               <Setter Property="Foreground" Value="{DynamicResource Down1Fg}"/>
                                                                        </DataTrigger>
                                                                        <!-- Hover: highlight row -->
                                                                        <Trigger Property="IsMouseOver" Value="True">

--- a/Themes/Dark.xaml
+++ b/Themes/Dark.xaml
@@ -38,6 +38,10 @@
     <SolidColorBrush x:Key="Up3Bg"          Color="#FF006400"/>
     <SolidColorBrush x:Key="Down1Bg"        Color="#FFF08080"/>
     <SolidColorBrush x:Key="Down3Bg"        Color="#FF8B0000"/>
+    <SolidColorBrush x:Key="Up1Fg"          Color="#FF000000"/>
+    <SolidColorBrush x:Key="Up3Fg"          Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="Down1Fg"        Color="#FF000000"/>
+    <SolidColorBrush x:Key="Down3Fg"        Color="#FFFFFFFF"/>
 
     <!-- System colors for controls -->
     <SolidColorBrush x:Key="{x:Static SystemColors.WindowBrushKey}"       Color="#FF181A20"/>

--- a/Themes/Light.xaml
+++ b/Themes/Light.xaml
@@ -38,6 +38,10 @@
     <SolidColorBrush x:Key="Up3Bg"          Color="#FF006400"/>
     <SolidColorBrush x:Key="Down1Bg"        Color="#FFF08080"/>
     <SolidColorBrush x:Key="Down3Bg"        Color="#FF8B0000"/>
+    <SolidColorBrush x:Key="Up1Fg"          Color="#FF000000"/>
+    <SolidColorBrush x:Key="Up3Fg"          Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="Down1Fg"        Color="#FF000000"/>
+    <SolidColorBrush x:Key="Down3Fg"        Color="#FFFFFFFF"/>
 
     <!-- System colors for controls -->
     <SolidColorBrush x:Key="{x:Static SystemColors.WindowBrushKey}"       Color="#FFFFFFFF"/>


### PR DESCRIPTION
## Summary
- add theme brushes for top mover text colors
- drive Top Movers list item styling from themed brushes so rows show green/red with appropriate contrast

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa55a1ca8c8333867cec5383352382