### PR TITLE
Fix screenHeight redeclaration in MainWindow

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -75,13 +75,13 @@ namespace BinanceUsdtTicker
             Grid.ItemsSource = _rows;
             CollectionViewSource.GetDefaultView(_rows).Filter = RowFilter;
 
+            var screenHeight = SystemParameters.PrimaryScreenHeight / 8;
+
             // alarm geçmişi bağla
             var alertList = FindName("AlertList") as ListView;
             if (alertList != null)
             {
                 alertList.ItemsSource = _alertLog;
-
-                var screenHeight = SystemParameters.PrimaryScreenHeight / 8;
 
                 alertList.Height = screenHeight;
                 alertList.MinHeight = screenHeight;
@@ -94,16 +94,12 @@ namespace BinanceUsdtTicker
             {
                 walletList.ItemsSource = _walletAssets;
 
-                var screenHeight = SystemParameters.PrimaryScreenHeight / 8;
-
                 walletList.Height = screenHeight;
                 walletList.MinHeight = screenHeight;
                 walletList.MaxHeight = screenHeight;
             }
 
             // emir listeleri bağla
-            var screenHeight = SystemParameters.PrimaryScreenHeight / 8;
-
             void SetupList(string name, IEnumerable? source = null)
             {
                 if (FindName(name) is ListView lv)


### PR DESCRIPTION
## Summary
- Declare screen height once and reuse for list setups to avoid redeclaration errors

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed.)*

------
https://chatgpt.com/codex/tasks/task_e_68acb71311f88333a7bde467d1d78509