### PR TITLE
Skip sound when Windows notifications enabled

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -640,7 +640,8 @@ namespace BinanceUsdtTicker
                     if (alert.Evaluate(row, nowUtc, out var msg))
                     {
                         anyTriggered = true;
-                        try { SystemSounds.Exclamation.Play(); } catch { }
+                        if (!_ui.WindowsNotification)
+                            try { SystemSounds.Exclamation.Play(); } catch { }
                         var sb = Q<TextBlock>("SnapshotInfoText");
                         if (sb != null) sb.Text = $"🔔 {msg} • {DateTime.Now:HH:mm:ss}";
                         LogAlert(msg, alert, row, nowUtc);
@@ -665,7 +666,8 @@ namespace BinanceUsdtTicker
                 if (alert.Evaluate(row, nowUtc, out var msg))
                 {
                     anyTriggered = true;
-                    try { SystemSounds.Exclamation.Play(); } catch { }
+                    if (!_ui.WindowsNotification)
+                        try { SystemSounds.Exclamation.Play(); } catch { }
                     var sb = Q<TextBlock>("SnapshotInfoText");
                     if (sb != null) sb.Text = $"🔔 {msg} • {DateTime.Now:HH:mm:ss}";
                     LogAlert(msg, alert, row, nowUtc);


### PR DESCRIPTION
## Summary
- Avoid playing alert sound if Windows notifications are active

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abb4b39a7483338d0b039395e99ca9