### PR TITLE
Add logging to diagnose missing ticker data

### DIFF
--- a/Services/Logger.cs
+++ b/Services/Logger.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+
+namespace BinanceUsdtTicker
+{
+    /// <summary>
+    /// Simple file logger to help diagnose data issues.
+    /// </summary>
+    public static class Logger
+    {
+        private static readonly object _lock = new();
+        private static readonly string _logFile;
+
+        static Logger()
+        {
+            var dir = Path.Combine(AppContext.BaseDirectory, "logs");
+            Directory.CreateDirectory(dir);
+            _logFile = Path.Combine(dir, "app.log");
+        }
+
+        public static void Log(string message)
+        {
+            var line = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss} {message}";
+            lock (_lock)
+            {
+                File.AppendAllText(_logFile, line + Environment.NewLine);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add simple file-based Logger
- log websocket state and parsing issues in BinanceSpotService
- monitor message gaps to detect missing data

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures missing)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6bc101688333afb3a47d43392a63