### PR TITLE
Stop auto updating limit price

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1223,10 +1223,7 @@ namespace BinanceUsdtTicker
         {
             if (Grid?.SelectedItem is TickerRow row)
             {
-                if (_selectedTicker != null)
-                    _selectedTicker.PropertyChanged -= SelectedTicker_PropertyChanged;
                 _selectedTicker = row;
-                _selectedTicker.PropertyChanged += SelectedTicker_PropertyChanged;
                 UpdateLimitPrice();
                 UpdatePriceAndSize();
                 await LoadFuturesUiAsync(row.Symbol);
@@ -1343,18 +1340,6 @@ namespace BinanceUsdtTicker
         {
             if (e.Source is TabControl)
                 UpdatePriceAndSize();
-        }
-
-        private void SelectedTicker_PropertyChanged(object? sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(TickerRow.Price))
-            {
-                Dispatcher.Invoke(() =>
-                {
-                    UpdateLimitPrice();
-                    UpdatePriceAndSize();
-                });
-            }
         }
 
         private void UpdateLimitPrice()


### PR DESCRIPTION
## Summary
- Set the selected ticker only once and stop listening for price changes
- Remove price-change handler so limit price field no longer updates continuously

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68adc16511808333b386010cf79b8a44