### PR TITLE
Widen theme color palette display

### DIFF
--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -58,8 +58,8 @@
         <TabItem Header="Tema" IsSelected="True">
             <Grid Margin="10">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -73,25 +73,25 @@
                 </Grid.RowDefinitions>
 
                 <Button Grid.Row="0" Grid.Column="0" Content="Tema Rengi..." Click="ThemeColor_Click" Margin="0,0,10,5"/>
-                <Border Grid.Row="0" Grid.Column="1" Width="20" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding ThemeColor}" Margin="0,0,0,5"/>
+                <Border Grid.Row="0" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding ThemeColor}" Margin="0,0,0,5"/>
 
                 <Button Grid.Row="1" Grid.Column="0" Content="Yazı Rengi..." Click="TextColor_Click" Margin="0,0,10,5"/>
-                <Border Grid.Row="1" Grid.Column="1" Width="20" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding TextColor}" Margin="0,0,0,5"/>
+                <Border Grid.Row="1" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding TextColor}" Margin="0,0,0,5"/>
 
                 <Button Grid.Row="2" Grid.Column="0" Content="Yükseliş %1-%3..." Click="Up1Color_Click" Margin="0,0,10,5"/>
-                <Border Grid.Row="2" Grid.Column="1" Width="20" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding Up1Color}" Margin="0,0,0,5"/>
+                <Border Grid.Row="2" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding Up1Color}" Margin="0,0,0,5"/>
 
                 <Button Grid.Row="3" Grid.Column="0" Content="Yükseliş ≥%3..." Click="Up3Color_Click" Margin="0,0,10,5"/>
-                <Border Grid.Row="3" Grid.Column="1" Width="20" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding Up3Color}" Margin="0,0,0,5"/>
+                <Border Grid.Row="3" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding Up3Color}" Margin="0,0,0,5"/>
 
                 <Button Grid.Row="4" Grid.Column="0" Content="Düşüş -%1 - -%3..." Click="Down1Color_Click" Margin="0,0,10,5"/>
-                <Border Grid.Row="4" Grid.Column="1" Width="20" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding Down1Color}" Margin="0,0,0,5"/>
+                <Border Grid.Row="4" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding Down1Color}" Margin="0,0,0,5"/>
 
                 <Button Grid.Row="5" Grid.Column="0" Content="Düşüş ≤-%3..." Click="Down3Color_Click" Margin="0,0,10,5"/>
-                <Border Grid.Row="5" Grid.Column="1" Width="20" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding Down3Color}" Margin="0,0,0,5"/>
+                <Border Grid.Row="5" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding Down3Color}" Margin="0,0,0,5"/>
 
                 <Button Grid.Row="6" Grid.Column="0" Content="Tablo Çizgileri..." Click="DividerColor_Click" Margin="0,0,10,5"/>
-                <Border Grid.Row="6" Grid.Column="1" Width="20" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding DividerColor}" Margin="0,0,0,5"/>
+                <Border Grid.Row="6" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding DividerColor}" Margin="0,0,0,5"/>
 
                 <StackPanel Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
                     <Button Content="Varsayılan Ayarlara Dön" Click="ResetDefaults_Click" Margin="0,0,10,0"/>


### PR DESCRIPTION
## Summary
- Narrow theme settings text column and expand color palette column
- Stretch color swatches to show wider color previews

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab457559a08333909121d850e57c65