### PR TITLE
Add futures info panel for margin and leverage selection

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -394,10 +394,11 @@
 
 			</Grid.RowDefinitions>
 
-			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="*"/>
-				<ColumnDefinition Width="260"/>
-			</Grid.ColumnDefinitions>
+                        <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="220"/>
+                                <ColumnDefinition Width="260"/>
+                        </Grid.ColumnDefinitions>
 
 			<!-- FİYAT TABLOSU -->
                         <DataGrid x:Name="Grid"
@@ -411,7 +412,8 @@
                       Background="{DynamicResource SurfaceAlt}"
                       Foreground="{DynamicResource OnSurface}"
                       GridLinesVisibility="None"
-                      ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="0,0,8,0">
+                      ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="0,0,8,0"
+                      SelectionChanged="Grid_SelectionChanged">
 
 				<!-- Satır stili -->
                                 <DataGrid.RowStyle>
@@ -642,8 +644,22 @@
 				</DataGrid.Columns>
 			</DataGrid>
 
-			<!-- TOP MOVERS -->
-			<GroupBox Grid.Row="0" Grid.Column="1" Header="Top Movers" Margin="8,0,8,0"
+                        <!-- FUTURES INFO -->
+                        <GroupBox Grid.Row="0" Grid.Column="1" Header="Futures" Margin="0,0,8,0"
+                      Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
+                      VerticalAlignment="Stretch" BorderBrush="{DynamicResource Divider}">
+                                <StackPanel Margin="4">
+                                        <TextBlock x:Name="FuturesSymbolText" FontWeight="Bold" Margin="0,0,0,8"/>
+                                        <ComboBox x:Name="MarginModeCombo" Margin="0,0,0,8">
+                                                <ComboBoxItem Content="Cross"/>
+                                                <ComboBoxItem Content="Isolated"/>
+                                        </ComboBox>
+                                        <ComboBox x:Name="LeverageCombo"/>
+                                </StackPanel>
+                        </GroupBox>
+
+                        <!-- TOP MOVERS -->
+                        <GroupBox Grid.Row="0" Grid.Column="2" Header="Top Movers" Margin="0,0,8,0"
                       Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
                       VerticalAlignment="Stretch" BorderBrush="{DynamicResource Divider}">
 				<Grid>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1034,5 +1034,45 @@ namespace BinanceUsdtTicker
             if (hdr != null) hdr.Text = "Top Movers — %24s";
         }
 
+        // Grid satır seçildiğinde futures bilgilerini yükle
+        private async void Grid_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (Grid?.SelectedItem is TickerRow row)
+            {
+                await LoadFuturesUiAsync(row.Symbol);
+            }
+        }
+
+        private async Task LoadFuturesUiAsync(string symbol)
+        {
+            var symText = Q<TextBlock>("FuturesSymbolText");
+            if (symText != null) symText.Text = symbol;
+
+            try
+            {
+                var posTask = _api.GetPositionInfoAsync(symbol);
+                var levTask = _api.GetLeverageOptionsAsync(symbol);
+                var pos = await posTask;
+                var levs = await levTask;
+
+                var margin = Q<ComboBox>("MarginModeCombo");
+                if (margin != null)
+                {
+                    margin.SelectedIndex = pos.MarginType == "isolated" ? 1 : 0;
+                }
+
+                var levCombo = Q<ComboBox>("LeverageCombo");
+                if (levCombo != null)
+                {
+                    levCombo.ItemsSource = levs;
+                    levCombo.SelectedItem = pos.Leverage;
+                }
+            }
+            catch
+            {
+                // hata varsa yoksay
+            }
+        }
+
     }
 }


### PR DESCRIPTION
## Summary
- introduce `Futures` panel between ticker grid and Top Movers
- load margin type and leverage options from Binance Futures API on row selection
- expose helper methods to query position and leverage bracket info

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aca152af1c83339e3c7ca48a01c5d9