### PR TITLE
Replace LiveCharts with WinForms chart

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1823.32" />
-    <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.0" />
+    <PackageReference Include="System.Windows.Forms.DataVisualization" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Windows/ChartWindow.xaml
+++ b/Windows/ChartWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="BinanceUsdtTicker.ChartWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:lvc="https://livecharts.dev"
+        xmlns:wfi="clr-namespace:System.Windows.Forms.Integration;assembly=WindowsFormsIntegration"
         Title="Grafik" Height="420" Width="680"
         Background="{DynamicResource Surface}"
         Foreground="{DynamicResource OnSurface}">
@@ -37,17 +37,12 @@
                 BorderBrush="{DynamicResource Divider}" BorderThickness="1" Padding="8"
                 Background="{DynamicResource SurfaceAlt}">
             <Grid>
-                <!-- Canlı mum grafiği için LiveCharts -->
-                <lvc:CartesianChart x:Name="CandleChart">
-                    <lvc:CartesianChart.Series>
-                        <lvc:CandlesticksSeries x:Name="CandleSeries"/>
-                    </lvc:CartesianChart.Series>
-                </lvc:CartesianChart>
+                <wfi:WindowsFormsHost x:Name="ChartHost"/>
                 <!-- Veri veya hata mesajları için -->
                 <TextBlock x:Name="InfoText" Text="Yükleniyor..."
                            HorizontalAlignment="Center" VerticalAlignment="Center"
                            Opacity="0.7" Panel.ZIndex="1"/>
-            </Grid>
+                </Grid>
         </Border>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- remove LiveCharts package and switch charting to WinForms
- embed WindowsFormsHost with candlestick chart and populate using Binance OHLC data

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8a1a41588333a6bc633313dadc0a