### PR TITLE
Add grid borders and toolbar separation

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -247,13 +247,14 @@
                 </Style>
 	</Window.Resources>
 
-	<DockPanel LastChildFill="True">
+        <DockPanel LastChildFill="True">
 
-		<ToolBarTray DockPanel.Dock="Top" Panel.ZIndex="10" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" IsLocked="True" Background="{DynamicResource TbBg}">
-			<ToolBar Band="0" BandIndex="0" ToolBarTray.IsLocked="True">
-				<ToolBar.Resources>
-					<!-- Neutralize any app-wide ScrollViewer ControlTemplate that may cause circular template issues in ToolBar/TextBox -->
-					<Style TargetType="{x:Type ScrollViewer}" BasedOn="{x:Null}" />
+                <Border DockPanel.Dock="Top" Background="{DynamicResource TbBg}" BorderBrush="{DynamicResource TbBorder}" BorderThickness="0,0,0,1">
+                        <ToolBarTray Panel.ZIndex="10" IsLocked="True">
+                                <ToolBar Band="0" BandIndex="0" ToolBarTray.IsLocked="True">
+                                <ToolBar.Resources>
+                                        <!-- Neutralize any app-wide ScrollViewer ControlTemplate that may cause circular template issues in ToolBar/TextBox -->
+                                        <Style TargetType="{x:Type ScrollViewer}" BasedOn="{x:Null}" />
 
 					<!-- Also force TextBox in ToolBar to use a safe template whose PART_ContentHost ScrollViewer does NOT pick implicit styles -->
 					<Style TargetType="{x:Type TextBox}">
@@ -344,8 +345,9 @@
                                 <Button x:Name="SettingsButton" Content="⚙" ToolBar.OverflowMode="Never"
                                         DockPanel.Dock="Right" Style="{StaticResource ToolbarButtonStyle}"
                                         FontSize="16" Width="32" Click="SettingsButton_Click"/>
-                        </ToolBar>
-                </ToolBarTray>
+                                </ToolBar>
+                        </ToolBarTray>
+                </Border>
 
 
 		<!-- STATUS BAR -->
@@ -387,9 +389,7 @@
 			</StatusBarItem>
 		</StatusBar>
 
-		<!-- TOOLBAR -->
-
-		<!-- ANA GÖVDE -->
+                <!-- ANA GÖVDE -->
 		<Grid Grid.Row="1">
 			<Grid.RowDefinitions>
 

--- a/Themes/Dark.xaml
+++ b/Themes/Dark.xaml
@@ -123,10 +123,14 @@
     <Style TargetType="ListBox">
         <Setter Property="Background" Value="{DynamicResource SurfaceAlt}"/>
         <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Divider}"/>
+        <Setter Property="BorderThickness" Value="1"/>
     </Style>
     <Style TargetType="ListView">
         <Setter Property="Background" Value="{DynamicResource SurfaceAlt}"/>
         <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Divider}"/>
+        <Setter Property="BorderThickness" Value="1"/>
     </Style>
     <Style TargetType="StatusBar">
         <Setter Property="Background" Value="{DynamicResource SurfaceAlt}"/>
@@ -164,6 +168,7 @@
         <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource Divider}"/>
         <Setter Property="VerticalGridLinesBrush"   Value="{DynamicResource Divider}"/>
         <Setter Property="BorderBrush"              Value="{DynamicResource Divider}"/>
+        <Setter Property="BorderThickness"         Value="1"/>
     </Style>
     <Style TargetType="{x:Type DataGridRow}">
         <Setter Property="Background" Value="{DynamicResource RowBg}"/>

--- a/Themes/Light.xaml
+++ b/Themes/Light.xaml
@@ -127,10 +127,14 @@
     <Style TargetType="ListBox">
         <Setter Property="Background" Value="{DynamicResource SurfaceAlt}"/>
         <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Divider}"/>
+        <Setter Property="BorderThickness" Value="1"/>
     </Style>
     <Style TargetType="ListView">
         <Setter Property="Background" Value="{DynamicResource SurfaceAlt}"/>
         <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Divider}"/>
+        <Setter Property="BorderThickness" Value="1"/>
     </Style>
     <Style TargetType="StatusBar">
         <Setter Property="Background" Value="{DynamicResource SurfaceAlt}"/>
@@ -153,6 +157,7 @@
         <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource Divider}"/>
         <Setter Property="VerticalGridLinesBrush"   Value="{DynamicResource Divider}"/>
         <Setter Property="BorderBrush"              Value="{DynamicResource Divider}"/>
+        <Setter Property="BorderThickness"         Value="1"/>
     </Style>
     <Style TargetType="{x:Type DataGridRow}">
         <Setter Property="Background" Value="{DynamicResource RowBg}"/>


### PR DESCRIPTION
## Summary
- add thin borders around DataGrid, ListView, and ListBox across themes
- add divider line beneath the toolbar for clearer transition to content

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3857dd1883338090b9cc099834ee