### PR TITLE
Add chart button to open coin graphs

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -24,10 +24,27 @@
 					</ControlTemplate>
 				</Setter.Value>
 			</Setter>
-		</Style>
+                </Style>
 
-		<!-- DataGrid başlığı -->
-		<Style TargetType="DataGridColumnHeader">
+                <!-- Şeffaf grafik butonu -->
+                <Style x:Key="ChartButtonStyle" TargetType="Button">
+                        <Setter Property="OverridesDefaultStyle" Value="True"/>
+                        <Setter Property="Background" Value="Transparent"/>
+                        <Setter Property="BorderThickness" Value="0"/>
+                        <Setter Property="Padding" Value="0"/>
+                        <Setter Property="Focusable" Value="False"/>
+                        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+                        <Setter Property="Template">
+                                <Setter.Value>
+                                        <ControlTemplate TargetType="Button">
+                                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                        </ControlTemplate>
+                                </Setter.Value>
+                        </Setter>
+                </Style>
+
+                <!-- DataGrid başlığı -->
+                <Style TargetType="DataGridColumnHeader">
 			<Setter Property="Background"  Value="{DynamicResource HeaderBg}"/>
 			<Setter Property="Foreground"  Value="{DynamicResource HeaderFg}"/>
 			<Setter Property="BorderBrush" Value="{DynamicResource HeaderBorder}"/>
@@ -479,10 +496,24 @@
 								</DataTemplate.Triggers>
 							</DataTemplate>
 						</DataGridTemplateColumn.CellTemplate>
-					</DataGridTemplateColumn>
+                                        </DataGridTemplateColumn>
 
-					<!-- 1) Sembol -->
-					<DataGridTemplateColumn x:Name="ColSymbol"
+                                        <!-- 1) Grafik -->
+                                        <DataGridTemplateColumn x:Name="ColChart"
+                                            Header="Grafik" Width="32"
+                                            IsReadOnly="True" CanUserSort="False">
+                                                <DataGridTemplateColumn.CellTemplate>
+                                                        <DataTemplate>
+                                                                <Button Style="{StaticResource ChartButtonStyle}"
+                                            Click="ChartButton_Click" Cursor="Hand">
+                                                                        <TextBlock Text="📈" FontSize="16" Foreground="#AAAAAA"/>
+                                                                </Button>
+                                                        </DataTemplate>
+                                                </DataGridTemplateColumn.CellTemplate>
+                                        </DataGridTemplateColumn>
+
+                                        <!-- 2) Sembol -->
+                                        <DataGridTemplateColumn x:Name="ColSymbol"
                                             Header="Sembol"
                                             Width="1.2*" MinWidth="100">
 						<DataGridTemplateColumn.CellTemplate>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -410,6 +410,16 @@ namespace BinanceUsdtTicker
             CollectionViewSource.GetDefaultView(_rows).Refresh();
         }
 
+        private void ChartButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement fe && fe.DataContext is TickerRow row)
+            {
+                var win = new ChartWindow(row.Symbol);
+                win.Owner = this;
+                win.Show();
+            }
+        }
+
         // ---------- alarmlar (UI tarafı sizde mevcut) ----------
         private void AddAlert_Click(object sender, RoutedEventArgs e)
         {
@@ -636,10 +646,12 @@ namespace BinanceUsdtTicker
             if (Grid?.Columns == null) return;
 
             DataGridColumn? star = Grid.Columns.FirstOrDefault(c => (c.Header?.ToString() ?? "") == "★");
+            DataGridColumn? chart = Grid.Columns.FirstOrDefault(c => (c.Header?.ToString() ?? "") == "Grafik");
             DataGridColumn? symbol = Grid.Columns.FirstOrDefault(c => (c.Header?.ToString() ?? "") == "Sembol");
 
             int idx = 0;
             if (star != null) star.DisplayIndex = idx++;
+            if (chart != null) chart.DisplayIndex = idx++;
             if (symbol != null) symbol.DisplayIndex = idx++;
         }
 


### PR DESCRIPTION
## Summary
- Add transparent chart button style and chart column to main grid
- Open placeholder chart window for selected symbol on button click
- Maintain special column order with new graph column

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aa5dc9f334833380ec3f163c733e86