### PR TITLE
Fix chart rendering by using REST candles

### DIFF
--- a/Windows/ChartWindow.xaml
+++ b/Windows/ChartWindow.xaml
@@ -37,12 +37,12 @@
                 BorderBrush="{DynamicResource Divider}" BorderThickness="1" Padding="8"
                 Background="{DynamicResource SurfaceAlt}">
             <Grid>
+                <!-- TradingView Lightweight Charts için WebView2 -->
+                <wv2:WebView2 x:Name="ChartWebView"/>
                 <!-- Veri veya hata mesajları için -->
                 <TextBlock x:Name="InfoText" Text="Yükleniyor..."
                            HorizontalAlignment="Center" VerticalAlignment="Center"
-                           Opacity="0.7"/>
-                <!-- TradingView Lightweight Charts için WebView2 -->
-                <wv2:WebView2 x:Name="ChartWebView"/>
+                           Opacity="0.7" Panel.ZIndex="1"/>
             </Grid>
         </Border>
     </Grid>


### PR DESCRIPTION
## Summary
- Render candlestick chart via Binance REST data instead of websocket updates
- Simplify ChartWindow to load candles after WebView navigation
- Ensure info/error text overlays the WebView properly

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab67def15c8333968acc3bb50521ab