### PR TITLE
Fix LiveCharts namespace for chart window

### DIFF
--- a/Windows/ChartWindow.xaml
+++ b/Windows/ChartWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 
-        xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.WPF;assembly=LiveChartsCore.SkiaSharpView.WPF"
+        xmlns:lvc="https://livecharts.dev"
 
         Title="Grafik" Height="420" Width="680">
 


### PR DESCRIPTION
## Summary
- use LiveCharts' updated namespace to enable CartesianChart control

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68aa69b0061083339ad97926aad63511