### PR TITLE
Apply theme color to buttons and backgrounds

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -189,6 +189,13 @@ namespace BinanceUsdtTicker
             TryApplyBrush("SurfaceAlt", _ui.ThemeColor);
             TryApplyBrush("RowBg", _ui.ThemeColor);
             TryApplyBrush("RowAltBg", _ui.ThemeColor);
+            // toolbar and button surfaces
+            TryApplyBrush("TbBg", _ui.ThemeColor);
+            TryApplyBrush("TbHover", _ui.ThemeColor);
+            TryApplyBrush("TbPressed", _ui.ThemeColor);
+            TryApplyBrush("TbBorder", _ui.ThemeColor);
+            TryApplyBrush("HeaderBg", _ui.ThemeColor);
+            TryApplyBrush("HeaderBorder", _ui.ThemeColor);
             TryApplyBrush("OnSurface", _ui.TextColor);
             TryApplyBrush("Up1Bg", _ui.Up1Color);
             TryApplyBrush("Up3Bg", _ui.Up3Color);


### PR DESCRIPTION
## Summary
- expand custom color application to toolbar and button surfaces so theme color affects buttons and headers

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2fa7a3c48333a5119768b6f1fab4