### PR TITLE
Enable full color palette selection

### DIFF
--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -99,8 +99,9 @@ namespace BinanceUsdtTicker
         {
             var dlg = new WinForms.ColorDialog
             {
-                FullOpen = false,
-                AllowFullOpen = false
+                FullOpen = true,
+                AllowFullOpen = true,
+                AnyColor = true
             };
             try
             {


### PR DESCRIPTION
## Summary
- Allow users to choose any theme color by enabling full palette access in the settings color picker

## Testing
- ❌ `dotnet build` *(command not found)*
- ⚠️ `apt-get update` *(403 Forbidden retrieving packages; could not install .NET SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9eb793e48333a43bb62b6b84273e