### PR TITLE
Align settings window items using grid layout

### DIFF
--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -3,31 +3,39 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Ayarlar" SizeToContent="WidthAndHeight" ResizeMode="NoResize"
         WindowStartupLocation="CenterOwner">
-    <StackPanel Margin="10">
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-            <Button Content="Tema Rengi..." Click="ThemeColor_Click" Margin="0,0,5,0"/>
-            <Border Width="20" Height="20" BorderBrush="Black" BorderThickness="1" Background="{Binding ThemeColor}"/>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-            <Button Content="Yazı Rengi..." Click="TextColor_Click" Margin="0,0,5,0"/>
-            <Border Width="20" Height="20" BorderBrush="Black" BorderThickness="1" Background="{Binding TextColor}"/>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-            <Button Content="Yükseliş %1-%3..." Click="Up1Color_Click" Margin="0,0,5,0"/>
-            <Border Width="20" Height="20" BorderBrush="Black" BorderThickness="1" Background="{Binding Up1Color}"/>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-            <Button Content="Yükseliş ≥%3..." Click="Up3Color_Click" Margin="0,0,5,0"/>
-            <Border Width="20" Height="20" BorderBrush="Black" BorderThickness="1" Background="{Binding Up3Color}"/>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-            <Button Content="Düşüş -%1 - -%3..." Click="Down1Color_Click" Margin="0,0,5,0"/>
-            <Border Width="20" Height="20" BorderBrush="Black" BorderThickness="1" Background="{Binding Down1Color}"/>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-            <Button Content="Düşüş ≤-%3..." Click="Down3Color_Click" Margin="0,0,5,0"/>
-            <Border Width="20" Height="20" BorderBrush="Black" BorderThickness="1" Background="{Binding Down3Color}"/>
-        </StackPanel>
-        <Button Content="Kaydet" Click="Save_Click" Width="80" HorizontalAlignment="Right" Margin="0,10,0,0"/>
-    </StackPanel>
+    <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <Button Grid.Row="0" Grid.Column="0" Content="Tema Rengi..." Click="ThemeColor_Click" Margin="0,0,5,5"/>
+        <Border Grid.Row="0" Grid.Column="1" Width="20" Height="20" BorderBrush="Black" BorderThickness="1" Background="{Binding ThemeColor}" Margin="0,0,0,5"/>
+
+        <Button Grid.Row="1" Grid.Column="0" Content="Yazı Rengi..." Click="TextColor_Click" Margin="0,0,5,5"/>
+        <Border Grid.Row="1" Grid.Column="1" Width="20" Height="20" BorderBrush="Black" BorderThickness="1" Background="{Binding TextColor}" Margin="0,0,0,5"/>
+
+        <Button Grid.Row="2" Grid.Column="0" Content="Yükseliş %1-%3..." Click="Up1Color_Click" Margin="0,0,5,5"/>
+        <Border Grid.Row="2" Grid.Column="1" Width="20" Height="20" BorderBrush="Black" BorderThickness="1" Background="{Binding Up1Color}" Margin="0,0,0,5"/>
+
+        <Button Grid.Row="3" Grid.Column="0" Content="Yükseliş ≥%3..." Click="Up3Color_Click" Margin="0,0,5,5"/>
+        <Border Grid.Row="3" Grid.Column="1" Width="20" Height="20" BorderBrush="Black" BorderThickness="1" Background="{Binding Up3Color}" Margin="0,0,0,5"/>
+
+        <Button Grid.Row="4" Grid.Column="0" Content="Düşüş -%1 - -%3..." Click="Down1Color_Click" Margin="0,0,5,5"/>
+        <Border Grid.Row="4" Grid.Column="1" Width="20" Height="20" BorderBrush="Black" BorderThickness="1" Background="{Binding Down1Color}" Margin="0,0,0,5"/>
+
+        <Button Grid.Row="5" Grid.Column="0" Content="Düşüş ≤-%3..." Click="Down3Color_Click" Margin="0,0,5,5"/>
+        <Border Grid.Row="5" Grid.Column="1" Width="20" Height="20" BorderBrush="Black" BorderThickness="1" Background="{Binding Down3Color}" Margin="0,0,0,5"/>
+
+        <Button Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Content="Kaydet" Click="Save_Click" Width="80" HorizontalAlignment="Right" Margin="0,10,0,0"/>
+    </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- Align settings window color options in a grid for consistent row layout

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2eb6032c8333b3d11223a90daceb