### PR TITLE
Add position size calculator panel

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -688,6 +688,13 @@
                                                         </ItemsControl.ItemTemplate>
                                                 </ItemsControl>
                                         </StackPanel>
+                                        <TextBlock Text="Miktar" Margin="0,0,0,4"/>
+                                        <Slider x:Name="SizeSlider" Minimum="0" Maximum="100" ValueChanged="SizeSlider_ValueChanged"/>
+                                        <TextBlock x:Name="QuantityValueText" Margin="0,4,0,0"/>
+                                        <TextBlock Text="Fiyat" Margin="0,8,0,0"/>
+                                        <TextBlock x:Name="CurrentPriceText"/>
+                                        <TextBlock Text="Tutar (USDT)" Margin="0,8,0,0"/>
+                                        <TextBlock x:Name="TotalUsdtText"/>
                                 </StackPanel>
                         </GroupBox>
 


### PR DESCRIPTION
## Summary
- add quantity slider, live price and USDT total to futures panel
- compute total using current ticker price

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68acaa58711483338d27eedfc736d23b