### PR TITLE
Replace 'Başlangıca Göre %' with 'Anlık Değişim'

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -557,8 +557,8 @@
 						</DataGridTextColumn.ElementStyle>
 					</DataGridTextColumn>
 
-					<!-- Başlangıca % -->
-					<DataGridTextColumn x:Name="ColChSnap" Header="Başlangıca Göre %"
+                                        <!-- Anlık Değişim -->
+                                        <DataGridTextColumn x:Name="ColChSnap" Header="Anlık Değişim"
                                         Width="0.9*" MinWidth="80"
                                         Binding="{Binding ChangeSinceStartPercent, StringFormat=N2}">
 						<DataGridTextColumn.ElementStyle>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -519,8 +519,8 @@ namespace BinanceUsdtTicker
             AlertType.PriceAtOrAbove => "Fiyat ≥",
             AlertType.PriceAtOrBelow => "Fiyat ≤",
             AlertType.PriceBetween => "Fiyat [min,max]",
-            AlertType.ChangeSinceStartAtOrAbove => "Başlangıca göre % ≥",
-            AlertType.ChangeSinceStartAtOrBelow => "Başlangıca göre % ≤",
+            AlertType.ChangeSinceStartAtOrAbove => "Anlık Değişim ≥",
+            AlertType.ChangeSinceStartAtOrBelow => "Anlık Değişim ≤",
             _ => t.ToString()
         };
 

--- a/Models/PriceAlert.cs
+++ b/Models/PriceAlert.cs
@@ -8,8 +8,8 @@ namespace BinanceUsdtTicker
         PriceAtOrAbove,            // Fiyat >= A
         PriceAtOrBelow,            // Fiyat <= A
         PriceBetween,              // A <= Fiyat <= B
-        ChangeSinceStartAtOrAbove, // Başlangıca göre % >= A
-        ChangeSinceStartAtOrBelow  // Başlangıca göre % <= A
+        ChangeSinceStartAtOrAbove, // Anlık Değişim % >= A
+        ChangeSinceStartAtOrBelow  // Anlık Değişim % <= A
     }
 
     public class PriceAlert
@@ -71,9 +71,9 @@ namespace BinanceUsdtTicker
                     AlertType.PriceBetween =>
                         $"{Symbol}: Fiyat {row.Price:N6} → [{lower:N6}, {upper:N6}] bandına GİRDİ",
                     AlertType.ChangeSinceStartAtOrAbove =>
-                        $"{Symbol}: Başlangıca göre %{row.ChangeSinceStartPercent:N2} → ≥ %{A:N2}",
+                        $"{Symbol}: Anlık Değişim %{row.ChangeSinceStartPercent:N2} → ≥ %{A:N2}",
                     AlertType.ChangeSinceStartAtOrBelow =>
-                        $"{Symbol}: Başlangıca göre %{row.ChangeSinceStartPercent:N2} → ≤ %{A:N2}",
+                        $"{Symbol}: Anlık Değişim %{row.ChangeSinceStartPercent:N2} → ≤ %{A:N2}",
                     _ => $"{Symbol}: Alarm"
                 };
             }

--- a/Windows/AddAlertWindow.xaml
+++ b/Windows/AddAlertWindow.xaml
@@ -38,8 +38,8 @@
             <ComboBoxItem Content="Fiyat ≥" Tag="PriceAtOrAbove" />
             <ComboBoxItem Content="Fiyat ≤" Tag="PriceAtOrBelow" />
             <ComboBoxItem Content="Fiyat [min,max]" Tag="PriceBetween" />
-            <ComboBoxItem Content="Başlangıca göre % ≥" Tag="ChangeSinceStartAtOrAbove" />
-            <ComboBoxItem Content="Başlangıca göre % ≤" Tag="ChangeSinceStartAtOrBelow" />
+            <ComboBoxItem Content="Anlık Değişim ≥" Tag="ChangeSinceStartAtOrAbove" />
+            <ComboBoxItem Content="Anlık Değişim ≤" Tag="ChangeSinceStartAtOrBelow" />
         </ComboBox>
 
         <!-- Değer(ler) -->

--- a/Windows/ManageAlertsWindow.xaml.cs
+++ b/Windows/ManageAlertsWindow.xaml.cs
@@ -30,8 +30,8 @@ namespace BinanceUsdtTicker
                 new AlertTypeOption { Value = AlertType.PriceAtOrAbove,            Text = "Fiyat ≥" },
                 new AlertTypeOption { Value = AlertType.PriceAtOrBelow,            Text = "Fiyat ≤" },
                 new AlertTypeOption { Value = AlertType.PriceBetween,              Text = "Fiyat [min,max]" },
-                new AlertTypeOption { Value = AlertType.ChangeSinceStartAtOrAbove, Text = "Başlangıca göre % ≥" },
-                new AlertTypeOption { Value = AlertType.ChangeSinceStartAtOrBelow, Text = "Başlangıca göre % ≤" }
+                new AlertTypeOption { Value = AlertType.ChangeSinceStartAtOrAbove, Text = "Anlık Değişim ≥" },
+                new AlertTypeOption { Value = AlertType.ChangeSinceStartAtOrBelow, Text = "Anlık Değişim ≤" }
             };
 
         // Orijinal listeyi al, klonla


### PR DESCRIPTION
## Summary
- Rename UI column and alert text from "Başlangıca Göre %" to "Anlık Değişim"
- Update alert descriptions and labels to use "Anlık Değişim"

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1ebc1b948333b9f33cb100890338