### PR TITLE
Fix LiveCharts namespace for ChartWindow

### DIFF
--- a/Windows/ChartWindow.xaml
+++ b/Windows/ChartWindow.xaml
@@ -1,8 +1,7 @@
 <Window x:Class="BinanceUsdtTicker.ChartWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.WPF;assembly=LiveChartsCore.SkiaSharpView.WPF"
-        xmlns:lvcx="clr-namespace:LiveChartsCore.SkiaSharpView;assembly=LiveChartsCore.SkiaSharpView"
+        xmlns:lvc="http://livecharts.com"
         Title="Grafik" Height="420" Width="680"
         Background="{DynamicResource Surface}"
         Foreground="{DynamicResource OnSurface}">
@@ -41,7 +40,7 @@
                 <!-- Canlı mum grafiği için LiveCharts -->
                 <lvc:CartesianChart x:Name="CandleChart">
                     <lvc:CartesianChart.Series>
-                        <lvcx:CandlesticksSeries x:Name="CandleSeries"/>
+                        <lvc:CandlesticksSeries x:Name="CandleSeries"/>
                     </lvc:CartesianChart.Series>
                 </lvc:CartesianChart>
                 <!-- Veri veya hata mesajları için -->


### PR DESCRIPTION
## Summary
- fix LiveCharts XAML namespace so CartesianChart and CandlesticksSeries resolve

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ab875fc46c8333a784fceb63fd43db