### PR TITLE
Use CDN for chart script to debug loading issue

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -12,9 +12,4 @@
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1823.32" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="Resources/lightweight-charts.standalone.production.js">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
 </Project>

--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -130,24 +130,9 @@ namespace BinanceUsdtTicker
             string up = GetColor("Up1Bg");
             string down = GetColor("Down1Bg");
 
-            string scriptTag;
-            string scriptPath = Path.Combine(AppContext.BaseDirectory, "Resources", "lightweight-charts.standalone.production.js");
-
-            // Çalışma zamanında bazı dağıtımlarda dosya "Resources" klasörü altına
-            // kopyalanmayabiliyor. Bu durumda doğrudan çıktı klasöründe arayalım.
-            if (!File.Exists(scriptPath))
-                scriptPath = Path.Combine(AppContext.BaseDirectory, "lightweight-charts.standalone.production.js");
-
-            if (File.Exists(scriptPath))
-            {
-                var localUri = new Uri(scriptPath);
-                scriptTag = $"<script src='{localUri.AbsoluteUri}'></script>";
-            }
-            else
-            {
-                // Son çare olarak CDN'den yükle
-                scriptTag = "<script src='https://unpkg.com/lightweight-charts/dist/lightweight-charts.standalone.production.js'></script>";
-            }
+            // Grafiğin yüklenememesi sorununu incelemek için
+            // yerel JavaScript dosyası yerine doğrudan CDN'den çekelim.
+            const string scriptTag = "<script src='https://unpkg.com/lightweight-charts/dist/lightweight-charts.standalone.production.js'></script>";
 
             return $@"<!DOCTYPE html>
 <html>


### PR DESCRIPTION
## Summary
- Always load lightweight-charts from CDN instead of local file to debug chart loading
- Remove local chart script from build configuration

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab66426a948333b4635d9435f8fd7e