### PR TITLE
Display open futures positions

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -841,7 +841,45 @@
                                 <Expander Grid.Column="0" Header="Emirler" IsExpanded="True" Padding="6,4">
                                         <TabControl Margin="0,6,0,0">
                                                 <TabItem Header="Açık Pozisyonlar">
-                                                        <ListView x:Name="PositionsList"/>
+                                                        <ListView x:Name="PositionsList">
+                                                                <ListView.View>
+                                                                        <GridView>
+                                                                                <GridViewColumn Header="Sembol" Width="90">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock>
+                                                                                                                <Run Text="{Binding BaseSymbol, Mode=OneWay}"/>
+                                                                                                                <Run Text="/USDT" Foreground="Gray"/>
+                                                                                                        </TextBlock>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="Adet" Width="80">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding PositionAmt, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="Giriş" Width="80">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding EntryPrice, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="PNL" Width="80">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding UnrealizedPnl, StringFormat={}{0:#,0.##}}" TextAlignment="Right"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="x" Width="40" DisplayMemberBinding="{Binding Leverage}"/>
+                                                                                <GridViewColumn Header="Marjin" Width="70" DisplayMemberBinding="{Binding MarginType}"/>
+                                                                        </GridView>
+                                                                </ListView.View>
+                                                        </ListView>
                                                 </TabItem>
                                                 <TabItem Header="Açık Emirler">
                                                         <ListView x:Name="OrdersList">

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -32,6 +32,7 @@ namespace BinanceUsdtTicker
         private readonly ObservableCollection<PriceAlert> _alerts = new();
         private readonly ObservableCollection<AlertHit> _alertLog = new();
         private readonly ObservableCollection<WalletAsset> _walletAssets = new();
+        private readonly ObservableCollection<FuturesPosition> _positions = new();
         private readonly ObservableCollection<FuturesOrder> _orders = new();
         private readonly ObservableCollection<FuturesOrder> _orderHistory = new();
         private readonly ObservableCollection<FuturesTrade> _tradeHistory = new();
@@ -117,7 +118,7 @@ namespace BinanceUsdtTicker
             }
 
             SetupList("OrdersList", _orders);
-            SetupList("PositionsList");
+            SetupList("PositionsList", _positions);
             SetupList("OrderHistoryList", _orderHistory);
             SetupList("TradeHistoryList", _tradeHistory);
 
@@ -139,6 +140,7 @@ namespace BinanceUsdtTicker
                 EnsureSpecialColumnsOrder(); // ★ -> Sembol
                 await InitializeAsync();
                 await LoadWalletAsync();
+                await LoadOpenPositionsAsync();
                 await LoadOrderHistoryAsync();
                 await LoadTradeHistoryAsync();
             };
@@ -299,6 +301,18 @@ namespace BinanceUsdtTicker
                 _walletAssets.Clear();
                 foreach (var b in balances)
                     _walletAssets.Add(b);
+            }
+            catch { }
+        }
+
+        private async Task LoadOpenPositionsAsync()
+        {
+            try
+            {
+                var positions = await _api.GetOpenPositionsAsync();
+                _positions.Clear();
+                foreach (var p in positions)
+                    _positions.Add(p);
             }
             catch { }
         }


### PR DESCRIPTION
## Summary
- Bind an observable collection of open futures positions in `MainWindow` and load it on startup
- Present open positions in a grid view with symbol, amount, entry price, PnL, leverage, and margin columns

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68acc42c34688333a821cc3a768da3f5