### PR TITLE
Add default theme settings and reset option

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -126,6 +126,7 @@ namespace BinanceUsdtTicker
         private static readonly string AlertsFile = Path.Combine(AppDir, "alerts.json");
         private static readonly string FavoritesFile = Path.Combine(AppDir, "favorites.json");
         private static readonly string UiSettingsFile = Path.Combine(AppDir, "ui_settings.json");
+        private static readonly string UiDefaultsFile = Path.Combine(AppDir, "ui_defaults.json");
 
         private UiSettings _ui = new();
         private ThemeKind _theme = ThemeKind.Light;
@@ -912,6 +913,36 @@ namespace BinanceUsdtTicker
             {
                 _ui = new UiSettings();
             }
+
+            SaveDefaultUiSettings(_ui);
+        }
+
+        private static void SaveDefaultUiSettings(UiSettings settings)
+        {
+            try
+            {
+                Directory.CreateDirectory(AppDir);
+                if (!File.Exists(UiDefaultsFile))
+                {
+                    var json = JsonSerializer.Serialize(settings, new JsonSerializerOptions { WriteIndented = true });
+                    File.WriteAllText(UiDefaultsFile, json);
+                }
+            }
+            catch { }
+        }
+
+        internal static UiSettings LoadDefaultUiSettings()
+        {
+            try
+            {
+                if (File.Exists(UiDefaultsFile))
+                {
+                    var json = File.ReadAllText(UiDefaultsFile);
+                    return JsonSerializer.Deserialize<UiSettings>(json) ?? new UiSettings();
+                }
+            }
+            catch { }
+            return new UiSettings();
         }
 
         private void ApplyColumnLayoutFromSettings()

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -93,7 +93,10 @@
                 <Button Grid.Row="6" Grid.Column="0" Content="Tablo Çizgileri..." Click="DividerColor_Click" Margin="0,0,10,5"/>
                 <Border Grid.Row="6" Grid.Column="1" Width="20" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding DividerColor}" Margin="0,0,0,5"/>
 
-                <Button Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Content="Kaydet" Click="Save_Click" Width="80" HorizontalAlignment="Right" Margin="0,10,0,0"/>
+                <StackPanel Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+                    <Button Content="Varsayılan Ayarlara Dön" Click="ResetDefaults_Click" Margin="0,0,10,0"/>
+                    <Button Content="Kaydet" Click="Save_Click" Width="80"/>
+                </StackPanel>
             </Grid>
         </TabItem>
     </TabControl>

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -64,10 +64,22 @@ namespace BinanceUsdtTicker
             if (c != null) _work.Down3Color = c;
         }
 
-        private void DividerColor_Click(object sender, RoutedEventArgs e)
+    private void DividerColor_Click(object sender, RoutedEventArgs e)
+    {
+        var c = PickColor(_work.DividerColor);
+        if (c != null) _work.DividerColor = c;
+    }
+
+        private void ResetDefaults_Click(object sender, RoutedEventArgs e)
         {
-            var c = PickColor(_work.DividerColor);
-            if (c != null) _work.DividerColor = c;
+            var def = MainWindow.LoadDefaultUiSettings();
+            _work.ThemeColor = def.ThemeColor;
+            _work.TextColor = def.TextColor;
+            _work.Up1Color = def.Up1Color;
+            _work.Up3Color = def.Up3Color;
+            _work.Down1Color = def.Down1Color;
+            _work.Down3Color = def.Down3Color;
+            _work.DividerColor = def.DividerColor;
         }
 
         private static string? PickColor(string current)


### PR DESCRIPTION
## Summary
- persist current theme settings as defaults
- add "Varsayılan Ayarlara Dön" button to reset theme colors to saved defaults

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab43e1ca3883338d4ee883cc52e84c