### PR TITLE
Load chart library locally

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -12,4 +12,10 @@
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1823.32" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Resources/lightweight-charts.standalone.production.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
@@ -117,16 +118,17 @@ namespace BinanceUsdtTicker
             string up = GetColor("Up1Bg");
             string down = GetColor("Down1Bg");
 
-            const string scriptTag = "<script src='https://unpkg.com/lightweight-charts/dist/lightweight-charts.standalone.production.js'></script>";
+            string scriptPath = Path.Combine(AppContext.BaseDirectory, "Resources", "lightweight-charts.standalone.production.js");
+            string library = File.ReadAllText(scriptPath).Replace("</script>", "<\\/script>");
 
             return $@"<!DOCTYPE html>
 <html>
 <head>
     <meta charset='UTF-8'/>
-    {scriptTag}
 </head>
 <body style='margin:0;background:{bg};color:{fg};'>
 <div id='chart' style='width:100%;height:100%;'></div>
+<script>{library}</script>
 <script>
     const fmt = p => p.toLocaleString(undefined, {{ maximumFractionDigits: 8 }});
     const chart = LightweightCharts.createChart(


### PR DESCRIPTION
## Summary
- Load lightweight-charts script from bundled resource instead of external CDN
- Copy lightweight-charts file to output during build

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab784d57c083339c87c1308cd71bc8