### PR TITLE
Filter trade history to last week

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -326,10 +326,12 @@ namespace BinanceUsdtTicker
                 }
                 catch { }
 
+                var weekAgoUtc = DateTime.UtcNow.AddDays(-7);
+                var weekAgoLocal = DateTime.Now.AddDays(-7);
                 foreach (var sym in symbols)
                 {
-                    var trades = await _api.GetUserTradesAsync(sym);
-                    foreach (var t in trades)
+                    var trades = await _api.GetUserTradesAsync(sym, 1000, weekAgoUtc);
+                    foreach (var t in trades.Where(t => t.Time >= weekAgoLocal))
                         _tradeHistory.Add(t);
                 }
             }

--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -127,15 +127,24 @@ namespace BinanceUsdtTicker
         }
 
         /// <summary>
-        /// Belirtilen sembol için son gerçekleşen işlemleri döner.
+        /// Belirtilen sembol için gerçekleşen işlemleri döner.
         /// </summary>
-        public async Task<IList<FuturesTrade>> GetUserTradesAsync(string symbol, int limit = 50)
+        /// <param name="symbol">İşlem yapılacak sembol.</param>
+        /// <param name="limit">Döndürülecek maksimum kayıt sayısı.</param>
+        /// <param name="startTime">Başlangıç zamanı (UTC). Belirtilirse bu tarihten sonraki işlemler getirilir.</param>
+        public async Task<IList<FuturesTrade>> GetUserTradesAsync(string symbol, int limit = 50, DateTime? startTime = null)
         {
             var query = new Dictionary<string, string>
             {
                 ["symbol"] = symbol,
                 ["limit"] = limit.ToString()
             };
+
+            if (startTime.HasValue)
+            {
+                var ms = new DateTimeOffset(startTime.Value).ToUnixTimeMilliseconds();
+                query["startTime"] = ms.ToString();
+            }
 
             var json = await SendSignedAsync(HttpMethod.Get, "/fapi/v1/userTrades", query);
             var list = new List<FuturesTrade>();


### PR DESCRIPTION
## Summary
- filter trade history to only include the past week's trades
- allow API call to request trades from a specific start time

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acbbcc7a048333a1441bf34459bea5