### PR TITLE
Expand futures panel and add order monitor

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -395,7 +395,8 @@
 			</Grid.RowDefinitions>
 
                         <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="220"/>
+                                <!-- Futures panel expanded for better usability -->
+                                <ColumnDefinition Width="300"/>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="260"/>
                         </Grid.ColumnDefinitions>
@@ -833,10 +834,47 @@
                                 <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="*"/>
                                 </Grid.ColumnDefinitions>
 
+                                <!-- EMIR VE POZISYONLAR -->
+                                <Expander Grid.Column="0" Header="Emirler" IsExpanded="True" Padding="6,4">
+                                        <ListView x:Name="OrdersList" Margin="0,6,0,0">
+                                                <ListView.View>
+                                                        <GridView>
+                                                                <GridViewColumn Header="Sembol" Width="90">
+                                                                        <GridViewColumn.CellTemplate>
+                                                                                <DataTemplate>
+                                                                                        <TextBlock>
+                                                                                                <Run Text="{Binding BaseSymbol, Mode=OneWay}"/>
+                                                                                                <Run Text="/USDT" Foreground="Gray"/>
+                                                                                        </TextBlock>
+                                                                                </DataTemplate>
+                                                                        </GridViewColumn.CellTemplate>
+                                                                </GridViewColumn>
+                                                                <GridViewColumn Header="Yön" Width="60" DisplayMemberBinding="{Binding Side}"/>
+                                                                <GridViewColumn Header="Adet" Width="80">
+                                                                        <GridViewColumn.CellTemplate>
+                                                                                <DataTemplate>
+                                                                                        <TextBlock Text="{Binding Quantity, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                </DataTemplate>
+                                                                        </GridViewColumn.CellTemplate>
+                                                                </GridViewColumn>
+                                                                <GridViewColumn Header="Fiyat" Width="80">
+                                                                        <GridViewColumn.CellTemplate>
+                                                                                <DataTemplate>
+                                                                                        <TextBlock Text="{Binding Price, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                </DataTemplate>
+                                                                        </GridViewColumn.CellTemplate>
+                                                                </GridViewColumn>
+                                                                <GridViewColumn Header="Durum" Width="80" DisplayMemberBinding="{Binding Status}"/>
+                                                        </GridView>
+                                                </ListView.View>
+                                        </ListView>
+                                </Expander>
+
                                 <!-- ALARM GEÇMİŞİ -->
-                                <Expander Grid.Column="0" IsExpanded="True" Padding="6,4">
+                                <Expander Grid.Column="1" IsExpanded="True" Padding="6,4">
                                         <Expander.Header>
                                                 <DockPanel LastChildFill="False">
                                                         <TextBlock Foreground="{DynamicResource OnSurface}"
@@ -881,7 +919,7 @@
                                 </Expander>
 
                                 <!-- CÜZDAN BİLGİLERİ -->
-                                <Expander Grid.Column="1" Header="Cüzdan" IsExpanded="True" Padding="6,4">
+                                <Expander Grid.Column="2" Header="Cüzdan" IsExpanded="True" Padding="6,4">
                                         <ListView x:Name="WalletList" Margin="0,6,0,0">
                                                 <ListView.View>
                                                         <GridView>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -30,6 +30,7 @@ namespace BinanceUsdtTicker
         private readonly ObservableCollection<PriceAlert> _alerts = new();
         private readonly ObservableCollection<AlertHit> _alertLog = new();
         private readonly ObservableCollection<WalletAsset> _walletAssets = new();
+        private readonly ObservableCollection<FuturesOrder> _orders = new();
         private const int MaxAlertLog = 500;
 
         private readonly HashSet<string> _favoriteSymbols = new(StringComparer.OrdinalIgnoreCase);
@@ -97,6 +98,19 @@ namespace BinanceUsdtTicker
                 walletList.Height = screenHeight;
                 walletList.MinHeight = screenHeight;
                 walletList.MaxHeight = screenHeight;
+            }
+
+            // emir listesi bağla
+            var ordersList = FindName("OrdersList") as ListView;
+            if (ordersList != null)
+            {
+                ordersList.ItemsSource = _orders;
+
+                var screenHeight = SystemParameters.PrimaryScreenHeight / 8;
+
+                ordersList.Height = screenHeight;
+                ordersList.MinHeight = screenHeight;
+                ordersList.MaxHeight = screenHeight;
             }
 
             // servis

--- a/Models/FuturesOrder.cs
+++ b/Models/FuturesOrder.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace BinanceUsdtTicker.Models
+{
+    /// <summary>
+    /// Temel vadeli işlem emri bilgisi.
+    /// </summary>
+    public class FuturesOrder
+    {
+        public string Symbol { get; set; } = string.Empty;
+        public string Side { get; set; } = string.Empty;
+        public decimal Quantity { get; set; }
+        public decimal Price { get; set; }
+        public string Status { get; set; } = string.Empty;
+
+        public string BaseSymbol =>
+            Symbol.EndsWith("USDT", StringComparison.OrdinalIgnoreCase)
+                ? Symbol[..^4]
+                : Symbol;
+    }
+}


### PR DESCRIPTION
## Summary
- widen futures control panel for more usable space
- add order monitoring panel left of alerts with list view
- introduce `FuturesOrder` model and bind to UI

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68acad205e6083338afbc6cbd9fb0b59