### PR TITLE
Show real-time PnL for open positions

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -871,7 +871,9 @@
                                                                                 <GridViewColumn Header="PNL" Width="80">
                                                                                         <GridViewColumn.CellTemplate>
                                                                                                 <DataTemplate>
-                                                                                                        <TextBlock Text="{Binding UnrealizedPnl, StringFormat={}{0:#,0.##}}" TextAlignment="Right"/>
+                                                                                                        <TextBlock Text="{Binding UnrealizedPnl, StringFormat={}{0:#,0.##}}"
+                                                       TextAlignment="Right"
+                                                       Foreground="{Binding PnlBrush}"/>
                                                                                                 </DataTemplate>
                                                                                         </GridViewColumn.CellTemplate>
                                                                                 </GridViewColumn>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -313,8 +313,21 @@ namespace BinanceUsdtTicker
                 _positions.Clear();
                 foreach (var p in positions)
                     _positions.Add(p);
+
+                UpdatePositionPnls();
             }
             catch { }
+        }
+
+        private void UpdatePositionPnls()
+        {
+            foreach (var pos in _positions)
+            {
+                if (_rowBySymbol.TryGetValue(pos.Symbol, out var row))
+                {
+                    pos.UnrealizedPnl = (row.Price - pos.EntryPrice) * pos.PositionAmt;
+                }
+            }
         }
 
         private async Task LoadOrderHistoryAsync()
@@ -414,6 +427,8 @@ namespace BinanceUsdtTicker
                 if (last != null) last.Text = "Son veri: " + DateTime.Now.ToString("HH:mm:ss");
 
                 CollectionViewSource.GetDefaultView(_rows).Refresh();
+
+                UpdatePositionPnls();
 
                 // seçili moda göre bir kez hesapla
                 UpdateTopMovers(_topMoversUse24h);

--- a/Models/FuturesPosition.cs
+++ b/Models/FuturesPosition.cs
@@ -1,22 +1,44 @@
 using System;
+using System.ComponentModel;
+using System.Windows.Media;
 
 namespace BinanceUsdtTicker.Models
 {
     /// <summary>
     /// Temel vadeli işlem pozisyon bilgisi.
     /// </summary>
-    public class FuturesPosition
+    public class FuturesPosition : INotifyPropertyChanged
     {
         public string Symbol { get; set; } = string.Empty;
         public decimal PositionAmt { get; set; }
         public decimal EntryPrice { get; set; }
-        public decimal UnrealizedPnl { get; set; }
+
+        private decimal _unrealizedPnl;
+        public decimal UnrealizedPnl
+        {
+            get => _unrealizedPnl;
+            set
+            {
+                if (_unrealizedPnl == value) return;
+                _unrealizedPnl = value;
+                OnPropertyChanged(nameof(UnrealizedPnl));
+                OnPropertyChanged(nameof(PnlBrush));
+            }
+        }
+
         public int Leverage { get; set; }
         public string MarginType { get; set; } = string.Empty;
+
+        public Brush PnlBrush =>
+            _unrealizedPnl >= 0m ? Brushes.ForestGreen : Brushes.Red;
 
         public string BaseSymbol =>
             Symbol.EndsWith("USDT", StringComparison.OrdinalIgnoreCase)
                 ? Symbol[..^4]
                 : Symbol;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged(string name) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
     }
 }


### PR DESCRIPTION
## Summary
- refresh each open position's PnL whenever ticker prices update
- color-code PnL values green for profit and red for loss

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 for Ubuntu repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68acc573cb008333bd6bda79280cd59f