### PR TITLE
Add customizable theme and alert colors with settings menu

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -3,6 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -314,21 +314,26 @@
 
 				<Separator/>
 
-				<Button Content="Alarm Ekle" ToolBar.OverflowMode="Never"
-						Style="{StaticResource ToolbarButtonStyle}"
-						Click="AddAlert_Click" Margin="6,0"/>
-				<Button Content="Alarmları Yönet" ToolBar.OverflowMode="Never"
-						Style="{StaticResource ToolbarButtonStyle}"
-						Click="ManageAlerts_Click" Margin="6,0"/>
+                                <Button Content="Alarm Ekle" ToolBar.OverflowMode="Never"
+                                                Style="{StaticResource ToolbarButtonStyle}"
+                                                Click="AddAlert_Click" Margin="6,0"/>
+                                <Button Content="Alarmları Yönet" ToolBar.OverflowMode="Never"
+                                                Style="{StaticResource ToolbarButtonStyle}"
+                                                Click="ManageAlerts_Click" Margin="6,0"/>
 
-				<Separator/>
+                                <Separator/>
 
-				<TextBox x:Name="SearchBox" Width="220"
-						 ToolTip="Sembol ara..."
-						 ToolBar.OverflowMode="Never"
-						 TextChanged="SearchBox_TextChanged"/>
-			</ToolBar>
-		</ToolBarTray>
+                                <TextBox x:Name="SearchBox" Width="220"
+                                                 ToolTip="Sembol ara..."
+                                                 ToolBar.OverflowMode="Never"
+                                                 TextChanged="SearchBox_TextChanged"/>
+
+                                <Separator DockPanel.Dock="Right"/>
+                                <Button x:Name="SettingsButton" Content="⚙" ToolBar.OverflowMode="Never"
+                                        DockPanel.Dock="Right" Style="{StaticResource ToolbarButtonStyle}"
+                                        FontSize="16" Width="32" Click="SettingsButton_Click"/>
+                        </ToolBar>
+                </ToolBarTray>
 
 
 		<!-- STATUS BAR -->
@@ -337,33 +342,33 @@
 				<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
 					<TextBlock x:Name="SnapshotInfoText" Text="Snapshot alınmadı"/>
 					<Rectangle Width="12" Fill="Transparent"/>
-					<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-						<Border Width="14" Height="14" CornerRadius="3" Background="LightGreen"
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <Border Width="14" Height="14" CornerRadius="3" Background="{DynamicResource Up1Bg}"
                                 BorderBrush="#66000000" BorderThickness="1" Margin="0,0,6,0"/>
-						<TextBlock Text="%1 – %3: açık yeşil" VerticalAlignment="Center"/>
-					</StackPanel>
-					<Rectangle Width="12" Fill="Transparent"/>
-					<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-						<Border Width="14" Height="14" CornerRadius="3" Background="DarkGreen"
+                                                <TextBlock Text="%1 – %3" VerticalAlignment="Center"/>
+                                        </StackPanel>
+                                        <Rectangle Width="12" Fill="Transparent"/>
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <Border Width="14" Height="14" CornerRadius="3" Background="{DynamicResource Up3Bg}"
                                 BorderBrush="#66000000" BorderThickness="1" Margin="0,0,6,0"/>
-						<TextBlock Text="≥%3: koyu yeşil" Foreground="White" VerticalAlignment="Center"
+                                                <TextBlock Text="≥%3" Foreground="{DynamicResource Up3Fg}" VerticalAlignment="Center"
                                    Background="#22000000" Padding="0,0,2,0"/>
-					</StackPanel>
-					<Rectangle Width="12" Fill="Transparent"/>
-					<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-						<Border Width="14" Height="14" CornerRadius="3" Background="LightCoral"
+                                        </StackPanel>
+                                        <Rectangle Width="12" Fill="Transparent"/>
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <Border Width="14" Height="14" CornerRadius="3" Background="{DynamicResource Down1Bg}"
                                 BorderBrush="#66000000" BorderThickness="1" Margin="0,0,6,0"/>
-						<TextBlock Text="-%1 – -%3: açık kırmızı" VerticalAlignment="Center"/>
-					</StackPanel>
-					<Rectangle Width="12" Fill="Transparent"/>
-					<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-						<Border Width="14" Height="14" CornerRadius="3" Background="DarkRed"
+                                                <TextBlock Text="-%1 – -%3" VerticalAlignment="Center"/>
+                                        </StackPanel>
+                                        <Rectangle Width="12" Fill="Transparent"/>
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <Border Width="14" Height="14" CornerRadius="3" Background="{DynamicResource Down3Bg}"
                                 BorderBrush="#66000000" BorderThickness="1" Margin="0,0,6,0"/>
