### PR TITLE
Fix LiveCharts namespace resolution in ChartWindow

### DIFF
--- a/Windows/ChartWindow.xaml
+++ b/Windows/ChartWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="BinanceUsdtTicker.ChartWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:lvc="https://github.com/beto-rodriguez/LiveCharts2"
+        xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.WPF;assembly=LiveChartsCore.SkiaSharpView.WPF"
+        xmlns:lvcx="clr-namespace:LiveChartsCore.SkiaSharpView;assembly=LiveChartsCore.SkiaSharpView"
         Title="Grafik" Height="420" Width="680"
         Background="{DynamicResource Surface}"
         Foreground="{DynamicResource OnSurface}">
@@ -40,7 +41,7 @@
                 <!-- Canlı mum grafiği için LiveCharts -->
                 <lvc:CartesianChart x:Name="CandleChart">
                     <lvc:CartesianChart.Series>
-                        <lvc:CandlesticksSeries x:Name="CandleSeries"/>
+                        <lvcx:CandlesticksSeries x:Name="CandleSeries"/>
                     </lvc:CartesianChart.Series>
                 </lvc:CartesianChart>
                 <!-- Veri veya hata mesajları için -->


### PR DESCRIPTION
## Summary
- fix LiveCharts XAML namespace in `ChartWindow` to ensure CartesianChart and series resolve correctly

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab868901d4833397fc2d1487923ee3