### PR TITLE
Fix chart script lookup to restore graph loading

### DIFF
--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -132,6 +132,12 @@ namespace BinanceUsdtTicker
 
             string scriptTag;
             string scriptPath = Path.Combine(AppContext.BaseDirectory, "Resources", "lightweight-charts.standalone.production.js");
+
+            // Çalışma zamanında bazı dağıtımlarda dosya "Resources" klasörü altına
+            // kopyalanmayabiliyor. Bu durumda doğrudan çıktı klasöründe arayalım.
+            if (!File.Exists(scriptPath))
+                scriptPath = Path.Combine(AppContext.BaseDirectory, "lightweight-charts.standalone.production.js");
+
             if (File.Exists(scriptPath))
             {
                 string chartJs = File.ReadAllText(scriptPath);
@@ -139,6 +145,7 @@ namespace BinanceUsdtTicker
             }
             else
             {
+                // Son çare olarak CDN'den yükle
                 scriptTag = "<script src='https://unpkg.com/lightweight-charts/dist/lightweight-charts.standalone.production.js'></script>";
             }
 


### PR DESCRIPTION
## Summary
- ensure lightweight-charts script is found locally with a fallback to the output directory
- fall back to CDN only when the local script cannot be found

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab58914c3483339d0708bedde30982