### PR TITLE
Ensure settings actions are always visible

### DIFF
--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -54,54 +54,62 @@
         </Style>
     </Window.Resources>
 
-    <TabControl TabStripPlacement="Left" Margin="10">
-        <TabItem Header="Tema" IsSelected="True">
-            <Grid Margin="10">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
 
-                <Button Grid.Row="0" Grid.Column="0" Content="Tema Rengi..." Click="ThemeColor_Click" Margin="0,0,10,5"/>
-                <Border Grid.Row="0" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding ThemeColor}" Margin="0,0,0,5"/>
+        <TabControl Grid.Row="0" TabStripPlacement="Left">
+            <TabItem Header="Tema" IsSelected="True">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <Grid Margin="10">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
 
-                <Button Grid.Row="1" Grid.Column="0" Content="Yazı Rengi..." Click="TextColor_Click" Margin="0,0,10,5"/>
-                <Border Grid.Row="1" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding TextColor}" Margin="0,0,0,5"/>
+                        <Button Grid.Row="0" Grid.Column="0" Content="Tema Rengi..." Click="ThemeColor_Click" Margin="0,0,10,5"/>
+                        <Border Grid.Row="0" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding ThemeColor}" Margin="0,0,0,5"/>
 
-                <Button Grid.Row="2" Grid.Column="0" Content="Yükseliş %1-%3..." Click="Up1Color_Click" Margin="0,0,10,5"/>
-                <Border Grid.Row="2" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding Up1Color}" Margin="0,0,0,5"/>
+                        <Button Grid.Row="1" Grid.Column="0" Content="Yazı Rengi..." Click="TextColor_Click" Margin="0,0,10,5"/>
+                        <Border Grid.Row="1" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding TextColor}" Margin="0,0,0,5"/>
 
-                <Button Grid.Row="3" Grid.Column="0" Content="Yükseliş ≥%3..." Click="Up3Color_Click" Margin="0,0,10,5"/>
-                <Border Grid.Row="3" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding Up3Color}" Margin="0,0,0,5"/>
+                        <Button Grid.Row="2" Grid.Column="0" Content="Yükseliş %1-%3..." Click="Up1Color_Click" Margin="0,0,10,5"/>
+                        <Border Grid.Row="2" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding Up1Color}" Margin="0,0,0,5"/>
 
-                <Button Grid.Row="4" Grid.Column="0" Content="Düşüş -%1 - -%3..." Click="Down1Color_Click" Margin="0,0,10,5"/>
-                <Border Grid.Row="4" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding Down1Color}" Margin="0,0,0,5"/>
+                        <Button Grid.Row="3" Grid.Column="0" Content="Yükseliş ≥%3..." Click="Up3Color_Click" Margin="0,0,10,5"/>
+                        <Border Grid.Row="3" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding Up3Color}" Margin="0,0,0,5"/>
 
-                <Button Grid.Row="5" Grid.Column="0" Content="Düşüş ≤-%3..." Click="Down3Color_Click" Margin="0,0,10,5"/>
-                <Border Grid.Row="5" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding Down3Color}" Margin="0,0,0,5"/>
+                        <Button Grid.Row="4" Grid.Column="0" Content="Düşüş -%1 - -%3..." Click="Down1Color_Click" Margin="0,0,10,5"/>
+                        <Border Grid.Row="4" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding Down1Color}" Margin="0,0,0,5"/>
 
-                <Button Grid.Row="6" Grid.Column="0" Content="Tablo Çizgileri..." Click="DividerColor_Click" Margin="0,0,10,5"/>
-                <Border Grid.Row="6" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding DividerColor}" Margin="0,0,0,5"/>
+                        <Button Grid.Row="5" Grid.Column="0" Content="Düşüş ≤-%3..." Click="Down3Color_Click" Margin="0,0,10,5"/>
+                        <Border Grid.Row="5" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding Down3Color}" Margin="0,0,0,5"/>
 
-                <Button Grid.Row="7" Grid.Column="0" Content="Ekrandaki Kontrollerin Rengi..." Click="ControlColor_Click" Margin="0,0,10,5"/>
-                <Border Grid.Row="7" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding ControlColor}" Margin="0,0,0,5"/>
+                        <Button Grid.Row="6" Grid.Column="0" Content="Tablo Çizgileri..." Click="DividerColor_Click" Margin="0,0,10,5"/>
+                        <Border Grid.Row="6" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding DividerColor}" Margin="0,0,0,5"/>
 
-                <StackPanel Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
-                    <Button Content="Varsayılan Ayarlara Dön" Click="ResetDefaults_Click" Margin="0,0,10,0"/>
-                    <Button Content="Kaydet" Click="Save_Click" Width="80"/>
-                </StackPanel>
-            </Grid>
-        </TabItem>
-    </TabControl>
+                        <Button Grid.Row="7" Grid.Column="0" Content="Ekrandaki Kontrollerin Rengi..." Click="ControlColor_Click" Margin="0,0,10,5"/>
+                        <Border Grid.Row="7" Grid.Column="1" Height="20" BorderBrush="{DynamicResource Divider}" BorderThickness="1" Background="{Binding ControlColor}" Margin="0,0,0,5"/>
+                    </Grid>
+                </ScrollViewer>
+            </TabItem>
+        </TabControl>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Varsayılan Ayarlara Dön" Click="ResetDefaults_Click" Margin="0,0,10,0"/>
+            <Button Content="Kaydet" Click="Save_Click" Width="80"/>
+        </StackPanel>
+    </Grid>
 </Window>

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -92,7 +92,11 @@ namespace BinanceUsdtTicker
 
         private static string? PickColor(string current)
         {
-            var dlg = new WinForms.ColorDialog { FullOpen = true };
+            var dlg = new WinForms.ColorDialog
+            {
+                FullOpen = false,
+                AllowFullOpen = false
+            };
             try
             {
                 if (!string.IsNullOrWhiteSpace(current))


### PR DESCRIPTION
## Summary
- Rebuild settings window layout so save and restore defaults buttons stay visible and content scrolls when needed
- Restrict color dialog to a simplified palette

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68abaef1978c8333924b13875a42cc3d