### PR TITLE
Allow manual baseline price and enlarge price display

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -416,7 +416,8 @@
                       Foreground="{DynamicResource OnSurface}"
                       GridLinesVisibility="None"
                       ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="0,0,8,0"
-                      SelectionChanged="Grid_SelectionChanged">
+                      SelectionChanged="Grid_SelectionChanged"
+                      MouseDoubleClick="Grid_MouseDoubleClick">
 
 				<!-- Satır stili -->
                                 <DataGrid.RowStyle>
@@ -530,13 +531,15 @@
 						</DataGridTextColumn.ElementStyle>
 					</DataGridTextColumn>
 
-					<!-- Fiyat -->
-					<DataGridTextColumn x:Name="ColPrice" Header="Fiyat"
-                                        Width="1*" MinWidth="90"
+                                        <!-- Fiyat -->
+                                        <DataGridTextColumn x:Name="ColPrice" Header="Fiyat"
+                                        Width="1.5*" MinWidth="120"
                                         Binding="{Binding Price, StringFormat={}{0:#,0.########}}">
                                                 <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock">
                                                                 <Setter Property="TextAlignment" Value="Right"/>
+                                                                <Setter Property="FontSize" Value="16"/>
+                                                                <Setter Property="FontWeight" Value="Bold"/>
                                                         </Style>
                                                 </DataGridTextColumn.ElementStyle>
                                         </DataGridTextColumn>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -19,6 +19,7 @@ using System.Windows.Controls.Primitives; // ToggleButton burada
 using System.Windows.Threading; // en üstte varsa gerekmez
 using WinForms = System.Windows.Forms;
 using BinanceUsdtTicker.Models;
+using Microsoft.VisualBasic;
 
 namespace BinanceUsdtTicker
 {
@@ -305,8 +306,6 @@ namespace BinanceUsdtTicker
 
                 await _service.StartAsync();
 
-                TakeSnapshot();
-
                 if (EvaluateAllAlertsNow())
                     SaveAlertsSafe();
 
@@ -516,7 +515,6 @@ namespace BinanceUsdtTicker
                 }
                 else
                 {
-                    kv.Value.BaselinePrice ??= kv.Value.Price;
                     kv.Value.IsFavorite = _favoriteSymbols.Contains(kv.Key);
                     _rowBySymbol[kv.Key] = kv.Value;
                     _rows.Add(kv.Value);
@@ -1229,6 +1227,23 @@ namespace BinanceUsdtTicker
                 _selectedTicker.PropertyChanged += SelectedTicker_PropertyChanged;
                 UpdatePriceAndSize();
                 await LoadFuturesUiAsync(row.Symbol);
+            }
+        }
+
+        // Satıra çift tıklanınca başlangıç fiyatını kullanıcıdan al
+        private void Grid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (Grid?.SelectedItem is TickerRow row)
+            {
+                var input = Interaction.InputBox(
+                    "Başlangıç fiyatını giriniz:",
+                    "Başlangıç Fiyatı",
+                    row.Price.ToString(CultureInfo.InvariantCulture));
+
+                if (decimal.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out var value))
+                {
+                    row.BaselinePrice = value;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- enlarge ticker price column for readability
- prompt user to enter baseline price on row double-click
- stop automatic baseline initialization

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68adb5ac1ec08333806832dd80cdc365