### PR TITLE
Improve futures margin and leverage controls

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -650,11 +650,23 @@
                       VerticalAlignment="Stretch" BorderBrush="{DynamicResource Divider}">
                                 <StackPanel Margin="4">
                                         <TextBlock x:Name="FuturesSymbolText" FontWeight="Bold" Margin="0,0,0,8"/>
-                                        <ComboBox x:Name="MarginModeCombo" Margin="0,0,0,8">
-                                                <ComboBoxItem Content="Cross"/>
-                                                <ComboBoxItem Content="Isolated"/>
-                                        </ComboBox>
-                                        <ComboBox x:Name="LeverageCombo"/>
+                                        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                                <ToggleButton x:Name="CrossMarginButton" Content="Cross" Width="60" Margin="0,0,4,0" Click="MarginMode_Click"/>
+                                                <ToggleButton x:Name="IsolatedMarginButton" Content="Isolated" Width="60" IsChecked="True" Click="MarginMode_Click"/>
+                                        </StackPanel>
+                                        <StackPanel Margin="0,0,0,8">
+                                                <Grid Margin="0,0,0,4">
+                                                        <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                        </Grid.ColumnDefinitions>
+                                                        <Button x:Name="LevMinusButton" Content="-" Width="30" Click="LevMinusButton_Click"/>
+                                                        <TextBlock x:Name="LeverageValueText" Grid.Column="1" TextAlignment="Center" VerticalAlignment="Center" Text="1x"/>
+                                                        <Button x:Name="LevPlusButton" Grid.Column="2" Content="+" Width="30" Click="LevPlusButton_Click"/>
+                                                </Grid>
+                                                <Slider x:Name="LeverageSlider" Minimum="1" Maximum="150" TickPlacement="BottomRight" IsSnapToTickEnabled="True" Value="1" ValueChanged="LeverageSlider_ValueChanged" Ticks="1,30,60,90,120,150"/>
+                                        </StackPanel>
                                 </StackPanel>
                         </GroupBox>
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1055,22 +1055,75 @@ namespace BinanceUsdtTicker
                 var pos = await posTask;
                 var levs = await levTask;
 
-                var margin = Q<ComboBox>("MarginModeCombo");
-                if (margin != null)
+                var crossBtn = Q<ToggleButton>("CrossMarginButton");
+                var isoBtn = Q<ToggleButton>("IsolatedMarginButton");
+                if (crossBtn != null && isoBtn != null)
                 {
-                    margin.SelectedIndex = pos.MarginType == "isolated" ? 1 : 0;
+                    var isIso = pos.MarginType == "isolated";
+                    isoBtn.IsChecked = isIso;
+                    crossBtn.IsChecked = !isIso;
                 }
 
-                var levCombo = Q<ComboBox>("LeverageCombo");
-                if (levCombo != null)
+                var levSlider = Q<Slider>("LeverageSlider");
+                var levText = Q<TextBlock>("LeverageValueText");
+                if (levSlider != null)
                 {
-                    levCombo.ItemsSource = levs;
-                    levCombo.SelectedItem = pos.Leverage;
+                    var max = levs.Count > 0 ? levs[^1] : 1;
+                    levSlider.Maximum = max;
+                    levSlider.Value = pos.Leverage;
+                    levSlider.Ticks = new DoubleCollection(new double[] { 1, 30, 60, 90, 120, 150 }.Where(v => v <= max));
+                }
+                if (levText != null)
+                {
+                    levText.Text = pos.Leverage + "x";
                 }
             }
             catch
             {
                 // hata varsa yoksay
+            }
+        }
+
+        private void MarginMode_Click(object sender, RoutedEventArgs e)
+        {
+            var crossBtn = Q<ToggleButton>("CrossMarginButton");
+            var isoBtn = Q<ToggleButton>("IsolatedMarginButton");
+            if (sender == crossBtn)
+            {
+                if (crossBtn != null) crossBtn.IsChecked = true;
+                if (isoBtn != null) isoBtn.IsChecked = false;
+            }
+            else if (sender == isoBtn)
+            {
+                if (isoBtn != null) isoBtn.IsChecked = true;
+                if (crossBtn != null) crossBtn.IsChecked = false;
+            }
+        }
+
+        private void LeverageSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            var text = Q<TextBlock>("LeverageValueText");
+            if (text != null)
+            {
+                text.Text = ((int)e.NewValue).ToString() + "x";
+            }
+        }
+
+        private void LevMinusButton_Click(object sender, RoutedEventArgs e)
+        {
+            var slider = Q<Slider>("LeverageSlider");
+            if (slider != null && slider.Value > slider.Minimum)
+            {
+                slider.Value -= 1;
+            }
+        }
+
+        private void LevPlusButton_Click(object sender, RoutedEventArgs e)
+        {
+            var slider = Q<Slider>("LeverageSlider");
+            if (slider != null && slider.Value < slider.Maximum)
+            {
+                slider.Value += 1;
             }
         }
 


### PR DESCRIPTION
## Summary
- Use toggle buttons for Cross/Isolated margin selection with Isolated default
- Add slider-based leverage selector with plus/minus buttons

## Testing
- ⚠️ `dotnet build` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68aca356ac7c8333a0eedb30c5c878c1