### PR TITLE
Fix LiveCharts namespace for CartesianChart

### DIFF
--- a/Windows/ChartWindow.xaml
+++ b/Windows/ChartWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="BinanceUsdtTicker.ChartWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:lvc="http://schemas.livecharts.com/2.0/wpf"
+        xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.WPF;assembly=LiveChartsCore.SkiaSharpView.WPF"
         Title="Grafik" Height="420" Width="680">
 
     <Grid Margin="10">


### PR DESCRIPTION
## Summary
- fix LiveCharts namespace in ChartWindow to ensure CartesianChart control is recognized

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6425193c8333b96e8a272e6523f3