### PR TITLE
Bundle default UI settings for initial install

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -16,6 +16,9 @@
     <Content Include="Resources/chart.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Resources/ui_defaults.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -43,6 +43,8 @@ namespace BinanceUsdtTicker
         private static readonly string FavoritesFile = Path.Combine(AppDir, "favorites.json");
         private static readonly string UiSettingsFile = Path.Combine(AppDir, "ui_settings.json");
         private static readonly string UiDefaultsFile = Path.Combine(AppDir, "ui_defaults.json");
+        private static readonly string UiDefaultsSrcFile =
+            Path.Combine(AppContext.BaseDirectory, "Resources", "ui_defaults.json");
 
         private UiSettings _ui = new();
         private ThemeKind _theme = ThemeKind.Light;
@@ -864,6 +866,11 @@ namespace BinanceUsdtTicker
                     var json = File.ReadAllText(UiDefaultsFile);
                     _ui = JsonSerializer.Deserialize<UiSettings>(json) ?? new UiSettings();
                 }
+                else if (File.Exists(UiDefaultsSrcFile))
+                {
+                    var json = File.ReadAllText(UiDefaultsSrcFile);
+                    _ui = JsonSerializer.Deserialize<UiSettings>(json) ?? new UiSettings();
+                }
                 else
                 {
                     _ui = new UiSettings();
@@ -882,11 +889,8 @@ namespace BinanceUsdtTicker
             try
             {
                 Directory.CreateDirectory(AppDir);
-                if (!File.Exists(UiDefaultsFile))
-                {
-                    var json = JsonSerializer.Serialize(settings, new JsonSerializerOptions { WriteIndented = true });
-                    File.WriteAllText(UiDefaultsFile, json);
-                }
+                var json = JsonSerializer.Serialize(settings, new JsonSerializerOptions { WriteIndented = true });
+                File.WriteAllText(UiDefaultsFile, json);
             }
             catch { }
         }

--- a/Resources/ui_defaults.json
+++ b/Resources/ui_defaults.json
@@ -1,0 +1,14 @@
+{
+  "Theme": "Light",
+  "FilterMode": "All",
+  "Columns": [],
+  "ThemeColor": "#FFF9FAFB",
+  "TextColor": "#FF1F2937",
+  "Up1Color": "#FF90EE90",
+  "Up3Color": "#FF006400",
+  "Down1Color": "#FFF08080",
+  "Down3Color": "#FF8B0000",
+  "DividerColor": "#FFE5E7EB",
+  "ControlColor": "#FFFFFFFF",
+  "WindowsNotification": false
+}


### PR DESCRIPTION
## Summary
- Load UI defaults from a bundled `ui_defaults.json` when no user settings exist
- Always write current UI configuration to the defaults file
- Ship `ui_defaults.json` with the application build

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68abbef0e6a083338c8eeac5c6568959