### PR TITLE
Fix object literal braces in chart update

### DIFF
--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -179,13 +179,13 @@ namespace BinanceUsdtTicker
         const url = 'https://api.binance.com/api/v3/klines?symbol=' + symbol + '&interval=' + interval + '&limit=200';
         const res = await fetch(url);
         const data = await res.json();
-        const candles = data.map(d => ({
+        const candles = data.map(d => ({{
             time: Math.floor(d[0] / 1000),
             open: parseFloat(d[1]),
             high: parseFloat(d[2]),
             low: parseFloat(d[3]),
             close: parseFloat(d[4])
-        }));
+        }}));
         series.setData(candles);
     }}
 


### PR DESCRIPTION
## Summary
- escape JavaScript object braces in ChartWindow update function to avoid C# interpolation errors

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4e908ff08333a71c53166ee5e1ad