### PR TITLE
Fix ChartWindow HTML string to compile

### DIFF
--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -148,7 +148,7 @@ namespace BinanceUsdtTicker
     }};
 
     async function loadCandles(symbol, interval) {{
-        const url = "https://api.binance.com/api/v3/klines?symbol=" + symbol + "&interval=" + interval + "&limit=200";
+        const url = 'https://api.binance.com/api/v3/klines?symbol=' + symbol + '&interval=' + interval + '&limit=200';
         const data = await fetch(url).then(r => r.json());
         const candles = data.map(c => ({{ time: c[0] / 1000, open: parseFloat(c[1]), high: parseFloat(c[2]), low: parseFloat(c[3]), close: parseFloat(c[4]) }}));
         setCandles(candles);


### PR DESCRIPTION
## Summary
- fix ChartWindow WebView URL string quoting so source compiles

## Testing
- `dotnet build BinanceUsdtTicker.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7e8610e08333977a0f8a6cc08374