### PR TITLE
Set chart default interval to 1m

### DIFF
--- a/Resources/chart.html
+++ b/Resources/chart.html
@@ -9,7 +9,7 @@
 <script>
 const params = new URLSearchParams(location.search);
 const symbol = (params.get('symbol') || 'BTCUSDT').toUpperCase();
-const interval = (params.get('interval') || '5m').toLowerCase();
+const interval = (params.get('interval') || '1m').toLowerCase();
 
 const intervalMap = {
     '1m': '1',
@@ -24,7 +24,7 @@ new TradingView.widget({
     autosize: true,
     container_id: 'tv_chart_container',
     symbol: 'BINANCE:' + symbol,
-    interval: intervalMap[interval] || '5',
+    interval: intervalMap[interval] || '1',
     timezone: 'Etc/UTC',
     theme: 'light',
     style: '1',

--- a/Windows/ChartWindow.xaml
+++ b/Windows/ChartWindow.xaml
@@ -21,8 +21,8 @@
             <ComboBox x:Name="IntervalBox" Width="90"
                       SelectionChanged="IntervalBox_SelectionChanged"
                       Margin="6,0,0,0">
-                <ComboBoxItem Content="1m"  Tag="1m"/>
-                <ComboBoxItem Content="5m"  Tag="5m"  IsSelected="True"/>
+                <ComboBoxItem Content="1m"  Tag="1m"  IsSelected="True"/>
+                <ComboBoxItem Content="5m"  Tag="5m"/>
                 <ComboBoxItem Content="15m" Tag="15m"/>
                 <ComboBoxItem Content="1h"  Tag="1h"/>
                 <ComboBoxItem Content="4h"  Tag="4h"/>

--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -28,19 +28,19 @@ namespace BinanceUsdtTicker
 
         private async void ChartWindow_Loaded(object? sender, RoutedEventArgs e)
         {
-            string interval = (IntervalBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "5m";
+            string interval = (IntervalBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "1m";
             await LoadChartAsync(interval);
         }
 
         private async void IntervalBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            string interval = (IntervalBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "5m";
+            string interval = (IntervalBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "1m";
             await LoadChartAsync(interval);
         }
 
         private async void Refresh_Click(object sender, RoutedEventArgs e)
         {
-            string interval = (IntervalBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "5m";
+            string interval = (IntervalBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "1m";
             await LoadChartAsync(interval);
         }
 


### PR DESCRIPTION
## Summary
- Select the 1-minute interval by default in the chart window
- Adjust code-behind and HTML to use 1m when no interval is provided

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aba3940a2883338b47f3f34ec2638b