### PR TITLE
Load open orders at startup

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -141,6 +141,7 @@ namespace BinanceUsdtTicker
                 await InitializeAsync();
                 await LoadWalletAsync();
                 await LoadOpenPositionsAsync();
+                await LoadOpenOrdersAsync();
                 await LoadOrderHistoryAsync();
                 await LoadTradeHistoryAsync();
             };
@@ -315,6 +316,18 @@ namespace BinanceUsdtTicker
                     _positions.Add(p);
 
                 UpdatePositionPnls();
+            }
+            catch { }
+        }
+
+        private async Task LoadOpenOrdersAsync()
+        {
+            try
+            {
+                var orders = await _api.GetOpenOrdersAsync();
+                _orders.Clear();
+                foreach (var o in orders)
+                    _orders.Add(o);
             }
             catch { }
         }


### PR DESCRIPTION
## Summary
- add `LoadOpenOrdersAsync` to fetch current open orders from Binance and populate the orders list
- invoke open-order loading during window initialization so open orders become visible

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403, repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package dotnet-sdk-8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68acc6de43608333a0bf632dc990400f