### PR TITLE
refactor: modernize datagrid styling

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -400,7 +400,7 @@
 			</Grid.ColumnDefinitions>
 
 			<!-- FİYAT TABLOSU -->
-			<DataGrid x:Name="Grid"
+                        <DataGrid x:Name="Grid"
                       Grid.Row="0" Grid.Column="0"
                       AutoGenerateColumns="False"
                       EnableRowVirtualization="True"
@@ -410,24 +410,14 @@
                       HeadersVisibility="Column"
                       Background="{DynamicResource SurfaceAlt}"
                       Foreground="{DynamicResource OnSurface}"
-                      HorizontalGridLinesBrush="{DynamicResource Divider}"
-                      VerticalGridLinesBrush="{DynamicResource Divider}"
-                      GridLinesVisibility="All"
-                      AlternationCount="2"
+                      GridLinesVisibility="None"
                       ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="0,0,8,0">
 
 				<!-- Satır stili -->
-				<DataGrid.RowStyle>
-					<Style TargetType="DataGridRow">
-                                                <Setter Property="Background" Value="{DynamicResource RowBg}"/>
-                                                <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
+                                <DataGrid.RowStyle>
+                                        <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
                                                 <Style.Triggers>
-                                                        <Trigger Property="IsMouseOver" Value="True">
-                                                                <Setter Property="Background" Value="{DynamicResource RowHoverBg}"/>
-                                                                <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
-                                                        </Trigger>
-
-							<!-- Renklendirme -->
+                                                        <!-- Renklendirme -->
                                                        <DataTrigger Binding="{Binding IsMove3Plus}" Value="True">
                                                                <Setter Property="Background" Value="{DynamicResource Up3Bg}"/>
                                                                <Setter Property="Foreground" Value="{DynamicResource Up3Fg}"/>
@@ -444,21 +434,6 @@
                                                                <Setter Property="Background" Value="{DynamicResource Down1Bg}"/>
                                                                <Setter Property="Foreground" Value="{DynamicResource Down1Fg}"/>
                                                        </DataTrigger>
-
-							<!-- Alternating: renklendirme yoksa -->
-							<MultiDataTrigger>
-								<MultiDataTrigger.Conditions>
-									<Condition Binding="{Binding IsMove3Plus}"  Value="False"/>
-									<Condition Binding="{Binding IsMove1Plus}"  Value="False"/>
-									<Condition Binding="{Binding IsMoveMinus3}" Value="False"/>
-									<Condition Binding="{Binding IsMoveMinus1}" Value="False"/>
-									<Condition Binding="{Binding RelativeSource={RelativeSource Self},
-                                                             Path=(ItemsControl.AlternationIndex)}"
-                                               Value="1"/>
-								</MultiDataTrigger.Conditions>
-								<Setter Property="Background" Value="{DynamicResource RowBgAlt}"/>
-							</MultiDataTrigger>
-
 							<DataTrigger Binding="{Binding IsFavorite}" Value="True">
 								<Setter Property="FontWeight" Value="Bold"/>
 							</DataTrigger>

--- a/Themes/Dark.xaml
+++ b/Themes/Dark.xaml
@@ -169,16 +169,19 @@
         <Setter Property="Foreground"               Value="{DynamicResource OnSurface}"/>
         <Setter Property="RowBackground"            Value="{DynamicResource RowBg}"/>
         <Setter Property="AlternatingRowBackground" Value="{DynamicResource RowAltBg}"/>
-        <Setter Property="GridLinesVisibility"      Value="All"/>
-        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource Divider}"/>
-        <Setter Property="VerticalGridLinesBrush"   Value="{DynamicResource Divider}"/>
-        <Setter Property="BorderBrush"              Value="{DynamicResource Divider}"/>
-        <Setter Property="BorderThickness"         Value="1"/>
+        <Setter Property="GridLinesVisibility"      Value="None"/>
+        <Setter Property="BorderBrush"              Value="Transparent"/>
+        <Setter Property="BorderThickness"         Value="0"/>
+        <Setter Property="AlternationCount"        Value="2"/>
     </Style>
     <Style TargetType="{x:Type DataGridRow}">
-        <Setter Property="Background" Value="{DynamicResource RowBg}"/>
-        <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
+        <Setter Property="Margin"      Value="0,2"/>
+        <Setter Property="Padding"     Value="4"/>
+        <Setter Property="Foreground"  Value="{DynamicResource OnSurface}"/>
         <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource RowHoverBg}"/>
+            </Trigger>
             <Trigger Property="IsSelected" Value="True">
                 <Setter Property="Background" Value="{DynamicResource SelectionBg}"/>
                 <Setter Property="Foreground" Value="{DynamicResource SelectionFg}"/>

--- a/Themes/Light.xaml
+++ b/Themes/Light.xaml
@@ -158,16 +158,19 @@
         <Setter Property="Foreground"               Value="{DynamicResource OnSurface}"/>
         <Setter Property="RowBackground"            Value="{DynamicResource RowBg}"/>
         <Setter Property="AlternatingRowBackground" Value="{DynamicResource RowAltBg}"/>
-        <Setter Property="GridLinesVisibility"      Value="All"/>
-        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource Divider}"/>
-        <Setter Property="VerticalGridLinesBrush"   Value="{DynamicResource Divider}"/>
-        <Setter Property="BorderBrush"              Value="{DynamicResource Divider}"/>
-        <Setter Property="BorderThickness"         Value="1"/>
+        <Setter Property="GridLinesVisibility"      Value="None"/>
+        <Setter Property="BorderBrush"              Value="Transparent"/>
+        <Setter Property="BorderThickness"         Value="0"/>
+        <Setter Property="AlternationCount"        Value="2"/>
     </Style>
     <Style TargetType="{x:Type DataGridRow}">
-        <Setter Property="Background" Value="{DynamicResource RowBg}"/>
-        <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
+        <Setter Property="Margin"      Value="0,2"/>
+        <Setter Property="Padding"     Value="4"/>
+        <Setter Property="Foreground"  Value="{DynamicResource OnSurface}"/>
         <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource RowHoverBg}"/>
+            </Trigger>
             <Trigger Property="IsSelected" Value="True">
                 <Setter Property="Background" Value="{DynamicResource SelectionBg}"/>
                 <Setter Property="Foreground" Value="{DynamicResource SelectionFg}"/>


### PR DESCRIPTION
## Summary
- remove legacy DataGrid gridlines and borders for a sleeker style
- add row spacing and hover highlights in theme resources
- simplify MainWindow row style to leverage shared theme

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac19b873248333a10b5459c429b0d5