### PR TITLE
Load chart script from local file

### DIFF
--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -140,8 +140,8 @@ namespace BinanceUsdtTicker
 
             if (File.Exists(scriptPath))
             {
-                string chartJs = File.ReadAllText(scriptPath);
-                scriptTag = $"<script>{chartJs}</script>";
+                var localUri = new Uri(scriptPath);
+                scriptTag = $"<script src='{localUri.AbsoluteUri}'></script>";
             }
             else
             {


### PR DESCRIPTION
## Summary
- Reference lightweight-charts script using a local file URI instead of embedding its contents.

## Testing
- ⚠️ `dotnet build` *(missing: dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_68ab59d7393c8333afcebbb606056a9f