### PR TITLE
Fix leverage tick labels grid access

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1078,7 +1078,8 @@ namespace BinanceUsdtTicker
                     {
                         tickLabels.ItemsSource = levSlider.Ticks;
                         tickLabels.ApplyTemplate();
-                        if (tickLabels.ItemsPanelRoot is Grid grid)
+                        var grid = FindDescendant<Grid>(tickLabels);
+                        if (grid != null)
                         {
                             grid.ColumnDefinitions.Clear();
                             foreach (var _ in levSlider.Ticks)


### PR DESCRIPTION
## Summary
- Replace ItemsPanelRoot usage with visual tree search to configure tick labels grid

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca7d50db08333b4a47bee3639fcab