### PR TITLE
Limit ControlColor to buttons

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -201,12 +201,13 @@ namespace BinanceUsdtTicker
         private void ApplyCustomColors()
         {
             TryApplyBrush("Surface", _ui.ThemeColor);
-            TryApplyBrush("SurfaceAlt", _ui.ControlColor);
+            TryApplyBrush("SurfaceAlt", _ui.ThemeColor);
             TryApplyBrush("RowBg", _ui.ThemeColor);
             TryApplyBrush("RowAltBg", _ui.ThemeColor);
             // button surfaces
-            TryApplyBrush("TbHover", _ui.ControlColor);
-            TryApplyBrush("TbPressed", _ui.ControlColor);
+            TryApplyBrush("BtnBg", _ui.ControlColor);
+            TryApplyBrush("BtnHover", _ui.ControlColor);
+            TryApplyBrush("BtnPressed", _ui.ControlColor);
             TryApplyBrush("HeaderBg", _ui.ThemeColor);
             TryApplyBrush("HeaderBorder", _ui.ThemeColor);
             TryApplyBrush("OnSurface", _ui.TextColor);

--- a/Themes/Dark.xaml
+++ b/Themes/Dark.xaml
@@ -30,6 +30,11 @@
     <SolidColorBrush x:Key="TbDisabledBg"   Color="#33181A20"/>
     <SolidColorBrush x:Key="TbDisabledFg"   Color="#66C5C7CB"/>
 
+    <!-- Button tokens -->
+    <SolidColorBrush x:Key="BtnBg"      Color="#FF181A20"/>
+    <SolidColorBrush x:Key="BtnHover"   Color="#FF20252C"/>
+    <SolidColorBrush x:Key="BtnPressed" Color="#FF2B3139"/>
+
     <!-- Hover color for list rows -->
     <SolidColorBrush x:Key="RowHoverBg"      Color="#FF20252C"/>
 

--- a/Themes/Light.xaml
+++ b/Themes/Light.xaml
@@ -30,6 +30,11 @@
     <SolidColorBrush x:Key="TbDisabledBg"   Color="#15FFFFFF"/>
     <SolidColorBrush x:Key="TbDisabledFg"   Color="#669CA3AF"/>
 
+    <!-- Button tokens -->
+    <SolidColorBrush x:Key="BtnBg"      Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="BtnHover"   Color="#FFEFF1F5"/>
+    <SolidColorBrush x:Key="BtnPressed" Color="#FFDFE3EA"/>
+
     <!-- Hover color for list rows -->
     <SolidColorBrush x:Key="RowHoverBg"      Color="#FFEFF1F5"/>
 

--- a/Themes/Styles.Base.xaml
+++ b/Themes/Styles.Base.xaml
@@ -3,7 +3,7 @@
 
     <!-- Base button style used across the app -->
     <Style x:Key="BaseButtonStyle" TargetType="{x:Type Button}">
-        <Setter Property="Background"      Value="{DynamicResource SurfaceAlt}"/>
+        <Setter Property="Background"      Value="{DynamicResource BtnBg}"/>
         <Setter Property="Foreground"      Value="{DynamicResource OnSurface}"/>
         <Setter Property="BorderBrush"     Value="{DynamicResource Divider}"/>
         <Setter Property="BorderThickness" Value="1"/>
@@ -25,10 +25,10 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource TbHover}"/>
+                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource BtnHover}"/>
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource TbPressed}"/>
+                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource BtnPressed}"/>
                             <Setter TargetName="Bd" Property="Effect">
                                 <Setter.Value>
                                     <DropShadowEffect Color="#66000000" BlurRadius="2" ShadowDepth="0"/>

--- a/Themes/Styles.Toolbar.xaml
+++ b/Themes/Styles.Toolbar.xaml
@@ -54,11 +54,11 @@
 	</ControlTemplate>
 
 	<!-- BUTTON -->
-	<Style x:Key="ToolbarButtonStyle" TargetType="{x:Type Button}">
-		<Setter Property="FontSize"   Value="{StaticResource TbFontSize}"/>
-		<Setter Property="FontWeight" Value="{StaticResource TbFontWeight}"/>
-		<Setter Property="Foreground" Value="{DynamicResource TbFg}"/>
-                <Setter Property="Background" Value="{DynamicResource TbHover}"/>
+        <Style x:Key="ToolbarButtonStyle" TargetType="{x:Type Button}">
+                <Setter Property="FontSize"   Value="{StaticResource TbFontSize}"/>
+                <Setter Property="FontWeight" Value="{StaticResource TbFontWeight}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TbFg}"/>
+                <Setter Property="Background" Value="{DynamicResource BtnBg}"/>
                 <Setter Property="BorderBrush" Value="{DynamicResource TbBorder}"/>
                 <Setter Property="Padding" Value="{StaticResource TbPad}"/>
                 <Setter Property="Template">
@@ -74,27 +74,27 @@
 					</ContentControl>
 					<ControlTemplate.Triggers>
                                                 <Trigger Property="IsMouseOver" Value="True">
-                                                        <Setter Property="Background" Value="{DynamicResource TbPressed}"/>
+                                                        <Setter Property="Background" Value="{DynamicResource BtnHover}"/>
                                                 </Trigger>
                                                 <Trigger Property="IsPressed" Value="True">
-                                                        <Setter Property="Background" Value="{DynamicResource TbPressed}"/>
+                                                        <Setter Property="Background" Value="{DynamicResource BtnPressed}"/>
                                                 </Trigger>
