### PR TITLE
Add control color theme setting

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -95,6 +95,13 @@ namespace BinanceUsdtTicker
             set { if (_dividerColor != value) { _dividerColor = value; OnPropertyChanged(); } }
         }
 
+        private string _controlColor = string.Empty;
+        public string ControlColor
+        {
+            get => _controlColor;
+            set { if (_controlColor != value) { _controlColor = value; OnPropertyChanged(); } }
+        }
+
         public event PropertyChangedEventHandler? PropertyChanged;
         private void OnPropertyChanged([CallerMemberName] string? name = null) =>
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
@@ -194,14 +201,14 @@ namespace BinanceUsdtTicker
         private void ApplyCustomColors()
         {
             TryApplyBrush("Surface", _ui.ThemeColor);
-            TryApplyBrush("SurfaceAlt", _ui.ThemeColor);
+            TryApplyBrush("SurfaceAlt", _ui.ControlColor);
             TryApplyBrush("RowBg", _ui.ThemeColor);
             TryApplyBrush("RowAltBg", _ui.ThemeColor);
             // toolbar and button surfaces
-            TryApplyBrush("TbBg", _ui.ThemeColor);
-            TryApplyBrush("TbHover", _ui.ThemeColor);
-            TryApplyBrush("TbPressed", _ui.ThemeColor);
-            TryApplyBrush("TbBorder", _ui.ThemeColor);
+            TryApplyBrush("TbBg", _ui.ControlColor);
+            TryApplyBrush("TbHover", _ui.ControlColor);
+            TryApplyBrush("TbPressed", _ui.ControlColor);
+            TryApplyBrush("TbBorder", _ui.ControlColor);
             TryApplyBrush("HeaderBg", _ui.ThemeColor);
             TryApplyBrush("HeaderBorder", _ui.ThemeColor);
             TryApplyBrush("OnSurface", _ui.TextColor);

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -70,6 +70,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
                 <Button Grid.Row="0" Grid.Column="0" Content="Tema Rengi..." Click="ThemeColor_Click" Margin="0,0,10,5"/>
@@ -93,7 +94,10 @@
                 <Button Grid.Row="6" Grid.Column="0" Content="Tablo Çizgileri..." Click="DividerColor_Click" Margin="0,0,10,5"/>
                 <Border Grid.Row="6" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding DividerColor}" Margin="0,0,0,5"/>
 
-                <StackPanel Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+                <Button Grid.Row="7" Grid.Column="0" Content="Ekrandaki Kontrollerin Rengi..." Click="ControlColor_Click" Margin="0,0,10,5"/>
+                <Border Grid.Row="7" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding ControlColor}" Margin="0,0,0,5"/>
+
+                <StackPanel Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
                     <Button Content="Varsayılan Ayarlara Dön" Click="ResetDefaults_Click" Margin="0,0,10,0"/>
                     <Button Content="Kaydet" Click="Save_Click" Width="80"/>
                 </StackPanel>

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -23,7 +23,8 @@ namespace BinanceUsdtTicker
                 Up3Color = settings.Up3Color,
                 Down1Color = settings.Down1Color,
                 Down3Color = settings.Down3Color,
-                DividerColor = settings.DividerColor
+                DividerColor = settings.DividerColor,
+                ControlColor = settings.ControlColor
             };
             DataContext = _work;
         }
@@ -70,6 +71,12 @@ namespace BinanceUsdtTicker
         if (c != null) _work.DividerColor = c;
     }
 
+        private void ControlColor_Click(object sender, RoutedEventArgs e)
+        {
+            var c = PickColor(_work.ControlColor);
+            if (c != null) _work.ControlColor = c;
+        }
+
         private void ResetDefaults_Click(object sender, RoutedEventArgs e)
         {
             var def = MainWindow.LoadDefaultUiSettings();
@@ -80,6 +87,7 @@ namespace BinanceUsdtTicker
             _work.Down1Color = def.Down1Color;
             _work.Down3Color = def.Down3Color;
             _work.DividerColor = def.DividerColor;
+            _work.ControlColor = def.ControlColor;
         }
 
         private static string? PickColor(string current)
@@ -108,6 +116,7 @@ namespace BinanceUsdtTicker
             _settings.Down1Color = _work.Down1Color;
             _settings.Down3Color = _work.Down3Color;
             _settings.DividerColor = _work.DividerColor;
+            _settings.ControlColor = _work.ControlColor;
             DialogResult = true;
         }
     }


### PR DESCRIPTION
## Summary
- add ControlColor field to UI settings
- expose "Ekrandaki Kontrollerin Rengi" option in settings window
- apply control color to button, textbox and combobox resources

## Testing
- `dotnet build` *(fails: command not found; attempted apt-get update but repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab696428008333bc5baa36c931016b