### PR TITLE
Ensure chart window matches active theme

### DIFF
--- a/Windows/ChartWindow.xaml
+++ b/Windows/ChartWindow.xaml
@@ -2,7 +2,9 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
-        Title="Grafik" Height="420" Width="680">
+        Title="Grafik" Height="420" Width="680"
+        Background="{DynamicResource Surface}"
+        Foreground="{DynamicResource OnSurface}">
 
     <Grid Margin="10">
         <Grid.RowDefinitions>
@@ -32,7 +34,8 @@
 
         <!-- Grafik çizim alanı -->
         <Border Grid.Row="1" Margin="0,10,0,0"
-                BorderBrush="{DynamicResource Divider}" BorderThickness="1" Padding="8">
+                BorderBrush="{DynamicResource Divider}" BorderThickness="1" Padding="8"
+                Background="{DynamicResource SurfaceAlt}">
             <Grid>
                 <!-- Veri veya hata mesajları için -->
                 <TextBlock x:Name="InfoText" Text="Yükleniyor..."

--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 using Microsoft.Web.WebView2.Wpf;
 
 namespace BinanceUsdtTicker
@@ -69,16 +70,29 @@ namespace BinanceUsdtTicker
 
         private static string BuildHtml(string symbol, string interval)
         {
+            string GetColor(string key)
+            {
+                if (Application.Current.Resources[key] is SolidColorBrush brush)
+                {
+                    var c = brush.Color;
+                    return $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+                }
+                return "#ffffff";
+            }
+
+            string bg = GetColor("SurfaceAlt");
+            string fg = GetColor("OnSurface");
+
             return $@"<!DOCTYPE html>
 <html>
 <head>
     <meta charset='UTF-8'/>
     <script src='https://unpkg.com/lightweight-charts@4.2.1/dist/lightweight-charts.standalone.production.js'></script>
 </head>
-<body style='margin:0'>
+<body style='margin:0;background:{bg};color:{fg};'>
 <div id='chart' style='width:100%;height:100%;'></div>
 <script>
-    const chart = LightweightCharts.createChart(document.getElementById('chart'), {{ width: window.innerWidth, height: window.innerHeight }});
+    const chart = LightweightCharts.createChart(document.getElementById('chart'), {{ width: window.innerWidth, height: window.innerHeight, layout: {{ background: {{ color: '{bg}' }}, textColor: '{fg}' }} }});
     const series = chart.addCandlestickSeries();
     fetch('https://api.binance.com/api/v3/klines?symbol={symbol}&interval={interval}&limit=200')
         .then(r => r.json())


### PR DESCRIPTION
## Summary
- Apply theme resources to the chart window and container border
- Render chart HTML with current theme colors for background and text

## Testing
- ⚠️ `dotnet build` (dotnet not installed)
- ⚠️ `apt-get update` (403 Forbidden accessing repositories)

------
https://chatgpt.com/codex/tasks/task_e_68ab34f9bc58833395a707ae027582a6