-						<Trigger Property="IsEnabled" Value="False">
-							<Setter Property="Foreground" Value="{DynamicResource TbDisabledFg}"/>
-							<Setter Property="Background" Value="{DynamicResource TbDisabledBg}"/>
-						</Trigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                                                <Trigger Property="IsEnabled" Value="False">
+                                                        <Setter Property="Foreground" Value="{DynamicResource TbDisabledFg}"/>
+                                                        <Setter Property="Background" Value="{DynamicResource TbDisabledBg}"/>
+                                                </Trigger>
+                                        </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                        </Setter.Value>
+                </Setter>
+        </Style>
 
 	<!-- TOGGLE -->
-	<Style x:Key="ToolbarToggleButtonStyle" TargetType="{x:Type ToggleButton}">
-		<Setter Property="FontSize"   Value="{StaticResource TbFontSize}"/>
-		<Setter Property="FontWeight" Value="{StaticResource TbFontWeight}"/>
-		<Setter Property="Foreground" Value="{DynamicResource TbFg}"/>
-                <Setter Property="Background" Value="{DynamicResource TbHover}"/>
+        <Style x:Key="ToolbarToggleButtonStyle" TargetType="{x:Type ToggleButton}">
+                <Setter Property="FontSize"   Value="{StaticResource TbFontSize}"/>
+                <Setter Property="FontWeight" Value="{StaticResource TbFontWeight}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TbFg}"/>
+                <Setter Property="Background" Value="{DynamicResource BtnBg}"/>
                 <Setter Property="BorderBrush" Value="{DynamicResource TbBorder}"/>
                 <Setter Property="Padding" Value="{StaticResource TbPad}"/>
                 <Setter Property="Template">
@@ -110,28 +110,28 @@
 					</ContentControl>
 					<ControlTemplate.Triggers>
                                                 <Trigger Property="IsMouseOver" Value="True">
-                                                        <Setter Property="Background" Value="{DynamicResource TbPressed}"/>
+                                                        <Setter Property="Background" Value="{DynamicResource BtnHover}"/>
                                                 </Trigger>
                                                 <Trigger Property="IsChecked" Value="True">
                                                         <Setter Property="Background" Value="{DynamicResource TbChecked}"/>
                                                         <Setter Property="Foreground" Value="{DynamicResource TbCheckedFg}"/>
                                                 </Trigger>
-						<Trigger Property="IsEnabled" Value="False">
-							<Setter Property="Foreground" Value="{DynamicResource TbDisabledFg}"/>
-							<Setter Property="Background" Value="{DynamicResource TbDisabledBg}"/>
-						</Trigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                                                <Trigger Property="IsEnabled" Value="False">
+                                                        <Setter Property="Foreground" Value="{DynamicResource TbDisabledFg}"/>
+                                                        <Setter Property="Background" Value="{DynamicResource TbDisabledBg}"/>
+                                                </Trigger>
+                                        </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                        </Setter.Value>
+                </Setter>
+        </Style>
 
 	<!-- RADIO (pill) -->
-	<Style x:Key="ToolbarRadioStyle" TargetType="{x:Type RadioButton}">
-		<Setter Property="FontSize"   Value="{StaticResource TbFontSize}"/>
-		<Setter Property="FontWeight" Value="{StaticResource TbFontWeight}"/>
-		<Setter Property="Foreground" Value="{DynamicResource TbFg}"/>
-                <Setter Property="Background" Value="{DynamicResource TbHover}"/>
+        <Style x:Key="ToolbarRadioStyle" TargetType="{x:Type RadioButton}">
+                <Setter Property="FontSize"   Value="{StaticResource TbFontSize}"/>
+                <Setter Property="FontWeight" Value="{StaticResource TbFontWeight}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TbFg}"/>
+                <Setter Property="Background" Value="{DynamicResource BtnBg}"/>
                 <Setter Property="BorderBrush" Value="{DynamicResource TbBorder}"/>
                 <Setter Property="Padding" Value="{StaticResource TbPad}"/>
                 <Setter Property="Template">
@@ -147,20 +147,20 @@
 					</ContentControl>
 					<ControlTemplate.Triggers>
                                                 <Trigger Property="IsMouseOver" Value="True">
-                                                        <Setter Property="Background" Value="{DynamicResource TbPressed}"/>
+                                                        <Setter Property="Background" Value="{DynamicResource BtnHover}"/>
                                                 </Trigger>
                                                 <Trigger Property="IsChecked" Value="True">
                                                         <Setter Property="Background" Value="{DynamicResource TbChecked}"/>
                                                         <Setter Property="Foreground" Value="{DynamicResource TbCheckedFg}"/>
                                                 </Trigger>
-						<Trigger Property="IsEnabled" Value="False">
-							<Setter Property="Foreground" Value="{DynamicResource TbDisabledFg}"/>
-							<Setter Property="Background" Value="{DynamicResource TbDisabledBg}"/>
-						</Trigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                                                <Trigger Property="IsEnabled" Value="False">
+                                                        <Setter Property="Foreground" Value="{DynamicResource TbDisabledFg}"/>
+                                                        <Setter Property="Background" Value="{DynamicResource TbDisabledBg}"/>
+                                                </Trigger>
+                                        </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                        </Setter.Value>
+                </Setter>
+        </Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
## Summary
- Add dedicated button color brushes and apply them when customizing UI
- Use theme color for general surfaces so non-button areas are unaffected

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aba9085a908333ab42dc9228a9e034