### PR TITLE
Default futures panel to isolated margin

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1235,9 +1235,12 @@ namespace BinanceUsdtTicker
                 var isoBtn = Q<ToggleButton>("IsolatedMarginButton");
                 if (crossBtn != null && isoBtn != null)
                 {
-                    var isIso = pos.MarginType == "isolated";
-                    isoBtn.IsChecked = isIso;
-                    crossBtn.IsChecked = !isIso;
+                    // Always default to isolated margin mode when a new
+                    // symbol is selected. This ensures the futures panel
+                    // starts with Isolated margin regardless of the
+                    // account's current margin setting.
+                    isoBtn.IsChecked = true;
+                    crossBtn.IsChecked = false;
                 }
 
                 var levSlider = Q<Slider>("LeverageSlider");


### PR DESCRIPTION
## Summary
- ensure futures panel always defaults to Isolated margin mode when selecting a symbol

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68ada816e78c83338822af1f910ec60b