### PR TITLE
Fix LiveCharts namespace in ChartWindow

### DIFF
--- a/Windows/ChartWindow.xaml
+++ b/Windows/ChartWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="BinanceUsdtTicker.ChartWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:lvc="http://livecharts.com"
+        xmlns:lvc="https://livecharts.dev"
         Title="Grafik" Height="420" Width="680"
         Background="{DynamicResource Surface}"
         Foreground="{DynamicResource OnSurface}">


### PR DESCRIPTION
## Summary
- point LiveCharts XAML namespace at livecharts.dev instead of livecharts.com

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab881c4e70833395341f50ad4c855f