### PR TITLE
Improve readability of green rows in dark theme

### DIFF
--- a/Themes/Dark.xaml
+++ b/Themes/Dark.xaml
@@ -34,11 +34,11 @@
     <SolidColorBrush x:Key="RowHoverBg"      Color="#FF20252C"/>
 
     <!-- Top Movers tokens (dark) -->
-    <SolidColorBrush x:Key="Up1Bg"          Color="#FF90EE90"/>
+    <SolidColorBrush x:Key="Up1Bg"          Color="#FF0E9C6A"/>
     <SolidColorBrush x:Key="Up3Bg"          Color="#FF006400"/>
     <SolidColorBrush x:Key="Down1Bg"        Color="#FFF08080"/>
     <SolidColorBrush x:Key="Down3Bg"        Color="#FF8B0000"/>
-    <SolidColorBrush x:Key="Up1Fg"          Color="#FF000000"/>
+    <SolidColorBrush x:Key="Up1Fg"          Color="#FFEAECEF"/>
     <SolidColorBrush x:Key="Up3Fg"          Color="#FFFFFFFF"/>
     <SolidColorBrush x:Key="Down1Fg"        Color="#FF000000"/>
     <SolidColorBrush x:Key="Down3Fg"        Color="#FFFFFFFF"/>


### PR DESCRIPTION
## Summary
- tweak dark theme colors so highlighted rows are easier to read

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5a31e4f88333baabc20862661489