### PR TITLE
Improve manage alerts grid editing

### DIFF
--- a/Windows/ManageAlertsWindow.xaml
+++ b/Windows/ManageAlertsWindow.xaml
@@ -36,7 +36,19 @@
                   CanUserResizeColumns="True"
                   ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                   ScrollViewer.VerticalScrollBarVisibility="Auto"
+                  RowHeight="36"
                   PreviewKeyDown="Grid_PreviewKeyDown">
+
+            <DataGrid.Resources>
+                <!-- Single-click edit -->
+                <Style TargetType="DataGridCell">
+                    <EventSetter Event="PreviewMouseLeftButtonDown" Handler="Grid_CellPreviewMouseLeftButtonDown"/>
+                </Style>
+                <!-- Extra spacing between rows -->
+                <Style TargetType="DataGridRow">
+                    <Setter Property="Margin" Value="0,3"/>
+                </Style>
+            </DataGrid.Resources>
 
             <DataGrid.Columns>
                 <!-- Sembol -->

--- a/Windows/ManageAlertsWindow.xaml.cs
+++ b/Windows/ManageAlertsWindow.xaml.cs
@@ -4,7 +4,9 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 
 namespace BinanceUsdtTicker
 {
@@ -81,6 +83,31 @@ namespace BinanceUsdtTicker
                 if (Keyboard.FocusedElement is System.Windows.Controls.TextBox) return;
                 e.Handled = true;
             }
+        }
+
+        private void Grid_CellPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is DataGridCell cell && !cell.IsEditing && !cell.IsReadOnly)
+            {
+                if (!cell.IsFocused)
+                {
+                    cell.Focus();
+                }
+
+                var grid = FindParent<DataGrid>(cell);
+                grid?.BeginEdit(e);
+                e.Handled = true;
+            }
+        }
+
+        private static T? FindParent<T>(DependencyObject child) where T : DependencyObject
+        {
+            DependencyObject? parent = VisualTreeHelper.GetParent(child);
+            while (parent is not null && parent is not T)
+            {
+                parent = VisualTreeHelper.GetParent(parent);
+            }
+            return parent as T;
         }
 
         private void New_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- Allow single-click editing in the manage alerts grid
- Add row spacing and increase row height for easier selection

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1ecbd0908333837fe8d82d5bf73a