### PR TITLE
Format wallet balances with two decimals

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -830,13 +830,13 @@
                                                 <ListView.View>
                                                         <GridView>
                                                                 <GridViewColumn Header="Varlık" Width="80" DisplayMemberBinding="{Binding Asset}"/>
-                                                                <GridViewColumn Header="Bakiye" Width="100" DisplayMemberBinding="{Binding Balance, StringFormat={}{0:#,0.####}}"/>
-                                                                <GridViewColumn Header="Kullanılabilir" Width="120" DisplayMemberBinding="{Binding Available, StringFormat={}{0:#,0.####}}"/>
+                                                                <GridViewColumn Header="Bakiye" Width="100" DisplayMemberBinding="{Binding Balance, StringFormat={}{0:#,0.00}}"/>
+                                                                <GridViewColumn Header="Kullanılabilir" Width="120" DisplayMemberBinding="{Binding Available, StringFormat={}{0:#,0.00}}"/>
                                                         </GridView>
                                                 </ListView.View>
                                         </ListView>
                                 </Expander>
                         </Grid>
-		</Grid>
-	</DockPanel>
+                </Grid>
+        </DockPanel>
 </Window>


### PR DESCRIPTION
## Summary
- Format wallet balance and available amounts to always show two decimal places and thousand separators

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9e7df0488333bb10dcbda1518899