### PR TITLE
Avoid TwoWay binding to ChangeSinceStartPercent

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -567,14 +567,14 @@
 					</DataGridTextColumn>
 
                                        <!-- Anlık Değişim -->
-                                       <DataGridTemplateColumn x:Name="ColChSnap" Header="Anlık Değişim"
-                                       Width="0.9*" MinWidth="80" SortMemberPath="ChangeSinceStartPercent">
+                                      <DataGridTemplateColumn x:Name="ColChSnap" Header="Anlık Değişim"
+                                      Width="0.9*" MinWidth="80" SortMemberPath="ChangeSinceStartPercent" IsReadOnly="True">
                                                <DataGridTemplateColumn.CellTemplate>
                                                        <DataTemplate>
                                                                <Border x:Name="border">
                                                                        <TextBlock x:Name="tb" TextAlignment="Right">
                                                                                <Run x:Name="ArrowRun"/>
-                                                                               <Run Text="{Binding ChangeSinceStartPercent, StringFormat=N2}"/>
+                                                                               <Run Text="{Binding ChangeSinceStartPercent, StringFormat=N2, Mode=OneWay}"/>
                                                                        </TextBlock>
                                                                </Border>
                                                                <DataTemplate.Triggers>


### PR DESCRIPTION
## Summary
- mark "ChangeSinceStartPercent" grid column as read-only and bind OneWay to the value

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac11da2e0883338a348388c569c25a