### PR TITLE
Revert manual baseline price and price column enlargement

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -416,8 +416,7 @@
                       Foreground="{DynamicResource OnSurface}"
                       GridLinesVisibility="None"
                       ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="0,0,8,0"
-                      SelectionChanged="Grid_SelectionChanged"
-                      MouseDoubleClick="Grid_MouseDoubleClick">
+                      SelectionChanged="Grid_SelectionChanged">
 
 				<!-- Satır stili -->
                                 <DataGrid.RowStyle>
@@ -531,15 +530,13 @@
 						</DataGridTextColumn.ElementStyle>
 					</DataGridTextColumn>
 
-                                        <!-- Fiyat -->
-                                        <DataGridTextColumn x:Name="ColPrice" Header="Fiyat"
-                                        Width="1.5*" MinWidth="120"
+					<!-- Fiyat -->
+					<DataGridTextColumn x:Name="ColPrice" Header="Fiyat"
+                                        Width="1*" MinWidth="90"
                                         Binding="{Binding Price, StringFormat={}{0:#,0.########}}">
                                                 <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock">
                                                                 <Setter Property="TextAlignment" Value="Right"/>
-                                                                <Setter Property="FontSize" Value="16"/>
-                                                                <Setter Property="FontWeight" Value="Bold"/>
                                                         </Style>
                                                 </DataGridTextColumn.ElementStyle>
                                         </DataGridTextColumn>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -19,7 +19,6 @@ using System.Windows.Controls.Primitives; // ToggleButton burada
 using System.Windows.Threading; // en üstte varsa gerekmez
 using WinForms = System.Windows.Forms;
 using BinanceUsdtTicker.Models;
-using Microsoft.VisualBasic;
 
 namespace BinanceUsdtTicker
 {
@@ -306,6 +305,8 @@ namespace BinanceUsdtTicker
 
                 await _service.StartAsync();
 
+                TakeSnapshot();
+
                 if (EvaluateAllAlertsNow())
                     SaveAlertsSafe();
 
@@ -515,6 +516,7 @@ namespace BinanceUsdtTicker
                 }
                 else
                 {
+                    kv.Value.BaselinePrice ??= kv.Value.Price;
                     kv.Value.IsFavorite = _favoriteSymbols.Contains(kv.Key);
                     _rowBySymbol[kv.Key] = kv.Value;
                     _rows.Add(kv.Value);
@@ -1227,23 +1229,6 @@ namespace BinanceUsdtTicker
                 _selectedTicker.PropertyChanged += SelectedTicker_PropertyChanged;
                 UpdatePriceAndSize();
                 await LoadFuturesUiAsync(row.Symbol);
-            }
-        }
-
-        // Satıra çift tıklanınca başlangıç fiyatını kullanıcıdan al
-        private void Grid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
-        {
-            if (Grid?.SelectedItem is TickerRow row)
-            {
-                var input = Interaction.InputBox(
-                    "Başlangıç fiyatını giriniz:",
-                    "Başlangıç Fiyatı",
-                    row.Price.ToString(CultureInfo.InvariantCulture));
-
-                if (decimal.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out var value))
-                {
-                    row.BaselinePrice = value;
-                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Revert changes that allowed editing baseline price and widened the price column
- Restore automatic baseline snapshot logic

## Testing
- ⚠️ `dotnet build` *(dotnet: command not found; `apt-get update` failed with repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68adb9d225448333abcacab84002dd79