### PR TITLE
Auto-fill futures price from selected row

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1227,6 +1227,7 @@ namespace BinanceUsdtTicker
                     _selectedTicker.PropertyChanged -= SelectedTicker_PropertyChanged;
                 _selectedTicker = row;
                 _selectedTicker.PropertyChanged += SelectedTicker_PropertyChanged;
+                UpdateLimitPrice();
                 UpdatePriceAndSize();
                 await LoadFuturesUiAsync(row.Symbol);
             }
@@ -1348,8 +1349,22 @@ namespace BinanceUsdtTicker
         {
             if (e.PropertyName == nameof(TickerRow.Price))
             {
-                Dispatcher.Invoke(UpdatePriceAndSize);
+                Dispatcher.Invoke(() =>
+                {
+                    UpdateLimitPrice();
+                    UpdatePriceAndSize();
+                });
             }
+        }
+
+        private void UpdateLimitPrice()
+        {
+            if (_selectedTicker == null)
+                return;
+
+            var priceBox = Q<TextBox>("LimitPriceTextBox");
+            if (priceBox != null)
+                priceBox.Text = _selectedTicker.Price.ToString("0.########", CultureInfo.InvariantCulture);
         }
 
         private void UpdatePriceAndSize()


### PR DESCRIPTION
## Summary
- auto-fill limit order price from the selected ticker row
- keep futures price box updated when live prices change

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68adbc6b521883339ac05f3be9a7da55