### PR TITLE
Sort order and trade history by newest first

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -124,6 +124,15 @@ namespace BinanceUsdtTicker
             SetupList("OrderHistoryList", _orderHistory);
             SetupList("TradeHistoryList", _tradeHistory);
 
+            // show most recent orders/trades first
+            var orderView = CollectionViewSource.GetDefaultView(_orderHistory);
+            orderView.SortDescriptions.Clear();
+            orderView.SortDescriptions.Add(new SortDescription(nameof(FuturesOrder.Time), ListSortDirection.Descending));
+
+            var tradeView = CollectionViewSource.GetDefaultView(_tradeHistory);
+            tradeView.SortDescriptions.Clear();
+            tradeView.SortDescriptions.Add(new SortDescription(nameof(FuturesTrade.Time), ListSortDirection.Descending));
+
             // servis
             _service.OnTickersUpdated += OnServiceTickersUpdated;
             _service.PropertyChanged += Service_PropertyChanged;


### PR DESCRIPTION
## Summary
- Sort order history list by `Time` in descending order so latest orders appear first
- Sort trade history list similarly to show newest trades at the top

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68acc94e38088333b33c4dfff9f86935