### PR TITLE
feat: add order tabs

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -839,38 +839,51 @@
 
                                 <!-- EMIR VE POZISYONLAR -->
                                 <Expander Grid.Column="0" Header="Emirler" IsExpanded="True" Padding="6,4">
-                                        <ListView x:Name="OrdersList" Margin="0,6,0,0">
-                                                <ListView.View>
-                                                        <GridView>
-                                                                <GridViewColumn Header="Sembol" Width="90">
-                                                                        <GridViewColumn.CellTemplate>
-                                                                                <DataTemplate>
-                                                                                        <TextBlock>
-                                                                                                <Run Text="{Binding BaseSymbol, Mode=OneWay}"/>
-                                                                                                <Run Text="/USDT" Foreground="Gray"/>
-                                                                                        </TextBlock>
-                                                                                </DataTemplate>
-                                                                        </GridViewColumn.CellTemplate>
-                                                                </GridViewColumn>
-                                                                <GridViewColumn Header="Yön" Width="60" DisplayMemberBinding="{Binding Side}"/>
-                                                                <GridViewColumn Header="Adet" Width="80">
-                                                                        <GridViewColumn.CellTemplate>
-                                                                                <DataTemplate>
-                                                                                        <TextBlock Text="{Binding Quantity, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
-                                                                                </DataTemplate>
-                                                                        </GridViewColumn.CellTemplate>
-                                                                </GridViewColumn>
-                                                                <GridViewColumn Header="Fiyat" Width="80">
-                                                                        <GridViewColumn.CellTemplate>
-                                                                                <DataTemplate>
-                                                                                        <TextBlock Text="{Binding Price, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
-                                                                                </DataTemplate>
-                                                                        </GridViewColumn.CellTemplate>
-                                                                </GridViewColumn>
-                                                                <GridViewColumn Header="Durum" Width="80" DisplayMemberBinding="{Binding Status}"/>
-                                                        </GridView>
-                                                </ListView.View>
-                                        </ListView>
+                                        <TabControl Margin="0,6,0,0">
+                                                <TabItem Header="Açık Pozisyonlar">
+                                                        <ListView x:Name="PositionsList"/>
+                                                </TabItem>
+                                                <TabItem Header="Açık Emirler">
+                                                        <ListView x:Name="OrdersList">
+                                                                <ListView.View>
+                                                                        <GridView>
+                                                                                <GridViewColumn Header="Sembol" Width="90">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock>
+                                                                                                                <Run Text="{Binding BaseSymbol, Mode=OneWay}"/>
+                                                                                                                <Run Text="/USDT" Foreground="Gray"/>
+                                                                                                        </TextBlock>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="Yön" Width="60" DisplayMemberBinding="{Binding Side}"/>
+                                                                                <GridViewColumn Header="Adet" Width="80">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding Quantity, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="Fiyat" Width="80">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding Price, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="Durum" Width="80" DisplayMemberBinding="{Binding Status}"/>
+                                                                        </GridView>
+                                                                </ListView.View>
+                                                        </ListView>
+                                                </TabItem>
+                                                <TabItem Header="Emir Geçmişi">
+                                                        <ListView x:Name="OrderHistoryList"/>
+                                                </TabItem>
+                                                <TabItem Header="Trade Geçmişi">
+                                                        <ListView x:Name="TradeHistoryList"/>
+                                                </TabItem>
+                                        </TabControl>
                                 </Expander>
 
                                 <!-- ALARM GEÇMİŞİ -->

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.Win32;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -100,18 +101,26 @@ namespace BinanceUsdtTicker
                 walletList.MaxHeight = screenHeight;
             }
 
-            // emir listesi bağla
-            var ordersList = FindName("OrdersList") as ListView;
-            if (ordersList != null)
+            // emir listeleri bağla
+            var screenHeight = SystemParameters.PrimaryScreenHeight / 8;
+
+            void SetupList(string name, IEnumerable? source = null)
             {
-                ordersList.ItemsSource = _orders;
+                if (FindName(name) is ListView lv)
+                {
+                    if (source != null)
+                        lv.ItemsSource = source;
 
-                var screenHeight = SystemParameters.PrimaryScreenHeight / 8;
-
-                ordersList.Height = screenHeight;
-                ordersList.MinHeight = screenHeight;
-                ordersList.MaxHeight = screenHeight;
+                    lv.Height = screenHeight;
+                    lv.MinHeight = screenHeight;
+                    lv.MaxHeight = screenHeight;
+                }
             }
+
+            SetupList("OrdersList", _orders);
+            SetupList("PositionsList");
+            SetupList("OrderHistoryList");
+            SetupList("TradeHistoryList");
 
             // servis
             _service.OnTickersUpdated += OnServiceTickersUpdated;


### PR DESCRIPTION
## Summary
- organize orders section with tabs for positions, open orders, and histories
- initialize tab lists with shared setup helper

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68acb5863854833396700ba10dcf18b9