### PR TITLE
Align wallet amounts to the right

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -830,8 +830,20 @@
                                                 <ListView.View>
                                                         <GridView>
                                                                 <GridViewColumn Header="Varlık" Width="80" DisplayMemberBinding="{Binding Asset}"/>
-                                                                <GridViewColumn Header="Bakiye" Width="100" DisplayMemberBinding="{Binding Balance, StringFormat={}{0:#,0.00}}"/>
-                                                                <GridViewColumn Header="Kullanılabilir" Width="120" DisplayMemberBinding="{Binding Available, StringFormat={}{0:#,0.00}}"/>
+                                                                <GridViewColumn Header="Bakiye" Width="100">
+                                                                        <GridViewColumn.CellTemplate>
+                                                                                <DataTemplate>
+                                                                                        <TextBlock Text="{Binding Balance, StringFormat={}{0:#,0.00}}" HorizontalAlignment="Right" TextAlignment="Right"/>
+                                                                                </DataTemplate>
+                                                                        </GridViewColumn.CellTemplate>
+                                                                </GridViewColumn>
+                                                                <GridViewColumn Header="Kullanılabilir" Width="120">
+                                                                        <GridViewColumn.CellTemplate>
+                                                                                <DataTemplate>
+                                                                                        <TextBlock Text="{Binding Available, StringFormat={}{0:#,0.00}}" HorizontalAlignment="Right" TextAlignment="Right"/>
+                                                                                </DataTemplate>
+                                                                        </GridViewColumn.CellTemplate>
+                                                                </GridViewColumn>
                                                         </GridView>
                                                 </ListView.View>
                                         </ListView>


### PR DESCRIPTION
## Summary
- Right-align Bakiye and Kullanılabilir columns in wallet list for better readability

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aca08705088333b3eb2f64d1bd831e