### PR TITLE
Tighten button styling for consistent padding and rounding

### DIFF
--- a/Themes/Styles.Base.xaml
+++ b/Themes/Styles.Base.xaml
@@ -7,7 +7,7 @@
         <Setter Property="Foreground"      Value="{DynamicResource OnSurface}"/>
         <Setter Property="BorderBrush"     Value="{DynamicResource Divider}"/>
         <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="Padding"         Value="6,2"/>
+        <Setter Property="Padding"         Value="10,8"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -15,7 +15,7 @@
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="3">
+                            CornerRadius="5">
                         <Border.Effect>
                             <DropShadowEffect Color="#99000000" BlurRadius="4" ShadowDepth="2"/>
                         </Border.Effect>

--- a/Themes/Styles.Toolbar.xaml
+++ b/Themes/Styles.Toolbar.xaml
@@ -4,9 +4,9 @@
 
 	<!-- Softer, more readable toolbar controls -->
 	<!-- Tuning knobs -->
-	<CornerRadius x:Key="TbRadius">18</CornerRadius>
+        <CornerRadius x:Key="TbRadius">5</CornerRadius>
 	<!-- daha yuvarlak -->
-	<Thickness    x:Key="TbPad">12,6</Thickness>
+        <Thickness    x:Key="TbPad">10,8</Thickness>
 	<!-- daha geniş iç boşluk -->
 	<sys:Double   x:Key="TbFontSize">13</sys:Double>
 	<FontWeight   x:Key="TbFontWeight">SemiBold</FontWeight>


### PR DESCRIPTION
## Summary
- Increase base button padding for balanced spacing and use 5px corner radius
- Standardize toolbar button/toggle/radio radius to 5px and adjust padding to 10x8

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68abad4009788333abdbbd8e4eb53231