### PR TITLE
Replace WinForms chart with Canvas drawing

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1823.32" />
-    <PackageReference Include="System.Windows.Forms.DataVisualization" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Windows/ChartWindow.xaml
+++ b/Windows/ChartWindow.xaml
@@ -1,7 +1,6 @@
 <Window x:Class="BinanceUsdtTicker.ChartWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:wfi="clr-namespace:System.Windows.Forms.Integration;assembly=WindowsFormsIntegration"
         Title="Grafik" Height="420" Width="680"
         Background="{DynamicResource Surface}"
         Foreground="{DynamicResource OnSurface}">
@@ -37,12 +36,12 @@
                 BorderBrush="{DynamicResource Divider}" BorderThickness="1" Padding="8"
                 Background="{DynamicResource SurfaceAlt}">
             <Grid>
-                <wfi:WindowsFormsHost x:Name="ChartHost"/>
+                <Canvas x:Name="ChartCanvas"/>
                 <!-- Veri veya hata mesajları için -->
                 <TextBlock x:Name="InfoText" Text="Yükleniyor..."
                            HorizontalAlignment="Center" VerticalAlignment="Center"
                            Opacity="0.7" Panel.ZIndex="1"/>
-                </Grid>
+            </Grid>
         </Border>
     </Grid>
 </Window>

--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -1,12 +1,14 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Forms;
-using System.Windows.Forms.DataVisualization.Charting;
+using System.Windows.Media;
+using System.Windows.Shapes;
 
 namespace BinanceUsdtTicker
 {
@@ -15,24 +17,11 @@ namespace BinanceUsdtTicker
         public string Symbol { get; private set; } = "";
 
         private readonly BinanceSpotService? _service;
-        private readonly Chart _chart = new();
-        private readonly Series _series;
 
         public ChartWindow()
         {
             InitializeComponent();
             Loaded += ChartWindow_Loaded;
-
-            _chart.ChartAreas.Add(new ChartArea("Main"));
-            _series = new Series("Price")
-            {
-                ChartType = SeriesChartType.Candlestick,
-                XValueType = ChartValueType.DateTime,
-                YValuesPerPoint = 4
-            };
-            _chart.Series.Add(_series);
-            _chart.Dock = DockStyle.Fill;
-            if (ChartHost != null) ChartHost.Child = _chart;
         }
 
         public ChartWindow(string symbol) : this()
@@ -81,16 +70,17 @@ namespace BinanceUsdtTicker
                 using var http = new HttpClient();
                 using var stream = await http.GetStreamAsync(url);
                 using var doc = await JsonDocument.ParseAsync(stream);
-                _series.Points.Clear();
+                var items = new List<Kline>();
                 foreach (var el in doc.RootElement.EnumerateArray())
                 {
-                    long time = el[0].GetInt64();
                     double open = double.Parse(el[1].GetString() ?? "0", CultureInfo.InvariantCulture);
                     double high = double.Parse(el[2].GetString() ?? "0", CultureInfo.InvariantCulture);
                     double low = double.Parse(el[3].GetString() ?? "0", CultureInfo.InvariantCulture);
                     double close = double.Parse(el[4].GetString() ?? "0", CultureInfo.InvariantCulture);
-                    _series.Points.AddXY(DateTimeOffset.FromUnixTimeMilliseconds(time).DateTime, high, low, open, close);
+                    items.Add(new Kline(open, high, low, close));
                 }
+
+                DrawCandles(items);
 
                 if (InfoText != null)
                     InfoText.Visibility = Visibility.Collapsed;
@@ -104,5 +94,55 @@ namespace BinanceUsdtTicker
                 }
             }
         }
+        private void DrawCandles(IReadOnlyList<Kline> items)
+        {
+            if (ChartCanvas == null) return;
+            ChartCanvas.Children.Clear();
+            if (items.Count == 0) return;
+
+            double width = ChartCanvas.ActualWidth;
+            double height = ChartCanvas.ActualHeight;
+            if (width <= 0 || height <= 0) return;
+
+            double candleWidth = width / items.Count;
+            double min = items.Min(k => k.Low);
+            double max = items.Max(k => k.High);
+            double scale = (height - 20) / (max - min);
+
+            for (int i = 0; i < items.Count; i++)
+            {
+                var k = items[i];
+                double x = i * candleWidth + candleWidth / 2;
+                double yOpen = height - (k.Open - min) * scale;
+                double yClose = height - (k.Close - min) * scale;
+                double yHigh = height - (k.High - min) * scale;
+                double yLow = height - (k.Low - min) * scale;
+
+                var line = new Line
+                {
+                    X1 = x,
+                    X2 = x,
+                    Y1 = yHigh,
+                    Y2 = yLow,
+                    Stroke = Brushes.Gray,
+                    StrokeThickness = 1
+                };
+                ChartCanvas.Children.Add(line);
+
+                var rect = new Rectangle
+                {
+                    Width = Math.Max(1, candleWidth * 0.7),
+                    Height = Math.Abs(yClose - yOpen),
+                    Fill = k.Close >= k.Open ? Brushes.Green : Brushes.Red,
+                    Stroke = Brushes.Black,
+                    StrokeThickness = 1
+                };
+                Canvas.SetLeft(rect, x - rect.Width / 2);
+                Canvas.SetTop(rect, Math.Min(yOpen, yClose));
+                ChartCanvas.Children.Add(rect);
+            }
+        }
+
+        private readonly record struct Kline(double Open, double High, double Low, double Close);
     }
 }


### PR DESCRIPTION
## Summary
- draw candlestick chart using WPF Canvas instead of WinForms DataVisualization
- remove System.Windows.Forms.DataVisualization package

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8d5fb7fc8333a90179447e35e75b