### PR TITLE
Add Binance API settings and REST client

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -24,6 +24,7 @@ namespace BinanceUsdtTicker
     {
         private readonly ObservableCollection<TickerRow> _rows = new();
         private readonly BinanceFuturesService _service = new();
+        private readonly BinanceApiService _api = new();
         private readonly Dictionary<string, TickerRow> _rowBySymbol = new(StringComparer.OrdinalIgnoreCase);
 
         private readonly ObservableCollection<PriceAlert> _alerts = new();
@@ -90,6 +91,7 @@ namespace BinanceUsdtTicker
             if (wsText != null) wsText.Text = "WS: " + _service.State;
 
             LoadUiSettingsSafe();
+            _api.SetApiCredentials(_ui.BinanceApiKey, _ui.BinanceApiSecret);
             ApplyTheme(_themeFromString(_ui.Theme));
             ApplyCustomColors();
             ApplyFilterFromString(_ui.FilterMode);
@@ -216,6 +218,7 @@ namespace BinanceUsdtTicker
             if (win.ShowDialog() == true)
             {
                 ApplyCustomColors();
+                _api.SetApiCredentials(_ui.BinanceApiKey, _ui.BinanceApiSecret);
                 SaveUiSettingsFromUi();
             }
         }

--- a/Models/UiSettings.cs
+++ b/Models/UiSettings.cs
@@ -90,6 +90,20 @@ namespace BinanceUsdtTicker.Models
             set { if (_windowsNotification != value) { _windowsNotification = value; OnPropertyChanged(); } }
         }
 
+        private string _binanceApiKey = string.Empty;
+        public string BinanceApiKey
+        {
+            get => _binanceApiKey;
+            set { if (_binanceApiKey != value) { _binanceApiKey = value; OnPropertyChanged(); } }
+        }
+
+        private string _binanceApiSecret = string.Empty;
+        public string BinanceApiSecret
+        {
+            get => _binanceApiSecret;
+            set { if (_binanceApiSecret != value) { _binanceApiSecret = value; OnPropertyChanged(); } }
+        }
+
         public event PropertyChangedEventHandler? PropertyChanged;
         private void OnPropertyChanged([CallerMemberName] string? name = null) =>
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));

--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BinanceUsdtTicker
+{
+    /// <summary>
+    /// Basit Binance Futures REST API istemcisi. API anahtarı ve gizli anahtarla imzalı istek gönderir.
+    /// </summary>
+    public class BinanceApiService
+    {
+        private readonly HttpClient _http;
+        private string _apiKey = string.Empty;
+        private string _secretKey = string.Empty;
+
+        public BinanceApiService()
+        {
+            _http = new HttpClient { BaseAddress = new Uri("https://fapi.binance.com") };
+        }
+
+        public void SetApiCredentials(string apiKey, string secretKey)
+        {
+            _apiKey = apiKey ?? string.Empty;
+            _secretKey = secretKey ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Örnek amaçlı hesap bilgilerini döner.
+        /// </summary>
+        public async Task<string> GetAccountInfoAsync()
+        {
+            var query = new Dictionary<string, string>
+            {
+                ["timestamp"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString()
+            };
+            return await SendSignedAsync(HttpMethod.Get, "/fapi/v2/account", query);
+        }
+
+        public async Task<string> SendSignedAsync(HttpMethod method, string endpoint, IDictionary<string, string>? parameters = null)
+        {
+            if (string.IsNullOrEmpty(_apiKey) || string.IsNullOrEmpty(_secretKey))
+                throw new InvalidOperationException("API bilgileri ayarlanmadı.");
+
+            parameters ??= new Dictionary<string, string>();
+            if (!parameters.ContainsKey("timestamp"))
+                parameters["timestamp"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
+
+            var queryString = string.Join("&", parameters.Select(kv => $"{kv.Key}={kv.Value}"));
+            var signature = Sign(queryString);
+            var url = endpoint + "?" + queryString + "&signature=" + signature;
+
+            var request = new HttpRequestMessage(method, url);
+            request.Headers.Add("X-MBX-APIKEY", _apiKey);
+            var response = await _http.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync();
+        }
+
+        private string Sign(string queryString)
+        {
+            using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(_secretKey));
+            var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(queryString));
+            return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
+        }
+    }
+}

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -105,6 +105,18 @@
             <TabItem Header="Ticaret Tercihi">
                 <TextBlock Margin="10" Text="Ticaret tercihleri burada yer alacaktır."/>
             </TabItem>
+            <TabItem Header="Binance API Bilgileri">
+                <StackPanel Margin="10">
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                        <TextBlock Text="API Key:" Width="120" VerticalAlignment="Center"/>
+                        <TextBox Text="{Binding BinanceApiKey}" Width="300"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="Secret Key:" Width="120" VerticalAlignment="Center"/>
+                        <TextBox Text="{Binding BinanceApiSecret}" Width="300"/>
+                    </StackPanel>
+                </StackPanel>
+            </TabItem>
             <TabItem Header="Bildirimler">
                 <StackPanel Margin="10">
                     <CheckBox Content="Windows bildirimi gönder" IsChecked="{Binding WindowsNotification}" Style="{StaticResource ToggleSwitchStyle}"/>

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -26,7 +26,9 @@ namespace BinanceUsdtTicker
                 Down3Color = settings.Down3Color,
                 DividerColor = settings.DividerColor,
                 ControlColor = settings.ControlColor,
-                WindowsNotification = settings.WindowsNotification
+                WindowsNotification = settings.WindowsNotification,
+                BinanceApiKey = settings.BinanceApiKey,
+                BinanceApiSecret = settings.BinanceApiSecret
             };
             DataContext = _work;
         }
@@ -125,6 +127,8 @@ namespace BinanceUsdtTicker
             _settings.DividerColor = _work.DividerColor;
             _settings.ControlColor = _work.ControlColor;
             _settings.WindowsNotification = _work.WindowsNotification;
+            _settings.BinanceApiKey = _work.BinanceApiKey;
+            _settings.BinanceApiSecret = _work.BinanceApiSecret;
             DialogResult = true;
         }
     }


### PR DESCRIPTION
## Summary
- add Binance API key and secret fields to settings storage and window
- create BinanceApiService for signed REST requests
- initialize REST client with stored credentials

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4d9d2cb08333a0692c47ad71dcf4