### PR TITLE
Load chart script locally to restore graphs

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -12,4 +12,10 @@
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1823.32" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="Resources/lightweight-charts.standalone.production.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -51,11 +52,11 @@ namespace BinanceUsdtTicker
                 ChartWebView.CoreWebView2.NavigationCompleted += (_, __) =>
                 {
                     if (InfoText != null) InfoText.Visibility = Visibility.Collapsed;
+                    _isInitialized = true;
                 };
 
                 string html = BuildHtml(Symbol, interval);
                 ChartWebView.NavigateToString(html);
-                _isInitialized = true;
             }
             catch (Exception ex)
             {
@@ -101,13 +102,14 @@ namespace BinanceUsdtTicker
             string up = GetColor("Up1Bg");
             string down = GetColor("Down1Bg");
 
-            const string scriptTag = "<script src='https://unpkg.com/lightweight-charts/dist/lightweight-charts.standalone.production.js'></script>";
+            var scriptPath = Path.Combine(AppContext.BaseDirectory, "Resources", "lightweight-charts.standalone.production.js");
+            string scriptContent = File.Exists(scriptPath) ? File.ReadAllText(scriptPath) : string.Empty;
 
             return $@"<!DOCTYPE html>
 <html>
 <head>
     <meta charset='UTF-8'/>
-    {scriptTag}
+    <script>{scriptContent}</script>
 </head>
 <body style='margin:0;background:{bg};color:{fg};'>
 <div id='chart' style='width:100%;height:100%;'></div>


### PR DESCRIPTION
## Summary
- Embed lightweight-charts script from local resources
- Mark chart window initialized only after WebView2 navigation completes
- Copy chart script to output during build

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab830b460c8333a3ab71ff6e7f1497