### PR TITLE
Fix unreadable 3%+ change colors in light theme

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -666,16 +666,19 @@
                                                                        <DataTrigger Binding="{Binding IsMove3Plus}" Value="True">
                                                                                <Setter Property="Background" Value="{DynamicResource Up3Bg}"/>
                                                                                <Setter Property="Foreground" Value="{DynamicResource Up3Fg}"/>
+                                                                               <Setter Property="TextElement.Foreground" Value="{DynamicResource Up3Fg}"/>
                                                                        </DataTrigger>
                                                                        <!-- 1-3% moves: light green with black text -->
                                                                        <DataTrigger Binding="{Binding IsMove1Plus}" Value="True">
                                                                                <Setter Property="Background" Value="{DynamicResource Up1Bg}"/>
                                                                                <Setter Property="Foreground" Value="{DynamicResource Up1Fg}"/>
+                                                                               <Setter Property="TextElement.Foreground" Value="{DynamicResource Up1Fg}"/>
                                                                        </DataTrigger>
                                                                        <!-- Hover: highlight row -->
                                                                        <Trigger Property="IsMouseOver" Value="True">
                                                                                <Setter Property="Background" Value="{DynamicResource RowHoverBg}"/>
                                                                                <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
+                                                                               <Setter Property="TextElement.Foreground" Value="{DynamicResource OnSurface}"/>
                                                                        </Trigger>
                                                                </Style.Triggers>
                                                        </Style>
@@ -717,16 +720,19 @@
                                                                        <DataTrigger Binding="{Binding IsMoveMinus3}" Value="True">
                                                                                <Setter Property="Background" Value="{DynamicResource Down3Bg}"/>
                                                                                <Setter Property="Foreground" Value="{DynamicResource Down3Fg}"/>
+                                                                               <Setter Property="TextElement.Foreground" Value="{DynamicResource Down3Fg}"/>
                                                                        </DataTrigger>
                                                                        <!-- -1% to -3%: light red with black text -->
                                                                        <DataTrigger Binding="{Binding IsMoveMinus1}" Value="True">
                                                                                <Setter Property="Background" Value="{DynamicResource Down1Bg}"/>
                                                                                <Setter Property="Foreground" Value="{DynamicResource Down1Fg}"/>
+                                                                               <Setter Property="TextElement.Foreground" Value="{DynamicResource Down1Fg}"/>
                                                                        </DataTrigger>
                                                                        <!-- Hover: highlight row -->
                                                                        <Trigger Property="IsMouseOver" Value="True">
                                                                                <Setter Property="Background" Value="{DynamicResource RowHoverBg}"/>
                                                                                <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
+                                                                               <Setter Property="TextElement.Foreground" Value="{DynamicResource OnSurface}"/>
                                                                        </Trigger>
                                                                </Style.Triggers>
                                                        </Style>


### PR DESCRIPTION
## Summary
- Ensure Top Movers rows apply text colors for all conditions so percentages stay legible on light theme

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1f37b8608333b0b30830c518065e