### PR TITLE
Resolve WPF vs WinForms type ambiguities

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,4 +1,3 @@
-using System.Windows;
-
 namespace BinanceUsdtTicker;
-public partial class App : Application { }
+
+public partial class App : System.Windows.Application { }

--- a/Windows/ManageAlertsWindow.xaml.cs
+++ b/Windows/ManageAlertsWindow.xaml.cs
@@ -74,7 +74,7 @@ namespace BinanceUsdtTicker
         }
 
         // NumPad Del ile satır silinmesini önle (TextBox içindeyse izin ver)
-        private void Grid_PreviewKeyDown(object sender, KeyEventArgs e)
+        private void Grid_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
         {
             if (e.Key == Key.Delete)
             {


### PR DESCRIPTION
## Summary
- Qualify WPF Application class to avoid conflict with Windows Forms Application.
- Specify WPF KeyEventArgs in ManageAlertsWindow to fix ambiguity.

## Testing
- ❌ `dotnet build` *(fails: command not found)*
- ⚠️ `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab24f8628c8333a063aaf0d6266ebf