### PR TITLE
feat: add margin mode preference

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -659,7 +659,7 @@
                                                         <ColumnDefinition Width="*"/>
                                                 </Grid.ColumnDefinitions>
                                                 <ToggleButton x:Name="CrossMarginButton" Content="Cross" Grid.Column="0" Margin="0,0,4,0" Click="MarginMode_Click" Style="{StaticResource ToolbarToggleButtonStyle}"/>
-                                                <ToggleButton x:Name="IsolatedMarginButton" Content="Isolated" Grid.Column="1" Margin="4,0,0,0" IsChecked="True" Click="MarginMode_Click" Style="{StaticResource ToolbarToggleButtonStyle}"/>
+                                                <ToggleButton x:Name="IsolatedMarginButton" Content="Isolated" Grid.Column="1" Margin="4,0,0,0" Click="MarginMode_Click" Style="{StaticResource ToolbarToggleButtonStyle}"/>
                                         </Grid>
                                         <StackPanel Margin="0,0,0,8">
                                                 <Grid Margin="0,0,0,4">

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -144,6 +144,7 @@ namespace BinanceUsdtTicker
             ApplyTheme(_themeFromString(_ui.Theme));
             ApplyCustomColors();
             ApplyFilterFromString(_ui.FilterMode);
+            ApplyMarginModeFromSettings();
 
             Loaded += async (_, __) =>
             {
@@ -209,6 +210,18 @@ namespace BinanceUsdtTicker
             TryApplyBrush("Up3Fg", IdealText(_ui.Up3Color));
             TryApplyBrush("Down1Fg", IdealText(_ui.Down1Color));
             TryApplyBrush("Down3Fg", IdealText(_ui.Down3Color));
+        }
+
+        private void ApplyMarginModeFromSettings()
+        {
+            var crossBtn = Q<ToggleButton>("CrossMarginButton");
+            var isoBtn = Q<ToggleButton>("IsolatedMarginButton");
+            if (crossBtn != null && isoBtn != null)
+            {
+                var isCross = string.Equals(_ui.MarginMode, "Cross", StringComparison.OrdinalIgnoreCase);
+                crossBtn.IsChecked = isCross;
+                isoBtn.IsChecked = !isCross;
+            }
         }
 
         private static void TryApplyBrush(string key, string color)
@@ -1231,17 +1244,8 @@ namespace BinanceUsdtTicker
                 var pos = await posTask;
                 var levs = await levTask;
 
-                var crossBtn = Q<ToggleButton>("CrossMarginButton");
-                var isoBtn = Q<ToggleButton>("IsolatedMarginButton");
-                if (crossBtn != null && isoBtn != null)
-                {
-                    // Always default to isolated margin mode when a new
-                    // symbol is selected. This ensures the futures panel
-                    // starts with Isolated margin regardless of the
-                    // account's current margin setting.
-                    isoBtn.IsChecked = true;
-                    crossBtn.IsChecked = false;
-                }
+                // Use preferred margin mode for new selections
+                ApplyMarginModeFromSettings();
 
                 var levSlider = Q<Slider>("LeverageSlider");
                 var levText = Q<TextBlock>("LeverageValueText");

--- a/Models/UiSettings.cs
+++ b/Models/UiSettings.cs
@@ -83,6 +83,13 @@ namespace BinanceUsdtTicker.Models
             set { if (_controlColor != value) { _controlColor = value; OnPropertyChanged(); } }
         }
 
+        private string _marginMode = "Isolated";
+        public string MarginMode
+        {
+            get => _marginMode;
+            set { if (_marginMode != value) { _marginMode = value; OnPropertyChanged(); } }
+        }
+
         private bool _windowsNotification;
         public bool WindowsNotification
         {

--- a/Resources/ui_defaults.json
+++ b/Resources/ui_defaults.json
@@ -10,5 +10,6 @@
   "Down3Color": "#FF8B0000",
   "DividerColor": "#FFE5E7EB",
   "ControlColor": "#FFFFFFFF",
+  "MarginMode": "Isolated",
   "WindowsNotification": false
 }

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -103,7 +103,17 @@
                 <TextBlock Margin="10" Text="Sistem ayarları burada yer alacaktır."/>
             </TabItem>
             <TabItem Header="Ticaret Tercihi">
-                <TextBlock Margin="10" Text="Ticaret tercihleri burada yer alacaktır."/>
+                <StackPanel Margin="10">
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                        <TextBlock Text="Margin Mod:" Width="120" VerticalAlignment="Center"/>
+                        <ComboBox Width="150"
+                                  SelectedValue="{Binding MarginMode}"
+                                  SelectedValuePath="Content">
+                            <ComboBoxItem Content="Isolated"/>
+                            <ComboBoxItem Content="Cross"/>
+                        </ComboBox>
+                    </StackPanel>
+                </StackPanel>
             </TabItem>
             <TabItem Header="Binance API Bilgileri">
                 <StackPanel Margin="10">

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -26,6 +26,7 @@ namespace BinanceUsdtTicker
                 Down3Color = settings.Down3Color,
                 DividerColor = settings.DividerColor,
                 ControlColor = settings.ControlColor,
+                MarginMode = settings.MarginMode,
                 WindowsNotification = settings.WindowsNotification,
                 BinanceApiKey = settings.BinanceApiKey,
                 BinanceApiSecret = settings.BinanceApiSecret
@@ -127,6 +128,7 @@ namespace BinanceUsdtTicker
             _settings.Down3Color = _work.Down3Color;
             _settings.DividerColor = _work.DividerColor;
             _settings.ControlColor = _work.ControlColor;
+            _settings.MarginMode = _work.MarginMode;
             _settings.WindowsNotification = _work.WindowsNotification;
             _settings.BinanceApiKey = _work.BinanceApiKey;
             _settings.BinanceApiSecret = _work.BinanceApiSecret;


### PR DESCRIPTION
## Summary
- allow choosing default margin mode in Trade Preference settings
- apply preferred margin mode when loading futures panel

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adaaca76b88333ba75a76007ad8f12