### PR TITLE
Remove toolbar from chart window

### DIFF
--- a/Windows/ChartWindow.xaml
+++ b/Windows/ChartWindow.xaml
@@ -7,35 +7,7 @@
         Foreground="{DynamicResource OnSurface}">
 
     <Grid Margin="10">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
-
-        <!-- Üst kontrol şeridi -->
-        <StackPanel Orientation="Horizontal">
-            <TextBlock Text="Sembol:" VerticalAlignment="Center" Margin="0,0,6,0"/>
-            <TextBlock x:Name="SymbolText" FontWeight="Bold" VerticalAlignment="Center"/>
-
-            <TextBlock Text="Aralık:" Margin="16,0,0,0" VerticalAlignment="Center"/>
-            <ComboBox x:Name="IntervalBox" Width="90"
-                      SelectionChanged="IntervalBox_SelectionChanged"
-                      Margin="6,0,0,0">
-                <ComboBoxItem Content="1m"  Tag="1m"  IsSelected="True"/>
-                <ComboBoxItem Content="5m"  Tag="5m"/>
-                <ComboBoxItem Content="15m" Tag="15m"/>
-                <ComboBoxItem Content="1h"  Tag="1h"/>
-                <ComboBoxItem Content="4h"  Tag="4h"/>
-                <ComboBoxItem Content="1d"  Tag="1d"/>
-            </ComboBox>
-
-            <Button Content="Yenile" Click="Refresh_Click" Margin="8,0,0,0"/>
-        </StackPanel>
-
-        <!-- TradingView Charting Library alanı -->
-        <Border Grid.Row="1" Margin="0,10,0,0"
-                BorderBrush="{DynamicResource Divider}" BorderThickness="1" Padding="0"
-                Background="{DynamicResource SurfaceAlt}">
+        <Border BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{DynamicResource SurfaceAlt}">
             <wv2:WebView2 x:Name="ChartWebView"/>
         </Border>
     </Grid>

--- a/Windows/ChartWindow.xaml.cs
+++ b/Windows/ChartWindow.xaml.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
 
 namespace BinanceUsdtTicker
 {
@@ -23,28 +22,14 @@ namespace BinanceUsdtTicker
                 Symbol = symbol.Trim().ToUpperInvariant();
 
             Title = string.IsNullOrEmpty(Symbol) ? "Grafik" : $"Grafik - {Symbol}";
-            if (SymbolText != null) SymbolText.Text = Symbol;
         }
 
         private async void ChartWindow_Loaded(object? sender, RoutedEventArgs e)
         {
-            string interval = (IntervalBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "1m";
-            await LoadChartAsync(interval);
+            await LoadChartAsync();
         }
 
-        private async void IntervalBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            string interval = (IntervalBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "1m";
-            await LoadChartAsync(interval);
-        }
-
-        private async void Refresh_Click(object sender, RoutedEventArgs e)
-        {
-            string interval = (IntervalBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "1m";
-            await LoadChartAsync(interval);
-        }
-
-        private async Task LoadChartAsync(string interval)
+        private async Task LoadChartAsync()
         {
             if (string.IsNullOrWhiteSpace(Symbol)) return;
 
@@ -54,7 +39,7 @@ namespace BinanceUsdtTicker
             var uri = new Uri(path);
             var builder = new UriBuilder(uri)
             {
-                Query = $"symbol={Uri.EscapeDataString(Symbol)}&interval={Uri.EscapeDataString(interval)}"
+                Query = $"symbol={Uri.EscapeDataString(Symbol)}&interval=1m"
             };
             ChartWebView.CoreWebView2.Navigate(builder.Uri.ToString());
         }


### PR DESCRIPTION
## Summary
- Simplify chart window by removing the control bar, leaving only the TradingView display.
- Load charts with a fixed 1‑minute interval.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aba5dd0c0c8333ae6b5f5026f3d9c9