### PR TITLE
Update cost and max when price changes

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1226,10 +1226,23 @@ namespace BinanceUsdtTicker
         {
             if (Grid?.SelectedItem is TickerRow row)
             {
+                if (_selectedTicker != null)
+                    _selectedTicker.PropertyChanged -= SelectedTicker_PropertyChanged;
+
                 _selectedTicker = row;
+                _selectedTicker.PropertyChanged += SelectedTicker_PropertyChanged;
+
                 UpdateLimitPrice();
                 UpdatePriceAndSize();
                 await LoadFuturesUiAsync(row.Symbol);
+                UpdateCostAndMax();
+            }
+        }
+
+        private void SelectedTicker_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(TickerRow.Price))
+            {
                 UpdateCostAndMax();
             }
         }


### PR DESCRIPTION
## Summary
- Recompute cost and max values whenever the selected ticker's price updates
- Attach/detach ticker price change handlers on selection

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adfae374788333bfbdd725c1c92398