### PR TITLE
fix: correct LiveCharts XAML namespace

### DIFF
--- a/Windows/ChartWindow.xaml
+++ b/Windows/ChartWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 
-        xmlns:lvc="https://wpf.livecharts.com"
+        xmlns:lvc="https://github.com/beto-rodriguez/LiveCharts2"
 
         Title="Grafik" Height="420" Width="680">
 


### PR DESCRIPTION
## Summary
- fix CartesianChart namespace to match LiveCharts2

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6cf047e483339b15d9a4daddf6d9