### PR TITLE
Add optional Windows alarm notifications

### DIFF
--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -81,7 +81,9 @@
                 <TextBlock Margin="10" Text="Ticaret tercihleri burada yer alacaktır."/>
             </TabItem>
             <TabItem Header="Bildirimler">
-                <TextBlock Margin="10" Text="Bildirim ayarları burada yer alacaktır."/>
+                <StackPanel Margin="10">
+                    <CheckBox Content="Windows bildirimi gönder" IsChecked="{Binding WindowsNotification}"/>
+                </StackPanel>
             </TabItem>
             <TabItem Header="Tema" IsSelected="True">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -24,7 +24,8 @@ namespace BinanceUsdtTicker
                 Down1Color = settings.Down1Color,
                 Down3Color = settings.Down3Color,
                 DividerColor = settings.DividerColor,
-                ControlColor = settings.ControlColor
+                ControlColor = settings.ControlColor,
+                WindowsNotification = settings.WindowsNotification
             };
             DataContext = _work;
         }
@@ -88,6 +89,7 @@ namespace BinanceUsdtTicker
             _work.Down3Color = def.Down3Color;
             _work.DividerColor = def.DividerColor;
             _work.ControlColor = def.ControlColor;
+            _work.WindowsNotification = def.WindowsNotification;
         }
 
         private static string? PickColor(string current)
@@ -121,6 +123,7 @@ namespace BinanceUsdtTicker
             _settings.Down3Color = _work.Down3Color;
             _settings.DividerColor = _work.DividerColor;
             _settings.ControlColor = _work.ControlColor;
+            _settings.WindowsNotification = _work.WindowsNotification;
             DialogResult = true;
         }
     }


### PR DESCRIPTION
## Summary
- add `WindowsNotification` setting and UI toggle for alerts
- show optional Windows balloon notifications when alarms trigger

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68abb375d7708333a452efd4220626f8