### PR TITLE
Fix control color application

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -113,7 +113,7 @@
                 <Style x:Key="{x:Static ToolBar.TextBoxStyleKey}"
                        TargetType="TextBox"
                        BasedOn="{StaticResource {x:Type TextBox}}">
-                        <Setter Property="Background"      Value="{DynamicResource TbBg}"/>
+                        <Setter Property="Background"      Value="{DynamicResource SurfaceAlt}"/>
                         <Setter Property="Foreground"      Value="{DynamicResource TbFg}"/>
                         <Setter Property="BorderBrush"     Value="{DynamicResource TbBorder}"/>
                         <Setter Property="BorderThickness" Value="1"/>
@@ -257,10 +257,10 @@
                                         <Style TargetType="{x:Type ScrollViewer}" BasedOn="{x:Null}" />
 
 					<!-- Also force TextBox in ToolBar to use a safe template whose PART_ContentHost ScrollViewer does NOT pick implicit styles -->
-					<Style TargetType="{x:Type TextBox}">
-						<Setter Property="BorderBrush" Value="{DynamicResource TbBorder}"/>
-						<Setter Property="Background" Value="{DynamicResource TbBg}"/>
-						<Setter Property="Foreground" Value="{DynamicResource TbFg}"/>
+                                        <Style TargetType="{x:Type TextBox}">
+                                                <Setter Property="BorderBrush" Value="{DynamicResource TbBorder}"/>
+                                                <Setter Property="Background" Value="{DynamicResource SurfaceAlt}"/>
+                                                <Setter Property="Foreground" Value="{DynamicResource TbFg}"/>
 						<Setter Property="Template">
 							<Setter.Value>
 								<ControlTemplate TargetType="{x:Type TextBox}">

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -204,11 +204,9 @@ namespace BinanceUsdtTicker
             TryApplyBrush("SurfaceAlt", _ui.ControlColor);
             TryApplyBrush("RowBg", _ui.ThemeColor);
             TryApplyBrush("RowAltBg", _ui.ThemeColor);
-            // toolbar and button surfaces
-            TryApplyBrush("TbBg", _ui.ControlColor);
+            // button surfaces
             TryApplyBrush("TbHover", _ui.ControlColor);
             TryApplyBrush("TbPressed", _ui.ControlColor);
-            TryApplyBrush("TbBorder", _ui.ControlColor);
             TryApplyBrush("HeaderBg", _ui.ThemeColor);
             TryApplyBrush("HeaderBorder", _ui.ThemeColor);
             TryApplyBrush("OnSurface", _ui.TextColor);


### PR DESCRIPTION
## Summary
- Preserve theme-based toolbar colors
- Apply custom control color to toolbar text boxes and buttons only

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6b8bfe448333b5855ea8362746bc