### PR TITLE
Expand toolbar and add gridline color option

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -250,8 +250,8 @@
         <DockPanel LastChildFill="True">
 
                 <Border DockPanel.Dock="Top" Background="{DynamicResource TbBg}" BorderBrush="{DynamicResource TbBorder}" BorderThickness="0,0,0,1">
-                        <ToolBarTray Panel.ZIndex="10" IsLocked="True">
-                                <ToolBar Band="0" BandIndex="0" ToolBarTray.IsLocked="True">
+                        <ToolBarTray Panel.ZIndex="10" IsLocked="True" HorizontalAlignment="Stretch">
+                                <ToolBar Band="0" BandIndex="0" ToolBarTray.IsLocked="True" HorizontalAlignment="Stretch">
                                 <ToolBar.Resources>
                                         <!-- Neutralize any app-wide ScrollViewer ControlTemplate that may cause circular template issues in ToolBar/TextBox -->
                                         <Style TargetType="{x:Type ScrollViewer}" BasedOn="{x:Null}" />
@@ -342,9 +342,14 @@
                                                  TextChanged="SearchBox_TextChanged"/>
 
                                 <Separator DockPanel.Dock="Right"/>
-                                <Button x:Name="SettingsButton" Content="⚙" ToolBar.OverflowMode="Never"
+                                <Button x:Name="SettingsButton" ToolBar.OverflowMode="Never"
                                         DockPanel.Dock="Right" Style="{StaticResource ToolbarButtonStyle}"
-                                        FontSize="16" Width="32" Click="SettingsButton_Click"/>
+                                        FontSize="16" Width="90" Click="SettingsButton_Click">
+                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                                <TextBlock Text="⚙" Margin="0,0,4,0"/>
+                                                <TextBlock Text="Ayarlar" FontWeight="Bold"/>
+                                        </StackPanel>
+                                </Button>
                                 </ToolBar>
                         </ToolBarTray>
                 </Border>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -88,6 +88,13 @@ namespace BinanceUsdtTicker
             set { if (_down3Color != value) { _down3Color = value; OnPropertyChanged(); } }
         }
 
+        private string _dividerColor = string.Empty;
+        public string DividerColor
+        {
+            get => _dividerColor;
+            set { if (_dividerColor != value) { _dividerColor = value; OnPropertyChanged(); } }
+        }
+
         public event PropertyChangedEventHandler? PropertyChanged;
         private void OnPropertyChanged([CallerMemberName] string? name = null) =>
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
@@ -201,6 +208,7 @@ namespace BinanceUsdtTicker
             TryApplyBrush("Up3Bg", _ui.Up3Color);
             TryApplyBrush("Down1Bg", _ui.Down1Color);
             TryApplyBrush("Down3Bg", _ui.Down3Color);
+            TryApplyBrush("Divider", _ui.DividerColor);
 
             TryApplyBrush("Up1Fg", IdealText(_ui.Up1Color));
             TryApplyBrush("Up3Fg", IdealText(_ui.Up3Color));

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -16,6 +16,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <Button Grid.Row="0" Grid.Column="0" Content="Tema Rengi..." Click="ThemeColor_Click" Margin="0,0,5,5"/>
@@ -36,6 +37,9 @@
         <Button Grid.Row="5" Grid.Column="0" Content="Düşüş ≤-%3..." Click="Down3Color_Click" Margin="0,0,5,5"/>
         <Border Grid.Row="5" Grid.Column="1" Width="20" Height="20" BorderBrush="Black" BorderThickness="1" Background="{Binding Down3Color}" Margin="0,0,0,5"/>
 
-        <Button Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Content="Kaydet" Click="Save_Click" Width="80" HorizontalAlignment="Right" Margin="0,10,0,0"/>
+        <Button Grid.Row="6" Grid.Column="0" Content="Tablo Çizgileri..." Click="DividerColor_Click" Margin="0,0,5,5"/>
+        <Border Grid.Row="6" Grid.Column="1" Width="20" Height="20" BorderBrush="Black" BorderThickness="1" Background="{Binding DividerColor}" Margin="0,0,0,5"/>
+
+        <Button Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Content="Kaydet" Click="Save_Click" Width="80" HorizontalAlignment="Right" Margin="0,10,0,0"/>
     </Grid>
 </Window>

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -22,7 +22,8 @@ namespace BinanceUsdtTicker
                 Up1Color = settings.Up1Color,
                 Up3Color = settings.Up3Color,
                 Down1Color = settings.Down1Color,
-                Down3Color = settings.Down3Color
+                Down3Color = settings.Down3Color,
+                DividerColor = settings.DividerColor
             };
             DataContext = _work;
         }
@@ -63,6 +64,12 @@ namespace BinanceUsdtTicker
             if (c != null) _work.Down3Color = c;
         }
 
+        private void DividerColor_Click(object sender, RoutedEventArgs e)
+        {
+            var c = PickColor(_work.DividerColor);
+            if (c != null) _work.DividerColor = c;
+        }
+
         private static string? PickColor(string current)
         {
             var dlg = new WinForms.ColorDialog { FullOpen = true };
@@ -88,6 +95,7 @@ namespace BinanceUsdtTicker
             _settings.Up3Color = _work.Up3Color;
             _settings.Down1Color = _work.Down1Color;
             _settings.Down3Color = _work.Down3Color;
+            _settings.DividerColor = _work.DividerColor;
             DialogResult = true;
         }
     }


### PR DESCRIPTION
## Summary
- Stretch toolbar to fit window width and enlarge settings button with label
- Allow customizing grid line color via new setting and application

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3a81ba408333ab968c94b4a12dbb