### PR TITLE
Handle WebSocket state in UI without service event

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -369,13 +369,17 @@
                                                 <TextBlock Text="≤-%3" Foreground="{DynamicResource Down3Fg}" VerticalAlignment="Center"
                                    Background="#22000000" Padding="0,0,2,0"/>
                                         </StackPanel>
-                                </StackPanel>
-                        </StatusBarItem>
+                </StackPanel>
+            </StatusBarItem>
 
-			<StatusBarItem HorizontalAlignment="Right">
-				<TextBlock x:Name="LastUpdateText"/>
-			</StatusBarItem>
-		</StatusBar>
+            <StatusBarItem HorizontalAlignment="Right" Margin="0,0,12,0">
+                <TextBlock x:Name="WsStateText"/>
+            </StatusBarItem>
+
+            <StatusBarItem HorizontalAlignment="Right">
+                <TextBlock x:Name="LastUpdateText"/>
+            </StatusBarItem>
+        </StatusBar>
 
                 <!-- ANA GÖVDE -->
 		<Grid Grid.Row="1">

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -83,6 +83,9 @@ namespace BinanceUsdtTicker
 
             // servis
             _service.OnTickersUpdated += OnServiceTickersUpdated;
+            _service.PropertyChanged += Service_PropertyChanged;
+            var wsText = Q<TextBlock>("WsStateText");
+            if (wsText != null) wsText.Text = "WS: " + _service.State;
 
             LoadUiSettingsSafe();
             ApplyTheme(_themeFromString(_ui.Theme));
@@ -99,6 +102,7 @@ namespace BinanceUsdtTicker
             Closed += async (_, __) =>
             {
                 _service.OnTickersUpdated -= OnServiceTickersUpdated;
+                _service.PropertyChanged -= Service_PropertyChanged;
                 await _service.StopAsync();
                 SaveFavoritesSafe();
                 SaveUiSettingsFromUi();
@@ -261,6 +265,21 @@ namespace BinanceUsdtTicker
                 // seçili moda göre bir kez hesapla
                 UpdateTopMovers(_topMoversUse24h);
             });
+        }
+
+        private void Service_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(BinanceSpotService.State))
+            {
+                if (Dispatcher.HasShutdownStarted || Dispatcher.HasShutdownFinished) return;
+
+                Dispatcher.Invoke(() =>
+                {
+                    var tb = Q<TextBlock>("WsStateText");
+                    if (tb != null)
+                        tb.Text = "WS: " + _service.State;
+                });
+            }
         }
 
         private void ApplyUpdate(List<TickerRow> latest)

--- a/Services/BinanceSpotService.cs
+++ b/Services/BinanceSpotService.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Net.WebSockets;
@@ -15,12 +16,9 @@ namespace BinanceUsdtTicker
     /// <summary>
     /// miniTicker + bookTicker (mid price) birleşik canlı akış. (DECIMAL tabanlı)
     /// </summary>
-    public class BinanceSpotService
+    public class BinanceSpotService : INotifyPropertyChanged
     {
         public event Action<List<TickerRow>>? OnTickersUpdated;
-
-        // WS durum bildirimi: (durum, deneme sayısı)
-        public event Action<WsState, int>? OnWsStateChanged;
 
         private ClientWebSocket? _ws;
         private CancellationTokenSource? _cts;
@@ -35,7 +33,19 @@ namespace BinanceUsdtTicker
         private long _nextEmitTicks = 0;
 
 
-        public WsState State { get; private set; } = WsState.Closed;
+        private WsState _state = WsState.Closed;
+        public WsState State
+        {
+            get => _state;
+            private set
+            {
+                if (_state != value)
+                {
+                    _state = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(State)));
+                }
+            }
+        }
         public DateTime LastMessageUtc { get; private set; }
         public int MessageGapMs => LastMessageUtc == default ? -1
             : (int)Math.Max(0, (DateTime.UtcNow - LastMessageUtc).TotalMilliseconds);
@@ -69,7 +79,6 @@ namespace BinanceUsdtTicker
             _cts?.Dispose(); _cts = null;
             _monitor = null;
             State = WsState.Closed;
-            OnWsStateChanged?.Invoke(State, 0);
         }
 
         private async Task ConnectLoopAsync(CancellationToken ct)
@@ -83,7 +92,6 @@ namespace BinanceUsdtTicker
                 {
                     State = attempt == 0 ? WsState.Connecting : WsState.Retrying;
                     Logger.Log($"WS state {State} attempt {attempt}");
-                    OnWsStateChanged?.Invoke(State, attempt);
 
                     using var ws = new ClientWebSocket();
                     _ws = ws;
@@ -92,7 +100,6 @@ namespace BinanceUsdtTicker
                     State = WsState.Connected;
                     attempt = 0;
                     Logger.Log("WS connected");
-                    OnWsStateChanged?.Invoke(State, attempt);
 
                     await ReceiveLoop(ws, ct);
                 }
@@ -106,7 +113,6 @@ namespace BinanceUsdtTicker
                 attempt++;
                 State = WsState.Retrying;
                 Logger.Log($"Retrying attempt {attempt}");
-                OnWsStateChanged?.Invoke(State, attempt);
 
                 // exponential backoff (1,2,4,8,16,30 sn)
                 var sec = Math.Min(30, 1 << Math.Min(5, attempt));
@@ -115,7 +121,6 @@ namespace BinanceUsdtTicker
 
             State = WsState.Closed;
             Logger.Log("WS closed");
-            OnWsStateChanged?.Invoke(State, attempt);
         }
 
         private async Task ReceiveLoop(ClientWebSocket ws, CancellationToken ct)
@@ -300,5 +305,7 @@ namespace BinanceUsdtTicker
             _nextEmitTicks = nowTicks + _emitIntervalTicks;
             OnTickersUpdated?.Invoke(_state.Values.ToList());
         }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
     }
 }


### PR DESCRIPTION
## Summary
- Remove unused OnWsStateChanged event from BinanceSpotService and notify state via INotifyPropertyChanged
- Display WebSocket state in MainWindow status bar and update through PropertyChanged

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68abbc9704f8833386e6d1211e9ccf7a