### PR TITLE
fix: update charting references

### DIFF
--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -6,7 +6,8 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Forms;
-using System.Windows.Forms.DataVisualization.Charting;
+using WinFormsChart = System.Windows.Forms.DataVisualization.Charting.Chart;
+using WinFormsSeries = System.Windows.Forms.DataVisualization.Charting.Series;
 
 namespace BinanceUsdtTicker
 {
@@ -15,19 +16,19 @@ namespace BinanceUsdtTicker
         public string Symbol { get; private set; } = "";
 
         private readonly BinanceSpotService? _service;
-        private readonly Chart _chart = new();
-        private readonly Series _series;
+        private readonly WinFormsChart _chart = new();
+        private readonly WinFormsSeries _series;
 
         public ChartWindow()
         {
             InitializeComponent();
             Loaded += ChartWindow_Loaded;
 
-            _chart.ChartAreas.Add(new ChartArea("Main"));
-            _series = new Series("Price")
+            _chart.ChartAreas.Add(new System.Windows.Forms.DataVisualization.Charting.ChartArea("Main"));
+            _series = new WinFormsSeries("Price")
             {
-                ChartType = SeriesChartType.Candlestick,
-                XValueType = ChartValueType.DateTime,
+                ChartType = System.Windows.Forms.DataVisualization.Charting.SeriesChartType.Candlestick,
+                XValueType = System.Windows.Forms.DataVisualization.Charting.ChartValueType.DateTime,
                 YValuesPerPoint = 4
             };
             _chart.Series.Add(_series);


### PR DESCRIPTION
## Summary
- qualify charting types with aliases so ChartWindow can compile

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8b80c9bc833389345f533abc4758