### PR TITLE
Fix LiveCharts XAML namespace for ChartWindow

### DIFF
--- a/Windows/ChartWindow.xaml
+++ b/Windows/ChartWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 
-        xmlns:lvc="http://livecharts.com"
+        xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.WPF;assembly=LiveChartsCore.SkiaSharpView.WPF"
 
         Title="Grafik" Height="420" Width="680">
 


### PR DESCRIPTION
## Summary
- fix LiveCharts XAML namespace in ChartWindow to reference the correct assembly

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6898af708333b60676073712ec9e