### PR TITLE
Use flexible price formatting in chart

### DIFF
--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -92,8 +92,18 @@ namespace BinanceUsdtTicker
 <body style='margin:0;background:{bg};color:{fg};'>
 <div id='chart' style='width:100%;height:100%;'></div>
 <script>
-    const chart = LightweightCharts.createChart(document.getElementById('chart'), {{ width: window.innerWidth, height: window.innerHeight, layout: {{ background: {{ color: '{bg}' }}, textColor: '{fg}' }} }});
-    const series = chart.addCandlestickSeries();
+    const fmt = p => p.toLocaleString(undefined, {{ maximumFractionDigits: 8 }});
+    const chart = LightweightCharts.createChart(
+        document.getElementById('chart'),
+        {{
+            width: window.innerWidth,
+            height: window.innerHeight,
+            layout: {{ background: {{ color: '{bg}' }}, textColor: '{fg}' }},
+            localization: {{ priceFormatter: fmt }}
+        }});
+    const series = chart.addCandlestickSeries({{
+        priceFormat: {{ type: 'custom', minMove: 0.00000001, formatter: fmt }}
+    }});
     fetch('https://api.binance.com/api/v3/klines?symbol={symbol}&interval={interval}&limit=200')
         .then(r => r.json())
         .then(data => {{


### PR DESCRIPTION
## Summary
- Format chart prices with up to eight decimal digits using locale-aware formatter
- Apply formatter to chart and candlestick series for consistent display

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab491f58588333b905b217a57fc6c3