### PR TITLE
Use futures tickers for Top Movers

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -709,7 +709,7 @@ namespace BinanceUsdtTicker
             var losersList = Q<ListView>("TopLosersList");
             if (gainersList == null || losersList == null) return;
 
-            var rows = _rows.ToList();
+            var rows = _service.GetTickersSnapshot();
 
             IEnumerable<TickerRow> positives = rows.Where(r =>
             {

--- a/Services/BinanceFuturesService.cs
+++ b/Services/BinanceFuturesService.cs
@@ -298,6 +298,14 @@ namespace BinanceUsdtTicker
             }
         }
 
+        public List<TickerRow> GetTickersSnapshot()
+        {
+            lock (_tickers)
+            {
+                return _tickers.Values.ToList();
+            }
+        }
+
         private void MaybeEmit()
         {
             var nowTicks = DateTime.UtcNow.Ticks;


### PR DESCRIPTION
## Summary
- expose current futures tickers via `GetTickersSnapshot`
- base Top Movers gainers/losers lists on futures snapshot rather than filtered UI rows

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2eb43f1c8333858114d3e531a5a5