### PR TITLE
Ensure chart button background follows theme

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -26,10 +26,12 @@
 			</Setter>
                 </Style>
 
-                <!-- Şeffaf grafik butonu -->
+                <!-- Grafik butonu: arka plan temaya göre uyarlanır -->
                 <Style x:Key="ChartButtonStyle" TargetType="Button">
                         <Setter Property="OverridesDefaultStyle" Value="True"/>
-                        <Setter Property="Background" Value="Transparent"/>
+                        <!-- Hücre arka planını miras al -->
+                        <Setter Property="Background"
+                                Value="{Binding RelativeSource={RelativeSource AncestorType=DataGridCell}, Path=Background}"/>
                         <Setter Property="BorderThickness" Value="0"/>
                         <Setter Property="Padding" Value="0"/>
                         <Setter Property="Focusable" Value="False"/>
@@ -37,7 +39,17 @@
                         <Setter Property="Template">
                                 <Setter.Value>
                                         <ControlTemplate TargetType="Button">
-                                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                <Border x:Name="Bd" Background="{TemplateBinding Background}">
+                                                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                </Border>
+                                                <ControlTemplate.Triggers>
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource RowHoverBg}"/>
+                                                        </Trigger>
+                                                        <Trigger Property="IsPressed" Value="True">
+                                                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource RowHoverBg}"/>
+                                                        </Trigger>
+                                                </ControlTemplate.Triggers>
                                         </ControlTemplate>
                                 </Setter.Value>
                         </Setter>
@@ -511,7 +523,7 @@
                                                         <DataTemplate>
                                                                 <Button Style="{StaticResource ChartButtonStyle}"
                                             Click="ChartButton_Click" Cursor="Hand">
-                                                                        <TextBlock Text="📈" FontSize="16" Foreground="#AAAAAA"/>
+                                                                        <TextBlock Text="📈" FontSize="16" Foreground="{DynamicResource SubtleText}"/>
                                                                 </Button>
                                                         </DataTemplate>
                                                 </DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
## Summary
- bind chart button background to its cell and highlight with theme resources
- use themed color for chart icon

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 forbidden)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab32e5276c8333b1b366dd4ba56e06