### PR TITLE
Add open order and position APIs

### DIFF
--- a/Models/FuturesPosition.cs
+++ b/Models/FuturesPosition.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace BinanceUsdtTicker.Models
+{
+    /// <summary>
+    /// Temel vadeli işlem pozisyon bilgisi.
+    /// </summary>
+    public class FuturesPosition
+    {
+        public string Symbol { get; set; } = string.Empty;
+        public decimal PositionAmt { get; set; }
+        public decimal EntryPrice { get; set; }
+        public decimal UnrealizedPnl { get; set; }
+        public int Leverage { get; set; }
+        public string MarginType { get; set; } = string.Empty;
+
+        public string BaseSymbol =>
+            Symbol.EndsWith("USDT", StringComparison.OrdinalIgnoreCase)
+                ? Symbol[..^4]
+                : Symbol;
+    }
+}


### PR DESCRIPTION
## Summary
- add futures position model
- extend REST service with open order and position helpers

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68acc29bcaf0833388ec16ef7d79cf2a