### PR TITLE
Remove unused ChartWindow service parameter

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -550,7 +550,7 @@ namespace BinanceUsdtTicker
         {
             if (sender is FrameworkElement fe && fe.DataContext is TickerRow row)
             {
-                var win = new ChartWindow(row.Symbol, _service);
+                var win = new ChartWindow(row.Symbol);
                 win.Owner = this;
                 win.Show();
             }

--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -14,6 +14,7 @@ namespace BinanceUsdtTicker
         {
             InitializeComponent();
             Loaded += ChartWindow_Loaded;
+            Symbol = string.Empty;
         }
 
         public ChartWindow(string symbol) : this()


### PR DESCRIPTION
## Summary
- Initialize `ChartWindow`'s Symbol to avoid nullable warning
- Open `ChartWindow` using only symbol argument

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_68ab99d0fcf0833390e40bf9015c1c36