### PR TITLE
Remove redundant chart script reference

### DIFF
--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -139,7 +139,6 @@ namespace BinanceUsdtTicker
 <head>
     <meta charset='UTF-8'/>
     {scriptTag}
-    <script src='ms-appx-web:///Resources/lightweight-charts.standalone.production.js'></script>
 </head>
 <body style='margin:0;background:{bg};color:{fg};'>
 <div id='chart' style='width:100%;height:100%;'></div>


### PR DESCRIPTION
## Summary
- Fix chart not loading by removing a leftover ms-appx-web script reference so the lightweight-charts library is loaded only from the intended source.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab53213b1c8333a76dc5a51fac2a52