### PR TITLE
Emphasize Futures price input for clarity

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -695,7 +695,7 @@
                                                 <TabItem Header="Limit">
                                                         <StackPanel Margin="4">
                                                                 <TextBlock Text="Price" Margin="0,0,0,4"/>
-                                                                <TextBox x:Name="LimitPriceTextBox" Margin="0,0,0,8"/>
+                                                                <TextBox x:Name="LimitPriceTextBox" Margin="0,0,0,8" Height="40" FontSize="18" FontWeight="Bold"/>
                                                                 <TextBlock Text="Size" Margin="0,0,0,4"/>
                                                                 <Slider x:Name="LimitSizeSlider" Minimum="0" Maximum="100" TickPlacement="BottomRight" Ticks="0,25,50,75,100" IsSnapToTickEnabled="False" ValueChanged="SizeSlider_ValueChanged"/>
                                                                 <TextBlock x:Name="LimitSizeValueText" Margin="0,4,0,0"/>


### PR DESCRIPTION
## Summary
- Increase Futures limit order price input height
- Bold and enlarge text for the entered price value

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adc30c60d08333906ef98a4eb8392e