### PR TITLE
Fix style inheritance for ToggleButton

### DIFF
--- a/Themes/Styles.Base.xaml
+++ b/Themes/Styles.Base.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <!-- Base button style used across the app -->
-    <Style x:Key="BaseButtonStyle" TargetType="{x:Type Button}">
+    <Style x:Key="BaseButtonStyle" TargetType="{x:Type ButtonBase}">
         <Setter Property="Background"      Value="{DynamicResource BtnBg}"/>
         <Setter Property="Foreground"      Value="{DynamicResource OnSurface}"/>
         <Setter Property="BorderBrush"     Value="{DynamicResource Divider}"/>
@@ -10,7 +10,7 @@
         <Setter Property="Padding"         Value="10,8"/>
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="Button">
+                <ControlTemplate TargetType="ButtonBase">
                     <Border x:Name="Bd"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"


### PR DESCRIPTION
## Summary
- Change base button style to target ButtonBase so ToggleButton can inherit without parse errors.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aca4a38b688333b30001a1b4174ca7