### PR TITLE
Add candle aggregation and real-time chart updates

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -545,7 +545,7 @@ namespace BinanceUsdtTicker
         {
             if (sender is FrameworkElement fe && fe.DataContext is TickerRow row)
             {
-                var win = new ChartWindow(row.Symbol);
+                var win = new ChartWindow(row.Symbol, _service);
                 win.Owner = this;
                 win.Show();
             }

--- a/Models/Candle.cs
+++ b/Models/Candle.cs
@@ -1,0 +1,11 @@
+namespace BinanceUsdtTicker
+{
+    public class Candle
+    {
+        public long Time { get; set; } // Unix time seconds
+        public decimal Open { get; set; }
+        public decimal High { get; set; }
+        public decimal Low { get; set; }
+        public decimal Close { get; set; }
+    }
+}

--- a/Services/BinanceSpotService.cs
+++ b/Services/BinanceSpotService.cs
@@ -19,6 +19,8 @@ namespace BinanceUsdtTicker
     {
         public event Action<List<TickerRow>>? OnTickersUpdated;
 
+        public event Action<string, Candle>? OnCandle;
+
         // WS durum bildirimi: (durum, deneme sayısı)
         public event Action<WsState, int>? OnWsStateChanged;
 
@@ -32,6 +34,13 @@ namespace BinanceUsdtTicker
         // Emit throttle
         private long _emitIntervalTicks = TimeSpan.FromMilliseconds(300).Ticks;
         private long _nextEmitTicks = 0;
+
+        private readonly CandleAggregator _candleAgg = new(TimeSpan.FromMinutes(1));
+
+        public BinanceSpotService()
+        {
+            _candleAgg.OnCandle += (s, c) => OnCandle?.Invoke(s, c);
+        }
 
         public WsState State { get; private set; } = WsState.Closed;
         public DateTime LastMessageUtc { get; private set; }
@@ -204,6 +213,8 @@ namespace BinanceUsdtTicker
                     row.ChangePercent = changePct;
                     row.LastUpdate = now;
                 }
+
+                _candleAgg.AddTick(s, price, now);
             }
         }
 
@@ -239,6 +250,8 @@ namespace BinanceUsdtTicker
                     row.Price = mid;
                     row.LastUpdate = now;
                 }
+
+                _candleAgg.AddTick(s, mid, now);
             }
         }
 

--- a/Services/CandleAggregator.cs
+++ b/Services/CandleAggregator.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace BinanceUsdtTicker
+{
+    public class CandleAggregator
+    {
+        private readonly TimeSpan _interval;
+        private readonly Dictionary<string, Candle> _candles = new(StringComparer.OrdinalIgnoreCase);
+
+        public event Action<string, Candle>? OnCandle;
+
+        public CandleAggregator(TimeSpan interval)
+        {
+            _interval = interval;
+        }
+
+        public void AddTick(string symbol, decimal price, DateTime timestamp)
+        {
+            var bucketStart = timestamp - TimeSpan.FromTicks(timestamp.Ticks % _interval.Ticks);
+            var unix = new DateTimeOffset(bucketStart).ToUnixTimeSeconds();
+
+            if (!_candles.TryGetValue(symbol, out var candle) || candle.Time != unix)
+            {
+                candle = new Candle
+                {
+                    Time = unix,
+                    Open = price,
+                    High = price,
+                    Low = price,
+                    Close = price
+                };
+                _candles[symbol] = candle;
+            }
+            else
+            {
+                if (price > candle.High) candle.High = price;
+                if (price < candle.Low) candle.Low = price;
+                candle.Close = price;
+            }
+
+            OnCandle?.Invoke(symbol, candle);
+        }
+    }
+}

--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -10,6 +11,7 @@ namespace BinanceUsdtTicker
     public partial class ChartWindow : Window
     {
         public string Symbol { get; private set; } = "";
+        private readonly BinanceSpotService? _service;
 
         // Parametresiz ctor (XAML designer/InitializeComponent için)
         public ChartWindow()
@@ -26,6 +28,13 @@ namespace BinanceUsdtTicker
 
             Title = string.IsNullOrEmpty(Symbol) ? "Grafik" : $"Grafik - {Symbol}";
             if (SymbolText != null) SymbolText.Text = Symbol;
+        }
+
+        public ChartWindow(string symbol, BinanceSpotService service) : this(symbol)
+        {
+            _service = service;
+            _service.OnCandle += Service_OnCandle;
+            Closed += (_, __) => _service.OnCandle -= Service_OnCandle;
         }
 
         private async void ChartWindow_Loaded(object? sender, RoutedEventArgs e)
@@ -116,6 +125,16 @@ namespace BinanceUsdtTicker
 </script>
 </body>
 </html>";
+        }
+
+        private void Service_OnCandle(string sym, Candle candle)
+        {
+            if (!string.Equals(sym, Symbol, StringComparison.OrdinalIgnoreCase)) return;
+            if (ChartWebView?.CoreWebView2 == null) return;
+
+            string js = $"series.update({{ time: {candle.Time}, open: {candle.Open.ToString(CultureInfo.InvariantCulture)}, high: {candle.High.ToString(CultureInfo.InvariantCulture)}, low: {candle.Low.ToString(CultureInfo.InvariantCulture)}, close: {candle.Close.ToString(CultureInfo.InvariantCulture)} }});";
+
+            _ = Dispatcher.InvokeAsync(() => ChartWebView.CoreWebView2.ExecuteScriptAsync(js));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Introduce `Candle` model and `CandleAggregator` to build candlesticks from live prices.
- Wire BinanceSpotService to emit candle updates and ChartWindow to update JavaScript chart via Dispatcher-safe calls.
- Pass BinanceSpotService instance to ChartWindow from MainWindow for real-time charting.

## Testing
- `apt-get update` *(fails: The repository is not signed)*
- `dotnet build` *(fails: command not found)*
- `time dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4ad94f808333989fd0735ab7b38f