### PR TITLE
Enable grid lines for alarm creation window

### DIFF
--- a/Windows/AddAlertWindow.xaml
+++ b/Windows/AddAlertWindow.xaml
@@ -8,7 +8,7 @@
         Background="{DynamicResource Surface}"
         Foreground="{DynamicResource OnSurface}">
 
-    <Grid Margin="16">
+    <Grid Margin="16" ShowGridLines="True">
         <!-- DOĞRU: Koleksiyon şeklinde tanımla -->
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>


### PR DESCRIPTION
## Summary
- show grid lines on the AddAlertWindow grid for clearer layout

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2333b6cc833397354d42efde02cf