### PR TITLE
Handle WebSocket state in UI without service event

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -369,13 +369,17 @@
                                                 <TextBlock Text="≤-%3" Foreground="{DynamicResource Down3Fg}" VerticalAlignment="Center"
                                    Background="#22000000" Padding="0,0,2,0"/>
                                         </StackPanel>
-                                </StackPanel>
-                        </StatusBarItem>
+                </StackPanel>
+            </StatusBarItem>
 
-			<StatusBarItem HorizontalAlignment="Right">
-				<TextBlock x:Name="LastUpdateText"/>
-			</StatusBarItem>
-		</StatusBar>
+            <StatusBarItem HorizontalAlignment="Right" Margin="0,0,12,0">
+                <TextBlock x:Name="WsStateText"/>
+            </StatusBarItem>
+
+            <StatusBarItem HorizontalAlignment="Right">
+                <TextBlock x:Name="LastUpdateText"/>
+            </StatusBarItem>
+        </StatusBar>
 
                 <!-- ANA GÖVDE -->
 		<Grid Grid.Row="1">

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -83,6 +83,9 @@ namespace BinanceUsdtTicker
 
             // servis
             _service.OnTickersUpdated += OnServiceTickersUpdated;
+            _service.PropertyChanged += Service_PropertyChanged;
+            var wsText = Q<TextBlock>("WsStateText");
+            if (wsText != null) wsText.Text = "WS: " + _service.State;
 
             LoadUiSettingsSafe();
             ApplyTheme(_themeFromString(_ui.Theme));
@@ -99,6 +102,7 @@ namespace BinanceUsdtTicker
             Closed += async (_, __) =>
             {
                 _service.OnTickersUpdated -= OnServiceTickersUpdated;
+                _service.PropertyChanged -= Service_PropertyChanged;
                 await _service.StopAsync();
                 SaveFavoritesSafe();
                 SaveUiSettingsFromUi();
@@ -261,6 +265,21 @@ namespace BinanceUsdtTicker
                 // seçili moda göre bir kez hesapla
                 UpdateTopMovers(_topMoversUse24h);
             });
+        }
+
+        private void Service_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(BinanceSpotService.State))
+            {
+                if (Dispatcher.HasShutdownStarted || Dispatcher.HasShutdownFinished) return;
+
+                Dispatcher.Invoke(() =>
+                {
+                    var tb = Q<TextBlock>("WsStateText");
+                    if (tb != null)
+                        tb.Text = "WS: " + _service.State;
+                });
+            }
         }
 
         private void ApplyUpdate(List<TickerRow> latest)


### PR DESCRIPTION
## Summary
- Remove unused OnWsStateChanged event from BinanceSpotService and notify state via INotifyPropertyChanged
- Display WebSocket state in MainWindow status bar and update through PropertyChanged
- Rename ticker cache field to _tickers to resolve naming conflict with new WsState field

## Testing
- `sudo apt-get update` *(fails: repository 403 Forbidden)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abbc9704f8833386e6d1211e9ccf7a