### PR TITLE
Fix missing brace causing build error in ChartWindow

### DIFF
--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -90,6 +90,8 @@ namespace BinanceUsdtTicker
             string interval = (IntervalBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "5m";
             await ChartWebView.CoreWebView2.ExecuteScriptAsync($"updateChart('{Symbol}', '{interval}')");
 
+        }
+
         private void CoreWebView2_WebMessageReceived(object? sender, CoreWebView2WebMessageReceivedEventArgs e)
         {
             Dispatcher.Invoke(() =>


### PR DESCRIPTION
## Summary
- close the `Refresh_Click` method with a missing brace in ChartWindow

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4dfd18348333a97c3a9af461db38