### PR TITLE
Refactor UI settings and enums into separate files

### DIFF
--- a/Enums.cs
+++ b/Enums.cs
@@ -1,0 +1,6 @@
+namespace BinanceUsdtTicker
+{
+    public enum FilterMode { All, Positive, Negative }
+    public enum ThemeKind { Light, Dark }
+    public enum QuickFilter { None, Pos3Plus, Neg3Minus }
+}

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -2,11 +2,10 @@ using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using System.IO;
 using System.Linq;
 using System.Media;
+using System.ComponentModel;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
@@ -17,110 +16,10 @@ using System.Windows.Media;
 using System.Windows.Controls.Primitives; // ToggleButton burada
 using System.Windows.Threading; // en üstte varsa gerekmez
 using WinForms = System.Windows.Forms;
+using BinanceUsdtTicker.Models;
 
 namespace BinanceUsdtTicker
 {
-    public enum FilterMode { All, Positive, Negative }
-    public enum ThemeKind { Light, Dark }
-    public enum QuickFilter { None, Pos3Plus, Neg3Minus }
-
-    public class UiSettings : INotifyPropertyChanged
-    {
-        private string _theme = "Light";
-        public string Theme
-        {
-            get => _theme;
-            set { if (_theme != value) { _theme = value; OnPropertyChanged(); } }
-        }
-
-        private string _filterMode = "All";
-        public string FilterMode
-        {
-            get => _filterMode;
-            set { if (_filterMode != value) { _filterMode = value; OnPropertyChanged(); } }
-        }
-
-        private List<ColumnState> _columns = new();
-        public List<ColumnState> Columns
-        {
-            get => _columns;
-            set { if (_columns != value) { _columns = value; OnPropertyChanged(); } }
-        }
-
-        private string _themeColor = string.Empty;
-        public string ThemeColor
-        {
-            get => _themeColor;
-            set { if (_themeColor != value) { _themeColor = value; OnPropertyChanged(); } }
-        }
-
-        private string _textColor = string.Empty;
-        public string TextColor
-        {
-            get => _textColor;
-            set { if (_textColor != value) { _textColor = value; OnPropertyChanged(); } }
-        }
-
-        private string _up1Color = string.Empty;
-        public string Up1Color
-        {
-            get => _up1Color;
-            set { if (_up1Color != value) { _up1Color = value; OnPropertyChanged(); } }
-        }
-
-        private string _up3Color = string.Empty;
-        public string Up3Color
-        {
-            get => _up3Color;
-            set { if (_up3Color != value) { _up3Color = value; OnPropertyChanged(); } }
-        }
-
-        private string _down1Color = string.Empty;
-        public string Down1Color
-        {
-            get => _down1Color;
-            set { if (_down1Color != value) { _down1Color = value; OnPropertyChanged(); } }
-        }
-
-        private string _down3Color = string.Empty;
-        public string Down3Color
-        {
-            get => _down3Color;
-            set { if (_down3Color != value) { _down3Color = value; OnPropertyChanged(); } }
-        }
-
-        private string _dividerColor = string.Empty;
-        public string DividerColor
-        {
-            get => _dividerColor;
-            set { if (_dividerColor != value) { _dividerColor = value; OnPropertyChanged(); } }
-        }
-
-        private string _controlColor = string.Empty;
-        public string ControlColor
-        {
-            get => _controlColor;
-            set { if (_controlColor != value) { _controlColor = value; OnPropertyChanged(); } }
-        }
-
-        private bool _windowsNotification;
-        public bool WindowsNotification
-        {
-            get => _windowsNotification;
-            set { if (_windowsNotification != value) { _windowsNotification = value; OnPropertyChanged(); } }
-        }
-
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string? name = null) =>
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
-    }
-    public class ColumnState
-    {
-        public string Header { get; set; } = "";
-        public int DisplayIndex { get; set; }
-        public double Width { get; set; }
-    }
-
     public partial class MainWindow : Window
     {
         private readonly ObservableCollection<TickerRow> _rows = new();

--- a/Models/ColumnState.cs
+++ b/Models/ColumnState.cs
@@ -1,0 +1,9 @@
+namespace BinanceUsdtTicker.Models
+{
+    public class ColumnState
+    {
+        public string Header { get; set; } = "";
+        public int DisplayIndex { get; set; }
+        public double Width { get; set; }
+    }
+}

--- a/Models/UiSettings.cs
+++ b/Models/UiSettings.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace BinanceUsdtTicker.Models
+{
+    public class UiSettings : INotifyPropertyChanged
+    {
+        private string _theme = "Light";
+        public string Theme
+        {
+            get => _theme;
+            set { if (_theme != value) { _theme = value; OnPropertyChanged(); } }
+        }
+
+        private string _filterMode = "All";
+        public string FilterMode
+        {
+            get => _filterMode;
+            set { if (_filterMode != value) { _filterMode = value; OnPropertyChanged(); } }
+        }
+
+        private List<ColumnState> _columns = new();
+        public List<ColumnState> Columns
+        {
+            get => _columns;
+            set { if (_columns != value) { _columns = value; OnPropertyChanged(); } }
+        }
+
+        private string _themeColor = string.Empty;
+        public string ThemeColor
+        {
+            get => _themeColor;
+            set { if (_themeColor != value) { _themeColor = value; OnPropertyChanged(); } }
+        }
+
+        private string _textColor = string.Empty;
+        public string TextColor
+        {
+            get => _textColor;
+            set { if (_textColor != value) { _textColor = value; OnPropertyChanged(); } }
+        }
+
+        private string _up1Color = string.Empty;
+        public string Up1Color
+        {
+            get => _up1Color;
+            set { if (_up1Color != value) { _up1Color = value; OnPropertyChanged(); } }
+        }
+
+        private string _up3Color = string.Empty;
+        public string Up3Color
+        {
+            get => _up3Color;
+            set { if (_up3Color != value) { _up3Color = value; OnPropertyChanged(); } }
+        }
+
+        private string _down1Color = string.Empty;
+        public string Down1Color
+        {
+            get => _down1Color;
+            set { if (_down1Color != value) { _down1Color = value; OnPropertyChanged(); } }
+        }
+
+        private string _down3Color = string.Empty;
+        public string Down3Color
+        {
+            get => _down3Color;
+            set { if (_down3Color != value) { _down3Color = value; OnPropertyChanged(); } }
+        }
+
+        private string _dividerColor = string.Empty;
+        public string DividerColor
+        {
+            get => _dividerColor;
+            set { if (_dividerColor != value) { _dividerColor = value; OnPropertyChanged(); } }
+        }
+
+        private string _controlColor = string.Empty;
+        public string ControlColor
+        {
+            get => _controlColor;
+            set { if (_controlColor != value) { _controlColor = value; OnPropertyChanged(); } }
+        }
+
+        private bool _windowsNotification;
+        public bool WindowsNotification
+        {
+            get => _windowsNotification;
+            set { if (_windowsNotification != value) { _windowsNotification = value; OnPropertyChanged(); } }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string? name = null) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using System.Windows.Media;
 using WinForms = System.Windows.Forms;
+using BinanceUsdtTicker.Models;
 
 namespace BinanceUsdtTicker
 {


### PR DESCRIPTION
## Summary
- Move `UiSettings` and `ColumnState` classes into dedicated files under the `Models` folder
- Centralize `FilterMode`, `ThemeKind`, and `QuickFilter` enums into a new `Enums.cs` file
- Update windows to reference new model locations
- Add missing `System.ComponentModel` namespace to support `SortDescription` usage

## Testing
- `apt-get update` *(fails: repository not signed / 403)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abb78be4ec8333be5d914368248fcd