### PR TITLE
Add visual depth to toolbar buttons

### DIFF
--- a/Themes/Styles.Toolbar.xaml
+++ b/Themes/Styles.Toolbar.xaml
@@ -30,11 +30,17 @@
 			<!-- Focus ring -->
 			<Border x:Name="focus" Style="{StaticResource TbFocusDecorator}" Opacity="0"/>
 			<!-- Surface -->
-			<Border x:Name="bd"
-					CornerRadius="{StaticResource TbRadius}"
-					Background="{TemplateBinding Background}"
-					BorderBrush="{TemplateBinding BorderBrush}"
-					BorderThickness="1"/>
+                        <Border x:Name="bd"
+                                        CornerRadius="{StaticResource TbRadius}"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="1">
+                                <Border.Effect>
+                                        <DropShadowEffect BlurRadius="5"
+                                                          ShadowDepth="2"
+                                                          Opacity="0.2"/>
+                                </Border.Effect>
+                        </Border>
 			<ContentPresenter Margin="{TemplateBinding Padding}"
 							  HorizontalAlignment="Center" VerticalAlignment="Center"
 							  RecognizesAccessKey="True"/>


### PR DESCRIPTION
## Summary
- give toolbar buttons a subtle drop shadow so they look more like clickable controls

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab33b2fb848333a90d8f2a3dac2d34