### PR TITLE
Enable fine-grained leverage slider

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -672,7 +672,7 @@
                                                         <TextBlock x:Name="LeverageValueText" Grid.Column="1" TextAlignment="Center" VerticalAlignment="Center" Text="1x"/>
                                                         <Button x:Name="LevPlusButton" Grid.Column="2" Content="+" Width="30" Click="LevPlusButton_Click"/>
                                                 </Grid>
-                                                <Slider x:Name="LeverageSlider" Minimum="1" Maximum="150" TickPlacement="BottomRight" IsSnapToTickEnabled="True" Value="1" ValueChanged="LeverageSlider_ValueChanged" Ticks="1,30,60,90,120,150"/>
+                                               <Slider x:Name="LeverageSlider" Minimum="1" Maximum="150" TickPlacement="BottomRight" IsSnapToTickEnabled="False" Value="1" ValueChanged="LeverageSlider_ValueChanged" Ticks="1,30,60,90,120,150"/>
                                                 <ItemsControl x:Name="LeverageTickLabels" Margin="0,4,0,0" AlternationCount="100">
                                                         <ItemsControl.ItemsPanel>
                                                                 <ItemsPanelTemplate>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1292,10 +1292,19 @@ namespace BinanceUsdtTicker
 
         private void LeverageSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
-            var text = Q<TextBlock>("LeverageValueText");
-            if (text != null)
+            if (sender is Slider slider)
             {
-                text.Text = ((int)e.NewValue).ToString() + "x";
+                var rounded = Math.Round(slider.Value);
+                if (rounded != slider.Value)
+                {
+                    slider.Value = rounded;
+                }
+
+                var text = Q<TextBlock>("LeverageValueText");
+                if (text != null)
+                {
+                    text.Text = ((int)rounded).ToString() + "x";
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Allow leverage slider to move freely between 1 and 150 instead of snapping to preset ticks
- Round slider value to nearest integer when changed and update display

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68ada3b14a108333950fdad5d6faf9a3