### PR TITLE
Handle chart data fetch errors

### DIFF
--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -184,27 +184,23 @@ namespace BinanceUsdtTicker
 
     async function updateChart(symbol, interval) {{
         const url = 'https://api.binance.com/api/v3/klines?symbol=' + symbol + '&interval=' + interval + '&limit=200';
-        const res = await fetch(url);
-        const data = await res.json();
-        const candles = data.map(d => ({{
-            time: Math.floor(d[0] / 1000),
-            open: parseFloat(d[1]),
-            high: parseFloat(d[2]),
-            low: parseFloat(d[3]),
-            close: parseFloat(d[4])
-        }}));
-        series.setData(candles);
+        try {{
+            const res = await fetch(url);
+            const data = await res.json();
+            const candles = data.map(d => ({{
+                time: Math.floor(d[0] / 1000),
+                open: parseFloat(d[1]),
+                high: parseFloat(d[2]),
+                low: parseFloat(d[3]),
+                close: parseFloat(d[4])
+            }}));
+            series.setData(candles);
+        }} catch (e) {{
+            window.chrome.webview.postMessage(e.message);
+        }}
     }}
 
     updateChart('{symbol}', '{interval}');
-
-    fetch('https://api.binance.com/api/v3/klines?symbol={symbol}&interval={interval}&limit=200')
-        .then(r => r.json())
-        .then(data => {{
-            const candles = data.map(d => ({{ time: Math.floor(d[0]/1000), open: parseFloat(d[1]), high: parseFloat(d[2]), low: parseFloat(d[3]), close: parseFloat(d[4]) }}));
-            series.setData(candles);
-        }})
-        .catch(e => window.chrome.webview.postMessage(e.message));
 
     window.addEventListener('resize', () => {{
         chart.applyOptions({{ width: window.innerWidth, height: window.innerHeight }});


### PR DESCRIPTION
## Summary
- streamline chart HTML to rely on a single fetch call
- add error handling in updateChart to surface issues via WebView message

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab56d8a7a08333b63d9e8eb5d30106