### PR TITLE
Color BUY and SELL text across tabs

### DIFF
--- a/Converters/SideToBrushConverter.cs
+++ b/Converters/SideToBrushConverter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace BinanceUsdtTicker
+{
+    /// <summary>
+    /// Converts trade side (BUY/SELL) to a foreground brush.
+    /// BUY -> Green, SELL -> Red.
+    /// </summary>
+    public class SideToBrushConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var side = value as string;
+            if (string.Equals(side, "BUY", StringComparison.OrdinalIgnoreCase))
+                return Brushes.Green;
+            if (string.Equals(side, "SELL", StringComparison.OrdinalIgnoreCase))
+                return Brushes.Red;
+            return Brushes.Gray;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -2,15 +2,17 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
+        xmlns:local="clr-namespace:BinanceUsdtTicker"
         Title="Binance USDT Canlı Fiyatlar"
         Height="680" Width="1100" MinHeight="500" MinWidth="900"
         Background="{DynamicResource Surface}"
         Foreground="{DynamicResource OnSurface}">
 
 	<!-- ========== RESOURCES ========== -->
-	<Window.Resources>
-		<!-- Şeffaf yıldız -->
-		<Style x:Key="StarToggleStyle" TargetType="ToggleButton">
+        <Window.Resources>
+                <local:SideToBrushConverter x:Key="SideToBrush"/>
+                <!-- Şeffaf yıldız -->
+                <Style x:Key="StarToggleStyle" TargetType="ToggleButton">
 			<Setter Property="OverridesDefaultStyle" Value="True"/>
 			<Setter Property="Background" Value="Transparent"/>
 			<Setter Property="BorderThickness" Value="0"/>
@@ -897,7 +899,13 @@
                                                                                                 </DataTemplate>
                                                                                         </GridViewColumn.CellTemplate>
                                                                                 </GridViewColumn>
-                                                                                <GridViewColumn Header="Yön" Width="60" DisplayMemberBinding="{Binding Side}"/>
+                                                                                <GridViewColumn Header="Yön" Width="60">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding Side}" Foreground="{Binding Side, Converter={StaticResource SideToBrush}}" TextAlignment="Center"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
                                                                                 <GridViewColumn Header="Adet" Width="80">
                                                                                         <GridViewColumn.CellTemplate>
                                                                                                 <DataTemplate>
@@ -931,7 +939,13 @@
                                                                                                 </DataTemplate>
                                                                                         </GridViewColumn.CellTemplate>
                                                                                 </GridViewColumn>
-                                                                                <GridViewColumn Header="Yön" Width="60" DisplayMemberBinding="{Binding Side}"/>
+                                                                                <GridViewColumn Header="Yön" Width="60">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding Side}" Foreground="{Binding Side, Converter={StaticResource SideToBrush}}" TextAlignment="Center"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
                                                                                 <GridViewColumn Header="Adet" Width="80">
                                                                                         <GridViewColumn.CellTemplate>
                                                                                                 <DataTemplate>
@@ -972,7 +986,13 @@
                                                                                                 </DataTemplate>
                                                                                         </GridViewColumn.CellTemplate>
                                                                                 </GridViewColumn>
-                                                                                <GridViewColumn Header="Yön" Width="60" DisplayMemberBinding="{Binding Side}"/>
+                                                                                <GridViewColumn Header="Yön" Width="60">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding Side}" Foreground="{Binding Side, Converter={StaticResource SideToBrush}}" TextAlignment="Center"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
                                                                                 <GridViewColumn Header="Adet" Width="80">
                                                                                         <GridViewColumn.CellTemplate>
                                                                                                 <DataTemplate>


### PR DESCRIPTION
## Summary
- add `SideToBrushConverter` to color BUY green and SELL red
- apply converter to all Side columns so directions stand out

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68acc9f1e4948333b8f166c6b48ae861