### PR TITLE
Ensure ComboBox text is visible in dark mode

### DIFF
--- a/Themes/Dark.xaml
+++ b/Themes/Dark.xaml
@@ -162,12 +162,12 @@
             </Trigger>
         </Style.Triggers>
     </Style>
-    <Style TargetType="ComboBox">
+    <Style TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
         <Setter Property="Background" Value="{DynamicResource SurfaceAlt}"/>
         <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource Divider}"/>
     </Style>
-    <Style TargetType="ComboBoxItem">
+    <Style TargetType="ComboBoxItem" BasedOn="{StaticResource {x:Type ComboBoxItem}}">
         <Setter Property="Background" Value="{DynamicResource SurfaceAlt}"/>
         <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
         <Style.Triggers>
@@ -177,7 +177,7 @@
             </Trigger>
         </Style.Triggers>
     </Style>
-    <Style TargetType="TextBox">
+    <Style TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
         <Setter Property="Background" Value="{DynamicResource SurfaceAlt}"/>
         <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource Divider}"/>

--- a/Themes/Styles.Base.xaml
+++ b/Themes/Styles.Base.xaml
@@ -13,13 +13,13 @@
     <Style TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource BaseButtonStyle}"/>
 
     <!-- Basic input controls -->
-    <Style TargetType="{x:Type ComboBox}">
+    <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource {x:Type ComboBox}}">
         <Setter Property="Background"  Value="{DynamicResource SurfaceAlt}"/>
         <Setter Property="Foreground"  Value="{DynamicResource OnSurface}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource Divider}"/>
     </Style>
 
-    <Style TargetType="{x:Type ComboBoxItem}">
+    <Style TargetType="{x:Type ComboBoxItem}" BasedOn="{StaticResource {x:Type ComboBoxItem}}">
         <Setter Property="Background" Value="{DynamicResource SurfaceAlt}"/>
         <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
         <Style.Triggers>
@@ -30,11 +30,11 @@
         </Style.Triggers>
     </Style>
 
-    <Style TargetType="{x:Type CheckBox}">
+    <Style TargetType="{x:Type CheckBox}" BasedOn="{StaticResource {x:Type CheckBox}}">
         <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
     </Style>
 
-    <Style TargetType="{x:Type TextBlock}">
+    <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
         <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
     </Style>
 


### PR DESCRIPTION
## Summary
- Base ComboBox and ComboBoxItem styles on the default templates and apply dark theme brushes
- Align base style definitions with dark palette resources

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1abceee48333a21529cc85cd569a