### PR TITLE
Add fee and net profit to trade history

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1007,17 +1007,24 @@
                                                                                                 </DataTemplate>
                                                                                         </GridViewColumn.CellTemplate>
                                                                                 </GridViewColumn>
-                                                                                <GridViewColumn Header="PnL" Width="80">
+                                                                                <GridViewColumn Header="Ücret" Width="80">
                                                                                         <GridViewColumn.CellTemplate>
                                                                                                 <DataTemplate>
-                                                                                                        <TextBlock Text="{Binding RealizedPnl, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                                        <TextBlock Text="{Binding Fee, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
                                                                                                 </DataTemplate>
                                                                                         </GridViewColumn.CellTemplate>
                                                                                 </GridViewColumn>
-                                                                                <GridViewColumn Header="Zaman" Width="120">
+                                                                                <GridViewColumn Header="Net" Width="80">
                                                                                         <GridViewColumn.CellTemplate>
                                                                                                 <DataTemplate>
-                                                                                                        <TextBlock Text="{Binding Time, StringFormat={}{0:HH:mm:ss}}" TextAlignment="Center"/>
+                                                                                                        <TextBlock Text="{Binding NetProfit, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="Zaman" Width="150">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding Time, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}" TextAlignment="Center"/>
                                                                                                 </DataTemplate>
                                                                                         </GridViewColumn.CellTemplate>
                                                                                 </GridViewColumn>

--- a/Models/FuturesTrade.cs
+++ b/Models/FuturesTrade.cs
@@ -11,6 +11,7 @@ namespace BinanceUsdtTicker.Models
         public string Side { get; set; } = string.Empty;
         public decimal Quantity { get; set; }
         public decimal Price { get; set; }
+        public decimal Fee { get; set; }
         public decimal RealizedPnl { get; set; }
         public DateTime Time { get; set; }
 
@@ -18,5 +19,7 @@ namespace BinanceUsdtTicker.Models
             Symbol.EndsWith("USDT", StringComparison.OrdinalIgnoreCase)
                 ? Symbol[..^4]
                 : Symbol;
+
+        public decimal NetProfit => RealizedPnl - Fee;
     }
 }

--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -156,6 +156,7 @@ namespace BinanceUsdtTicker
                     decimal.TryParse(el.GetProperty("qty").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var qty);
                     decimal.TryParse(el.GetProperty("price").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var price);
                     decimal.TryParse(el.GetProperty("realizedPnl").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var pnl);
+                    decimal.TryParse(el.GetProperty("commission").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var fee);
                     long time = el.GetProperty("time").GetInt64();
                     list.Add(new FuturesTrade
                     {
@@ -163,6 +164,7 @@ namespace BinanceUsdtTicker
                         Side = el.GetProperty("side").GetString() ?? string.Empty,
                         Quantity = qty,
                         Price = price,
+                        Fee = fee,
                         RealizedPnl = pnl,
                         Time = DateTimeOffset.FromUnixTimeMilliseconds(time).LocalDateTime
                     });


### PR DESCRIPTION
## Summary
- show fee and net profit in trade history
- include trade date in time column

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68accbf4170c8333aca26db7aba494af