-						<TextBlock Text="≤-%3: koyu kırmızı" Foreground="White" VerticalAlignment="Center"
+                                                <TextBlock Text="≤-%3" Foreground="{DynamicResource Down3Fg}" VerticalAlignment="Center"
                                    Background="#22000000" Padding="0,0,2,0"/>
-					</StackPanel>
-				</StackPanel>
-			</StatusBarItem>
+                                        </StackPanel>
+                                </StackPanel>
+                        </StatusBarItem>
 
 			<StatusBarItem HorizontalAlignment="Right">
 				<TextBlock x:Name="LastUpdateText"/>

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -1,0 +1,15 @@
+<Window x:Class="BinanceUsdtTicker.SettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Ayarlar" SizeToContent="WidthAndHeight" ResizeMode="NoResize"
+        WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="10">
+        <Button Content="Tema Rengi..." Click="ThemeColor_Click" Margin="0,0,0,5"/>
+        <Button Content="Yazı Rengi..." Click="TextColor_Click" Margin="0,0,0,5"/>
+        <Button Content="Yükseliş %1-%3..." Click="Up1Color_Click" Margin="0,0,0,5"/>
+        <Button Content="Yükseliş ≥%3..." Click="Up3Color_Click" Margin="0,0,0,5"/>
+        <Button Content="Düşüş -%1 - -%3..." Click="Down1Color_Click" Margin="0,0,0,5"/>
+        <Button Content="Düşüş ≤-%3..." Click="Down3Color_Click" Margin="0,0,0,5"/>
+        <Button Content="Kaydet" Click="Save_Click" Width="80" HorizontalAlignment="Right" Margin="0,10,0,0"/>
+    </StackPanel>
+</Window>

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -1,0 +1,93 @@
+using System.Windows;
+using System.Windows.Media;
+using WinForms = System.Windows.Forms;
+
+namespace BinanceUsdtTicker
+{
+    public partial class SettingsWindow : Window
+    {
+        private readonly UiSettings _settings;
+        private readonly UiSettings _work;
+        public SettingsWindow(UiSettings settings)
+        {
+            InitializeComponent();
+            _settings = settings;
+            _work = new UiSettings
+            {
+                Theme = settings.Theme,
+                FilterMode = settings.FilterMode,
+                Columns = settings.Columns,
+                ThemeColor = settings.ThemeColor,
+                TextColor = settings.TextColor,
+                Up1Color = settings.Up1Color,
+                Up3Color = settings.Up3Color,
+                Down1Color = settings.Down1Color,
+                Down3Color = settings.Down3Color
+            };
+        }
+
+        private void ThemeColor_Click(object sender, RoutedEventArgs e)
+        {
+            var c = PickColor(_work.ThemeColor);
+            if (c != null) _work.ThemeColor = c;
+        }
+
+        private void TextColor_Click(object sender, RoutedEventArgs e)
+        {
+            var c = PickColor(_work.TextColor);
+            if (c != null) _work.TextColor = c;
+        }
+
+        private void Up1Color_Click(object sender, RoutedEventArgs e)
+        {
+            var c = PickColor(_work.Up1Color);
+            if (c != null) _work.Up1Color = c;
+        }
+
+        private void Up3Color_Click(object sender, RoutedEventArgs e)
+        {
+            var c = PickColor(_work.Up3Color);
+            if (c != null) _work.Up3Color = c;
+        }
+
+        private void Down1Color_Click(object sender, RoutedEventArgs e)
+        {
+            var c = PickColor(_work.Down1Color);
+            if (c != null) _work.Down1Color = c;
+        }
+
+        private void Down3Color_Click(object sender, RoutedEventArgs e)
+        {
+            var c = PickColor(_work.Down3Color);
+            if (c != null) _work.Down3Color = c;
+        }
+
+        private static string? PickColor(string current)
+        {
+            var dlg = new WinForms.ColorDialog { FullOpen = true };
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(current))
+                {
+                    var col = (Color)ColorConverter.ConvertFromString(current);
+                    dlg.Color = System.Drawing.Color.FromArgb(col.A, col.R, col.G, col.B);
+                }
+            }
+            catch { }
+            return dlg.ShowDialog() == WinForms.DialogResult.OK
+                ? $"#{dlg.Color.A:X2}{dlg.Color.R:X2}{dlg.Color.G:X2}{dlg.Color.B:X2}"
+                : null;
+        }
+
+        private void Save_Click(object sender, RoutedEventArgs e)
+        {
+            _settings.ThemeColor = _work.ThemeColor;
+            _settings.TextColor = _work.TextColor;
+            _settings.Up1Color = _work.Up1Color;
+            _settings.Up3Color = _work.Up3Color;
+            _settings.Down1Color = _work.Down1Color;
+            _settings.Down3Color = _work.Down3Color;
+            DialogResult = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a gear settings button to toolbar
- allow choosing theme, text, and price-change colors in new Settings window
- store color preferences and apply dynamically across the app

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab222798588333a2b91e368d92ceb4