### PR TITLE
Fix JavaScript object escaping in chart HTML

### DIFF
--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -150,7 +150,7 @@ namespace BinanceUsdtTicker
     async function loadCandles(symbol, interval) {{
         const url = "https://api.binance.com/api/v3/klines?symbol=" + symbol + "&interval=" + interval + "&limit=200";
         const data = await fetch(url).then(r => r.json());
-        const candles = data.map(c => ({ time: c[0] / 1000, open: parseFloat(c[1]), high: parseFloat(c[2]), low: parseFloat(c[3]), close: parseFloat(c[4]) }));
+        const candles = data.map(c => ({{ time: c[0] / 1000, open: parseFloat(c[1]), high: parseFloat(c[2]), low: parseFloat(c[3]), close: parseFloat(c[4]) }}));
         setCandles(candles);
     }}
     window.loadCandles = loadCandles;


### PR DESCRIPTION
## Summary
- properly escape JavaScript object braces when building chart HTML

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7dcb07d8833384195cfefae9ab3d