### PR TITLE
Remove summary view toggle

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -284,22 +284,10 @@
                                          TextChanged="SearchBox_TextChanged"/>
 
                                 <Separator/>
-
-                                <ToggleButton x:Name="ViewToggle"
-                                                          ToolBar.OverflowMode="Never"
-                                                          Style="{StaticResource ToolbarToggleButtonStyle}"
-                                                          IsChecked="True"
-                                                          Content="Detay"
-                                                          Checked="ViewToggle_Checked"
-                                                          Unchecked="ViewToggle_Unchecked"
-                                                          Margin="0,0,12,0"/>
-
-                                <Separator/>
-
-				<RadioButton x:Name="RbAll" ToolBar.OverflowMode="Never"
-							 Style="{StaticResource ToolbarRadioStyle}"
-							 Tag="All" Content="Tümü" GroupName="Mode" IsChecked="True"
-							 Checked="FilterModeChanged" Margin="6,0"/>
+                                <RadioButton x:Name="RbAll" ToolBar.OverflowMode="Never"
+                                                         Style="{StaticResource ToolbarRadioStyle}"
+                                                         Tag="All" Content="Tümü" GroupName="Mode" IsChecked="True"
+                                                         Checked="FilterModeChanged" Margin="6,0"/>
 				<RadioButton x:Name="RbPos" ToolBar.OverflowMode="Never"
 							 Style="{StaticResource ToolbarRadioStyle}"
 							 Tag="Positive" Content="Yükselen" GroupName="Mode"

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -791,33 +791,6 @@ namespace BinanceUsdtTicker
             if (symbol != null) symbol.DisplayIndex = idx++;
         }
 
-        private void SetColumnVisibilityByHeader(string header, Visibility v)
-        {
-            var col = Grid?.Columns?.FirstOrDefault(c => string.Equals(c.Header?.ToString(), header, StringComparison.OrdinalIgnoreCase));
-            if (col != null) col.Visibility = v;
-        }
-
-        // Görünüm: Özet (Unchecked) / Detay (Checked)
-        private void ViewToggle_Checked(object sender, RoutedEventArgs e)
-        {
-            var viewToggle = sender as ToggleButton ?? Q<ToggleButton>("ViewToggle");
-            if (viewToggle != null) viewToggle.Content = "Detay";
-            SetColumnVisibilityByHeader("Açılış", Visibility.Visible);
-            SetColumnVisibilityByHeader("Yüksek", Visibility.Visible);
-            SetColumnVisibilityByHeader("Düşük", Visibility.Visible);
-            EnsureSpecialColumnsOrder();
-        }
-
-        private void ViewToggle_Unchecked(object sender, RoutedEventArgs e)
-        {
-            var viewToggle = sender as ToggleButton ?? Q<ToggleButton>("ViewToggle");
-            if (viewToggle != null) viewToggle.Content = "Özet";
-            SetColumnVisibilityByHeader("Açılış", Visibility.Collapsed);
-            SetColumnVisibilityByHeader("Yüksek", Visibility.Collapsed);
-            SetColumnVisibilityByHeader("Düşük", Visibility.Collapsed);
-            EnsureSpecialColumnsOrder();
-        }
-
         // ---------- UI settings / favorites ----------
         private void SaveAlertsSafe()
         {


### PR DESCRIPTION
## Summary
- Remove the summary/detail view toggle from the toolbar, showing details only.
- Delete unused event handlers and column visibility helper tied to the summary view.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aba669f9048333b6b66553d599c60a