### PR TITLE
Display trade history from Binance API

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -881,7 +881,51 @@
                                                         <ListView x:Name="OrderHistoryList"/>
                                                 </TabItem>
                                                 <TabItem Header="Trade Geçmişi">
-                                                        <ListView x:Name="TradeHistoryList"/>
+                                                        <ListView x:Name="TradeHistoryList">
+                                                                <ListView.View>
+                                                                        <GridView>
+                                                                                <GridViewColumn Header="Sembol" Width="90">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock>
+                                                                                                                <Run Text="{Binding BaseSymbol, Mode=OneWay}"/>
+                                                                                                                <Run Text="/USDT" Foreground="Gray"/>
+                                                                                                        </TextBlock>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="Yön" Width="60" DisplayMemberBinding="{Binding Side}"/>
+                                                                                <GridViewColumn Header="Adet" Width="80">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding Quantity, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="Fiyat" Width="80">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding Price, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="PnL" Width="80">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding RealizedPnl, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="Zaman" Width="120">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding Time, StringFormat={}{0:HH:mm:ss}}" TextAlignment="Center"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                        </GridView>
+                                                                </ListView.View>
+                                                        </ListView>
                                                 </TabItem>
                                         </TabControl>
                                 </Expander>

--- a/Models/FuturesTrade.cs
+++ b/Models/FuturesTrade.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace BinanceUsdtTicker.Models
+{
+    /// <summary>
+    /// Temel vadeli işlem trade kaydı.
+    /// </summary>
+    public class FuturesTrade
+    {
+        public string Symbol { get; set; } = string.Empty;
+        public string Side { get; set; } = string.Empty;
+        public decimal Quantity { get; set; }
+        public decimal Price { get; set; }
+        public decimal RealizedPnl { get; set; }
+        public DateTime Time { get; set; }
+
+        public string BaseSymbol =>
+            Symbol.EndsWith("USDT", StringComparison.OrdinalIgnoreCase)
+                ? Symbol[..^4]
+                : Symbol;
+    }
+}


### PR DESCRIPTION
## Summary
- add FuturesTrade model for storing trade history entries
- extend BinanceApiService with user trade retrieval
- load and display recent trades in Trade Geçmişi tab

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68acb9ca61dc83339abc37faef7e9b47