### PR TITLE
Apply theme color to background surfaces

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -128,7 +128,9 @@ namespace BinanceUsdtTicker
         private void ApplyCustomColors()
         {
             TryApplyBrush("Surface", _ui.ThemeColor);
+            TryApplyBrush("SurfaceAlt", _ui.ThemeColor);
             TryApplyBrush("RowBg", _ui.ThemeColor);
+            TryApplyBrush("RowAltBg", _ui.ThemeColor);
             TryApplyBrush("OnSurface", _ui.TextColor);
             TryApplyBrush("Up1Bg", _ui.Up1Color);
             TryApplyBrush("Up3Bg", _ui.Up3Color);


### PR DESCRIPTION
## Summary
- ensure custom theme color updates alternative surfaces
- apply color to alternating row backgrounds so list rows match the selected theme

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2e43d1e083339aead80e7d883a91