### PR TITLE
Fix LiveCharts namespace for ChartWindow

### DIFF
--- a/Windows/ChartWindow.xaml
+++ b/Windows/ChartWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 
-        xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.WPF;assembly=LiveChartsCore.SkiaSharpView.WPF"
+        xmlns:lvc="http://livecharts.com"
 
         Title="Grafik" Height="420" Width="680">
 


### PR DESCRIPTION
## Summary
- use LiveCharts URL namespace in ChartWindow

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa66bb1f848333bece0da82648283f