### PR TITLE
Periodically refresh open positions and orders

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -63,6 +63,8 @@ namespace BinanceUsdtTicker
         private bool _topMoversUse24h = true;
         private TickerRow? _selectedTicker;
 
+        private readonly DispatcherTimer _refreshTimer = new();
+
         public MainWindow()
         {
             InitializeComponent();
@@ -146,6 +148,10 @@ namespace BinanceUsdtTicker
                 await LoadTradeHistoryAsync();
             };
 
+            _refreshTimer.Interval = TimeSpan.FromSeconds(5);
+            _refreshTimer.Tick += RefreshTimer_Tick;
+            _refreshTimer.Start();
+
             Closed += async (_, __) =>
             {
                 _service.OnTickersUpdated -= OnServiceTickersUpdated;
@@ -154,6 +160,7 @@ namespace BinanceUsdtTicker
                 SaveFavoritesSafe();
                 SaveUiSettingsFromUi();
                 _notifyIcon?.Dispose();
+                _refreshTimer.Stop();
             };
         }
 
@@ -330,6 +337,12 @@ namespace BinanceUsdtTicker
                     _orders.Add(o);
             }
             catch { }
+        }
+
+        private async void RefreshTimer_Tick(object? sender, EventArgs e)
+        {
+            await LoadOpenPositionsAsync();
+            await LoadOpenOrdersAsync();
         }
 
         private void UpdatePositionPnls()

--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -320,7 +320,7 @@ namespace BinanceUsdtTicker
                     decimal.TryParse(el.GetProperty("unRealizedProfit").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var pnl);
                     var sym = el.GetProperty("symbol").GetString() ?? string.Empty;
                     details.TryGetValue(sym, out var det);
-                    if (amt != 0m || pnl != 0m)
+                    if (amt != 0m)
                     {
                         positions.Add(new FuturesPosition
                         {


### PR DESCRIPTION
## Summary
- filter closed positions by requiring non-zero amount in API position queries
- add dispatcher timer to refresh open positions and orders every 5 seconds

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68acc8680f48833394d720062418c914