### PR TITLE
Move futures panel to left and style margin toggles

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -395,14 +395,14 @@
 			</Grid.RowDefinitions>
 
                         <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="220"/>
+                                <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="260"/>
                         </Grid.ColumnDefinitions>
 
-			<!-- FİYAT TABLOSU -->
+                        <!-- FİYAT TABLOSU -->
                         <DataGrid x:Name="Grid"
-                      Grid.Row="0" Grid.Column="0"
+                      Grid.Row="0" Grid.Column="1"
                       AutoGenerateColumns="False"
                       EnableRowVirtualization="True"
                       IsReadOnly="True"
@@ -645,7 +645,7 @@
 			</DataGrid>
 
                         <!-- FUTURES INFO -->
-                        <GroupBox Grid.Row="0" Grid.Column="1" Header="Futures" Margin="0,0,8,0"
+                        <GroupBox Grid.Row="0" Grid.Column="0" Header="Futures" Margin="0,0,8,0"
                       Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
                       VerticalAlignment="Stretch" BorderBrush="{DynamicResource Divider}">
                                 <StackPanel Margin="4">
@@ -655,8 +655,8 @@
                                                         <ColumnDefinition Width="*"/>
                                                         <ColumnDefinition Width="*"/>
                                                 </Grid.ColumnDefinitions>
-                                                <ToggleButton x:Name="CrossMarginButton" Content="Cross" Grid.Column="0" Margin="0,0,4,0" Click="MarginMode_Click"/>
-                                                <ToggleButton x:Name="IsolatedMarginButton" Content="Isolated" Grid.Column="1" Margin="4,0,0,0" IsChecked="True" Click="MarginMode_Click"/>
+                                                <ToggleButton x:Name="CrossMarginButton" Content="Cross" Grid.Column="0" Margin="0,0,4,0" Click="MarginMode_Click" Style="{StaticResource ToolbarToggleButtonStyle}"/>
+                                                <ToggleButton x:Name="IsolatedMarginButton" Content="Isolated" Grid.Column="1" Margin="4,0,0,0" IsChecked="True" Click="MarginMode_Click" Style="{StaticResource ToolbarToggleButtonStyle}"/>
                                         </Grid>
                                         <StackPanel Margin="0,0,0,8">
                                                 <Grid Margin="0,0,0,4">


### PR DESCRIPTION
## Summary
- Reordered main grid columns to place the Futures panel on the left and the coin grid in the center.
- Styled Cross/Isolated margin toggle buttons so their color changes when selected.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aca90a797c8333af22a6d4861fcaf0