### PR TITLE
Add order history display using Binance API

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -878,7 +878,45 @@
                                                         </ListView>
                                                 </TabItem>
                                                 <TabItem Header="Emir Geçmişi">
-                                                        <ListView x:Name="OrderHistoryList"/>
+                                                        <ListView x:Name="OrderHistoryList">
+                                                                <ListView.View>
+                                                                        <GridView>
+                                                                                <GridViewColumn Header="Sembol" Width="90">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock>
+                                                                                                                <Run Text="{Binding BaseSymbol, Mode=OneWay}"/>
+                                                                                                                <Run Text="/USDT" Foreground="Gray"/>
+                                                                                                        </TextBlock>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="Yön" Width="60" DisplayMemberBinding="{Binding Side}"/>
+                                                                                <GridViewColumn Header="Adet" Width="80">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding Quantity, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="Fiyat" Width="80">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding Price, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="Durum" Width="80" DisplayMemberBinding="{Binding Status}"/>
+                                                                                <GridViewColumn Header="Zaman" Width="120">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding Time, StringFormat={}{0:HH:mm:ss}}" TextAlignment="Center"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                        </GridView>
+                                                                </ListView.View>
+                                                        </ListView>
                                                 </TabItem>
                                                 <TabItem Header="Trade Geçmişi">
                                                         <ListView x:Name="TradeHistoryList">

--- a/Models/FuturesOrder.cs
+++ b/Models/FuturesOrder.cs
@@ -12,6 +12,7 @@ namespace BinanceUsdtTicker.Models
         public decimal Quantity { get; set; }
         public decimal Price { get; set; }
         public string Status { get; set; } = string.Empty;
+        public DateTime Time { get; set; }
 
         public string BaseSymbol =>
             Symbol.EndsWith("USDT", StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
## Summary
- show order history in its own tab with symbol, side, qty, price, status and time
- fetch order history from Binance `/fapi/v1/allOrders` endpoint
- include `Time` on FuturesOrder model and bind order history list to collection

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acbd4efa9083339f51b2a0f73b40d6