### PR TITLE
Load chart data after WebView ready

### DIFF
--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -48,12 +48,13 @@ namespace BinanceUsdtTicker
                 string interval = (IntervalBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "5m";
 
                 await ChartWebView.EnsureCoreWebView2Async();
-                ChartWebView.CoreWebView2.NavigationCompleted += (_, __) =>
+                ChartWebView.CoreWebView2.NavigationCompleted += async (_, __) =>
                 {
                     if (InfoText != null) InfoText.Visibility = Visibility.Collapsed;
+                    await LoadCandlesAsync(interval);
                 };
 
-                string html = BuildHtml(Symbol, interval);
+                string html = BuildHtml(Symbol);
                 ChartWebView.NavigateToString(html);
                 _isInitialized = true;
             }
@@ -82,7 +83,7 @@ namespace BinanceUsdtTicker
             await LoadCandlesAsync(interval);
         }
 
-        private static string BuildHtml(string symbol, string interval)
+        private static string BuildHtml(string symbol)
         {
             string GetColor(string key)
             {
@@ -154,7 +155,6 @@ namespace BinanceUsdtTicker
         setCandles(candles);
     }}
     window.loadCandles = loadCandles;
-    loadCandles('{symbol}','{interval}');
 
     window.addEventListener('resize', () => {{
         chart.applyOptions({{ width: window.innerWidth, height: window.innerHeight }});


### PR DESCRIPTION
## Summary
- Ensure chart window fetches candles after the WebView2 control finishes navigating
- Simplify embedded HTML to defer candle loading to C# logic

## Testing
- `dotnet build` *(fails: bash: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ab80d8a29c833392bbd7c67ff64970