### PR TITLE
Fix LiveCharts namespace in ChartWindow

### DIFF
--- a/Windows/ChartWindow.xaml
+++ b/Windows/ChartWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 
-        xmlns:lvc="https://livecharts.dev"
+        xmlns:lvc="https://wpf.livecharts.com"
 
         Title="Grafik" Height="420" Width="680">
 


### PR DESCRIPTION
## Summary
- use LiveCharts WPF namespace so CartesianChart is recognized

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository ... is not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6b121dd88333b476c4774f238ebb