### PR TITLE
Remove theme toggle and load default settings

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -275,24 +275,16 @@
 					</Style>
 				</ToolBar.Resources>
 
-				<ToggleButton x:Name="ViewToggle"
-							  ToolBar.OverflowMode="Never"
-							  Style="{StaticResource ToolbarToggleButtonStyle}"
-							  IsChecked="True"
-							  Content="Detay"
-							  Checked="ViewToggle_Checked"
-							  Unchecked="ViewToggle_Unchecked"
-							  Margin="0,0,8,0"/>
-				<ToggleButton x:Name="ThemeToggle"
-							  ToolBar.OverflowMode="Never"
-							  Style="{StaticResource ToolbarToggleButtonStyle}"
-							  IsChecked="True"
-							  Content="Açık Tema"
-							  Checked="ThemeToggle_Checked"
-							  Unchecked="ThemeToggle_Unchecked"
-							  Margin="0,0,12,0"/>
+                                <ToggleButton x:Name="ViewToggle"
+                                                          ToolBar.OverflowMode="Never"
+                                                          Style="{StaticResource ToolbarToggleButtonStyle}"
+                                                          IsChecked="True"
+                                                          Content="Detay"
+                                                          Checked="ViewToggle_Checked"
+                                                          Unchecked="ViewToggle_Unchecked"
+                                                          Margin="0,0,12,0"/>
 
-				<Separator/>
+                                <Separator/>
 
 				<RadioButton x:Name="RbAll" ToolBar.OverflowMode="Never"
 							 Style="{StaticResource ToolbarRadioStyle}"

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -274,18 +274,8 @@ namespace BinanceUsdtTicker
             if (Application.Current != null)
                 SwapThemes(Application.Current.Resources.MergedDictionaries, uri);
 
-            var themeToggle = Q<ToggleButton>("ThemeToggle");
-            if (themeToggle != null)
-            {
-                themeToggle.IsChecked = (kind == ThemeKind.Dark);
-                themeToggle.Content = (kind == ThemeKind.Dark) ? "Açık Tema" : "Koyu Tema";
-            }
-
             ApplyCustomColors();
         }
-
-        private void ThemeToggle_Checked(object sender, RoutedEventArgs e) => ApplyTheme(ThemeKind.Dark);
-        private void ThemeToggle_Unchecked(object sender, RoutedEventArgs e) => ApplyTheme(ThemeKind.Light);
 
         private void SettingsButton_Click(object sender, RoutedEventArgs e)
         {
@@ -905,9 +895,20 @@ namespace BinanceUsdtTicker
         {
             try
             {
-                if (!File.Exists(UiSettingsFile)) { _ui = new UiSettings(); return; }
-                var json = File.ReadAllText(UiSettingsFile);
-                _ui = JsonSerializer.Deserialize<UiSettings>(json) ?? new UiSettings();
+                if (File.Exists(UiSettingsFile))
+                {
+                    var json = File.ReadAllText(UiSettingsFile);
+                    _ui = JsonSerializer.Deserialize<UiSettings>(json) ?? new UiSettings();
+                }
+                else if (File.Exists(UiDefaultsFile))
+                {
+                    var json = File.ReadAllText(UiDefaultsFile);
+                    _ui = JsonSerializer.Deserialize<UiSettings>(json) ?? new UiSettings();
+                }
+                else
+                {
+                    _ui = new UiSettings();
+                }
             }
             catch
             {


### PR DESCRIPTION
## Summary
- load stored UI defaults at first launch
- drop obsolete light/dark theme toggle
- rely on saved theme when applying styles

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab469ac8288333ac27deed6a80be86