### PR TITLE
feat: add limit/market order tabs with size slider

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -691,13 +691,24 @@
                                                         </ItemsControl.ItemTemplate>
                                                 </ItemsControl>
                                         </StackPanel>
-                                        <TextBlock Text="Miktar" Margin="0,0,0,4"/>
-                                        <Slider x:Name="SizeSlider" Minimum="0" Maximum="100" ValueChanged="SizeSlider_ValueChanged"/>
-                                        <TextBlock x:Name="QuantityValueText" Margin="0,4,0,0"/>
-                                        <TextBlock Text="Fiyat" Margin="0,8,0,0"/>
-                                        <TextBlock x:Name="CurrentPriceText"/>
-                                        <TextBlock Text="Tutar (USDT)" Margin="0,8,0,0"/>
-                                        <TextBlock x:Name="TotalUsdtText"/>
+                                        <TabControl x:Name="OrderTypeTab" Margin="0,8,0,0" SelectionChanged="OrderTypeTab_SelectionChanged">
+                                                <TabItem Header="Limit">
+                                                        <StackPanel Margin="4">
+                                                                <TextBlock Text="Price" Margin="0,0,0,4"/>
+                                                                <TextBox x:Name="LimitPriceTextBox" Margin="0,0,0,8"/>
+                                                                <TextBlock Text="Size" Margin="0,0,0,4"/>
+                                                                <Slider x:Name="LimitSizeSlider" Minimum="0" Maximum="100" TickPlacement="BottomRight" Ticks="0,25,50,75,100" IsSnapToTickEnabled="False" ValueChanged="SizeSlider_ValueChanged"/>
+                                                                <TextBlock x:Name="LimitSizeValueText" Margin="0,4,0,0"/>
+                                                        </StackPanel>
+                                                </TabItem>
+                                                <TabItem Header="Market">
+                                                        <StackPanel Margin="4">
+                                                                <TextBlock Text="Size" Margin="0,0,0,4"/>
+                                                                <Slider x:Name="MarketSizeSlider" Minimum="0" Maximum="100" TickPlacement="BottomRight" Ticks="0,25,50,75,100" IsSnapToTickEnabled="False" ValueChanged="SizeSlider_ValueChanged"/>
+                                                                <TextBlock x:Name="MarketSizeValueText" Margin="0,4,0,0"/>
+                                                        </StackPanel>
+                                                </TabItem>
+                                        </TabControl>
                                         <Grid Margin="0,8,0,0">
                                                 <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="*"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1338,6 +1338,12 @@ namespace BinanceUsdtTicker
             UpdatePriceAndSize();
         }
 
+        private void OrderTypeTab_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (e.Source is TabControl)
+                UpdatePriceAndSize();
+        }
+
         private void SelectedTicker_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(TickerRow.Price))
@@ -1348,27 +1354,27 @@ namespace BinanceUsdtTicker
 
         private void UpdatePriceAndSize()
         {
-            var priceText = Q<TextBlock>("CurrentPriceText");
-            var totalText = Q<TextBlock>("TotalUsdtText");
-            var qtyText = Q<TextBlock>("QuantityValueText");
-            var slider = Q<Slider>("SizeSlider");
+            var tab = Q<TabControl>("OrderTypeTab");
+            if (tab == null)
+                return;
 
-            if (_selectedTicker != null && slider != null)
+            Slider? slider = null;
+            TextBlock? qtyText = null;
+
+            if (tab.SelectedIndex == 0)
             {
-                var price = _selectedTicker.Price;
-                var qty = (decimal)slider.Value;
-                if (priceText != null)
-                    priceText.Text = price.ToString("#,0.####");
-                if (qtyText != null)
-                    qtyText.Text = qty.ToString("#,0.####");
-                if (totalText != null)
-                    totalText.Text = (price * qty).ToString("#,0.####");
+                slider = Q<Slider>("LimitSizeSlider");
+                qtyText = Q<TextBlock>("LimitSizeValueText");
             }
             else
             {
-                if (priceText != null) priceText.Text = string.Empty;
-                if (qtyText != null) qtyText.Text = string.Empty;
-                if (totalText != null) totalText.Text = string.Empty;
+                slider = Q<Slider>("MarketSizeSlider");
+                qtyText = Q<TextBlock>("MarketSizeValueText");
+            }
+
+            if (slider != null && qtyText != null)
+            {
+                qtyText.Text = $"{slider.Value:0}%";
             }
         }
 


### PR DESCRIPTION
## Summary
- add Limit/Market tabs under leverage controls
- show price input for Limit orders and percent-based size sliders for both order types
- update code-behind to display slider percentage and react to tab changes

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68adb2570ec883338355c913eadec83c