### PR TITLE
Use Binance USDT futures market

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -23,7 +23,7 @@ namespace BinanceUsdtTicker
     public partial class MainWindow : Window
     {
         private readonly ObservableCollection<TickerRow> _rows = new();
-        private readonly BinanceSpotService _service = new();
+        private readonly BinanceFuturesService _service = new();
         private readonly Dictionary<string, TickerRow> _rowBySymbol = new(StringComparer.OrdinalIgnoreCase);
 
         private readonly ObservableCollection<PriceAlert> _alerts = new();
@@ -271,7 +271,7 @@ namespace BinanceUsdtTicker
 
         private void Service_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(BinanceSpotService.State))
+            if (e.PropertyName == nameof(BinanceFuturesService.State))
             {
                 if (Dispatcher.HasShutdownStarted || Dispatcher.HasShutdownFinished) return;
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Binance USDT Canlı Fiyat Gösterici (WPF, .NET 8)
 
-Bu uygulama, Binance spot borsasındaki **aktif (TRADING) USDT paritelerinin anlık fiyatlarını** gösterir.  
-- `/api/v3/exchangeInfo` ile aktif USDT pariteleri alır.  
-- WebSocket üzerinden `!miniTicker@arr` akışına bağlanır.  
-- Yalnızca USDT paritelerini filtreleyip listeler.  
-- Arama kutusu ve pozitif değişim filtresi vardır.  
+Bu uygulama, Binance **USDT futures** borsasındaki aktif paritelerin anlık fiyatlarını gösterir.
+- WebSocket üzerinden `wss://fstream.binance.com/stream?streams=!miniTicker@arr/!bookTicker@arr` akışına bağlanır.
+- Yalnızca USDT paritelerini filtreleyip listeler.
+- Arama kutusu ve pozitif değişim filtresi vardır.
 
 ## Kurulum / Çalıştırma
 

--- a/Services/BinanceFuturesService.cs
+++ b/Services/BinanceFuturesService.cs
@@ -15,8 +15,9 @@ namespace BinanceUsdtTicker
 
     /// <summary>
     /// miniTicker + bookTicker (mid price) birleşik canlı akış. (DECIMAL tabanlı)
+    /// Binance USDT futures piyasası için.
     /// </summary>
-    public class BinanceSpotService : INotifyPropertyChanged
+    public class BinanceFuturesService : INotifyPropertyChanged
     {
         public event Action<List<TickerRow>>? OnTickersUpdated;
 
@@ -84,7 +85,7 @@ namespace BinanceUsdtTicker
         private async Task ConnectLoopAsync(CancellationToken ct)
         {
             int attempt = 0;
-            var url = "wss://stream.binance.com:9443/stream?streams=!miniTicker@arr/!bookTicker@arr";
+            var url = "wss://fstream.binance.com/stream?streams=!miniTicker@arr/!bookTicker@arr";
 
             while (!ct.IsCancellationRequested)
             {


### PR DESCRIPTION
## Summary
- switch data service to Binance USDT futures stream
- update main window to use BinanceFuturesService
- clarify README to mention futures market usage

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2c3e2fd48333b8a0325617338fec