### PR TITLE
Add order preview service using live Binance futures API

### DIFF
--- a/Services/Trading/OrderPreviewService.cs
+++ b/Services/Trading/OrderPreviewService.cs
@@ -1,0 +1,486 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BinanceUsdtTicker.Trading
+{
+    #region Enums & Request/Response
+
+    public enum OrderType { Market, Limit }
+    public enum OrderSide { Buy, Sell }
+    public enum MarginMode { Cross, Isolated }
+    public enum PositionSide { OneWay, Long, Short }
+
+    public sealed record OrderPreviewRequest(
+        string Symbol,
+        OrderType OrderType,
+        OrderSide Side,
+        PositionSide PositionSide,
+        MarginMode MarginMode,
+        int Leverage,
+        decimal WalletPercent,
+        decimal? LimitPrice = null,
+        decimal MarketSlippageBps = 10m,
+        decimal? MakerFeeRate = null,
+        decimal? TakerFeeRate = null
+    );
+
+    public sealed class OrderPreview
+    {
+        public string Symbol { get; init; } = "";
+        public OrderType OrderType { get; init; }
+        public OrderSide Side { get; init; }
+        public PositionSide PositionSide { get; init; }
+        public MarginMode MarginMode { get; init; }
+        public int Leverage { get; init; }
+
+        public decimal LastPrice { get; init; }
+        public decimal MarkPrice { get; init; }
+        public decimal ReferencePrice { get; init; }
+        public decimal InitialMarginRate { get; init; }
+
+        public decimal LotStepSize { get; init; }
+        public decimal LotMinQty { get; init; }
+        public decimal? MarketLotStepSize { get; init; }
+        public decimal? MarketLotMinQty { get; init; }
+        public decimal? MinNotional { get; init; }
+        public decimal? NotionalCap { get; init; }
+
+        public decimal UsableBalance { get; init; }
+        public decimal ExistingAbsNotional { get; init; }
+
+        public decimal OpenLossPerUnit { get; init; }
+        public decimal MaxQtyByBalance { get; init; }
+        public decimal MaxQtyByBracket { get; init; }
+        public decimal MaxQtyByFilters { get; init; }
+        public decimal MaxQtyFinal { get; init; }
+
+        public decimal SuggestedQty => MaxQtyFinal;
+        public decimal SuggestedNotional => Round4(SuggestedQty * ReferencePrice);
+        public decimal InitialMargin => Round4(SuggestedNotional * InitialMarginRate);
+        public decimal OpenLoss => Round4(SuggestedQty * OpenLossPerUnit);
+        public decimal Cost => Round4(InitialMargin + OpenLoss);
+        public decimal? EstFee => null;
+
+        public List<string> Warnings { get; init; } = new();
+
+        static decimal Round4(decimal v) => Math.Round(v, 4, MidpointRounding.AwayFromZero);
+    }
+
+    #endregion
+
+    #region Service
+
+    public class OrderPreviewService
+    {
+        private readonly BinanceFuturesRestClient _client;
+        private readonly SymbolMetaCache _cache = new();
+
+        public OrderPreviewService(BinanceFuturesRestClient client)
+        {
+            _client = client;
+        }
+
+        public async Task<OrderPreview> ComputeAsync(OrderPreviewRequest r, CancellationToken ct = default)
+        {
+            var symbol = r.Symbol.ToUpperInvariant();
+            if (r.OrderType == OrderType.Limit && r.LimitPrice is null)
+                throw new ArgumentException("Limit emri için LimitPrice gereklidir.");
+            if (r.Leverage < 1) throw new ArgumentException("Leverage >= 1 olmalı");
+            if (r.WalletPercent is < 0m or > 1m) throw new ArgumentException("WalletPercent 0..1 aralığında olmalı");
+
+            var last = await _client.GetLastPriceAsync(symbol, ct);
+            var mark = await _client.GetMarkPriceAsync(symbol, ct);
+            decimal refPx = r.OrderType switch
+            {
+                OrderType.Market => r.Side == OrderSide.Buy
+                    ? last * (1m + r.MarketSlippageBps / 10_000m)
+                    : last * (1m - r.MarketSlippageBps / 10_000m),
+                _ => r.LimitPrice!.Value
+            };
+
+            var meta = await _cache.GetOrLoadAsync(_client, symbol, ct);
+            var lot = r.OrderType == OrderType.Market ? meta.MarketLot : meta.Lot;
+            var minNotional = meta.MinNotional;
+
+            decimal usable;
+            decimal existingAbsNotional = 0m;
+            if (r.MarginMode == MarginMode.Cross)
+            {
+                var acc = await _client.GetAccountV3Async(ct);
+                usable = acc.AvailableBalance * r.WalletPercent;
+                existingAbsNotional = await _client.GetAbsNotionalAsync(symbol, ct);
+            }
+            else
+            {
+                var pr = await _client.GetPositionRiskAsync(symbol, ct);
+                var isoWallet = pr.Sum(x => x.IsolatedWallet);
+                usable = isoWallet * r.WalletPercent;
+                existingAbsNotional = pr.Sum(x => Math.Abs(x.Notional));
+            }
+
+            var cap = meta.ResolveNotionalCapForLeverage(r.Leverage);
+
+            var imr = 1m / r.Leverage;
+            decimal openLossPerUnit = 0m;
+            if (r.Side == OrderSide.Buy)
+            {
+                if (refPx > mark) openLossPerUnit = refPx - mark;
+            }
+            else
+            {
+                if (refPx < mark) openLossPerUnit = mark - refPx;
+            }
+            var denom = refPx * imr + openLossPerUnit;
+            var maxByBalance = denom > 0m ? usable / denom : decimal.Zero;
+
+            decimal maxByBracket = decimal.MaxValue;
+            if (cap != null)
+            {
+                var capFree = cap.Value - existingAbsNotional;
+                if (capFree < 0) capFree = 0;
+                maxByBracket = refPx > 0 ? capFree / refPx : 0;
+            }
+
+            var maxRaw = MinSafe(maxByBalance, maxByBracket);
+            var maxByFilters = QuantizeDown(maxRaw, lot.StepSize);
+            if (maxByFilters < lot.MinQty) maxByFilters = 0m;
+
+            var warnings = new List<string>();
+            if (maxByFilters > 0 && minNotional != null)
+            {
+                var notion = maxByFilters * refPx;
+                if (notion < minNotional)
+                {
+                    warnings.Add($"Önerilen miktar MIN_NOTIONAL'ı karşılamıyor (gereken ≥ {minNotional}).");
+                    maxByFilters = 0m;
+                }
+            }
+
+            if (cap != null && maxByBracket <= maxByBalance)
+                warnings.Add("Risk kademesi (notional cap) limiti nedeniyle MAX kısıtlandı.");
+
+            if (maxByFilters == 0m)
+                warnings.Add("Yeterli bakiye/limit/filtre koşulları sağlanamadı.");
+
+            return new OrderPreview
+            {
+                Symbol = symbol,
+                OrderType = r.OrderType,
+                Side = r.Side,
+                PositionSide = r.PositionSide,
+                MarginMode = r.MarginMode,
+                Leverage = r.Leverage,
+
+                LastPrice = last,
+                MarkPrice = mark,
+                ReferencePrice = refPx,
+                InitialMarginRate = imr,
+
+                LotStepSize = lot.StepSize,
+                LotMinQty = lot.MinQty,
+                MarketLotStepSize = meta.MarketLot?.StepSize,
+                MarketLotMinQty = meta.MarketLot?.MinQty,
+                MinNotional = minNotional,
+                NotionalCap = cap,
+
+                UsableBalance = usable,
+                ExistingAbsNotional = existingAbsNotional,
+
+                OpenLossPerUnit = openLossPerUnit,
+                MaxQtyByBalance = Round6(maxByBalance),
+                MaxQtyByBracket = Round6(maxByBracket),
+                MaxQtyByFilters = Round6(maxByFilters),
+                MaxQtyFinal = Round6(maxByFilters),
+                Warnings = warnings
+            };
+
+            static decimal MinSafe(decimal a, decimal b) => a < b ? a : b;
+            static decimal QuantizeDown(decimal v, decimal step)
+            {
+                if (step <= 0m) return v;
+                var n = Math.Floor(v / step);
+                return n * step;
+            }
+            static decimal Round6(decimal v) => Math.Round(v, 6, MidpointRounding.ToZero);
+        }
+    }
+
+    #endregion
+
+    #region REST Client + Cache + DTOs
+
+    public class BinanceFuturesRestClient
+    {
+        private readonly HttpClient _http;
+        private readonly string _apiKey;
+        private readonly string _apiSecret;
+        private readonly string _baseUrl;
+
+        public BinanceFuturesRestClient(HttpClient http, string apiKey, string apiSecret, bool useTestnet = false)
+        {
+            _http = http;
+            _apiKey = apiKey;
+            _apiSecret = apiSecret;
+            _baseUrl = useTestnet ? "https://testnet.binancefuture.com" : "https://fapi.binance.com";
+        }
+
+        public async Task<decimal> GetLastPriceAsync(string symbol, CancellationToken ct)
+        {
+            var s = await SendAsync($"/fapi/v1/ticker/price?symbol={symbol}", HttpMethod.Get, false, ct);
+            using var d = JsonDocument.Parse(s);
+            return d.RootElement.GetProperty("price").GetDecimalString();
+        }
+
+        public async Task<decimal> GetMarkPriceAsync(string symbol, CancellationToken ct)
+        {
+            var s = await SendAsync($"/fapi/v1/premiumIndex?symbol={symbol}", HttpMethod.Get, false, ct);
+            using var d = JsonDocument.Parse(s);
+            return d.RootElement.GetProperty("markPrice").GetDecimalString();
+        }
+
+        public async Task<AccountV3> GetAccountV3Async(CancellationToken ct)
+        {
+            var s = await SendSignedAsync("/fapi/v3/account", HttpMethod.Get, null, ct);
+            return JsonSerializer.Deserialize<AccountV3>(s, JsonOptions) ?? new();
+        }
+
+        public async Task<List<PositionRisk>> GetPositionRiskAsync(string symbol, CancellationToken ct)
+        {
+            var qp = new Dictionary<string, string> { ["symbol"] = symbol };
+            var s = await SendSignedAsync("/fapi/v3/positionRisk", HttpMethod.Get, qp, ct);
+            return JsonSerializer.Deserialize<List<PositionRisk>>(s, JsonOptions) ?? new();
+        }
+
+        public async Task<decimal> GetAbsNotionalAsync(string symbol, CancellationToken ct)
+        {
+            var list = await GetPositionRiskAsync(symbol, ct);
+            return list.Sum(x => Math.Abs(x.Notional));
+        }
+
+        public async Task<ExchangeInfo> GetExchangeInfoAsync(CancellationToken ct)
+        {
+            var s = await SendAsync("/fapi/v1/exchangeInfo", HttpMethod.Get, false, ct);
+            return JsonSerializer.Deserialize<ExchangeInfo>(s, JsonOptions) ?? new();
+        }
+
+        public async Task<List<LeverageBracket>> GetLeverageBracketsAsync(string symbol, CancellationToken ct)
+        {
+            var s = await SendSignedAsync("/fapi/v1/leverageBracket", HttpMethod.Get, new() { ["symbol"] = symbol }, ct);
+            if (s.TrimStart().StartsWith("["))
+                return JsonSerializer.Deserialize<List<LeverageBracket>>(s, JsonOptions) ?? new();
+            var one = JsonSerializer.Deserialize<LeverageBracketSingle>(s, JsonOptions);
+            return one != null ? new List<LeverageBracket> { one } : new();
+        }
+
+        private async Task<string> SendSignedAsync(string path, HttpMethod method, Dictionary<string, string>? query, CancellationToken ct)
+        {
+            query ??= new();
+            query["timestamp"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture);
+            var qs = string.Join("&", query.Select(kv => $"{kv.Key}={Uri.EscapeDataString(kv.Value)}"));
+            var sig = Sign(qs, _apiSecret);
+            var url = $"{_baseUrl}{path}?{qs}&signature={sig}";
+            using var req = new HttpRequestMessage(method, url);
+            req.Headers.Add("X-MBX-APIKEY", _apiKey);
+            using var res = await _http.SendAsync(req, ct);
+            res.EnsureSuccessStatusCode();
+            return await res.Content.ReadAsStringAsync(ct);
+        }
+
+        private async Task<string> SendAsync(string path, HttpMethod method, bool signed, CancellationToken ct)
+        {
+            using var req = new HttpRequestMessage(method, _baseUrl + path);
+            if (signed) req.Headers.Add("X-MBX-APIKEY", _apiKey);
+            using var res = await _http.SendAsync(req, ct);
+            res.EnsureSuccessStatusCode();
+            return await res.Content.ReadAsStringAsync(ct);
+        }
+
+        private static string Sign(string data, string secret)
+        {
+            using var h = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+            return Convert.ToHexString(h.ComputeHash(Encoding.UTF8.GetBytes(data))).ToLowerInvariant();
+        }
+
+        internal static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true,
+            NumberHandling = JsonNumberHandling.AllowReadingFromString,
+            ReadCommentHandling = JsonCommentHandling.Skip
+        };
+    }
+
+    internal sealed class SymbolMetaCache
+    {
+        private readonly Dictionary<string, SymbolMeta> _map = new(StringComparer.OrdinalIgnoreCase);
+        private ExchangeInfo? _ex;
+
+        public async Task<SymbolMeta> GetOrLoadAsync(BinanceFuturesRestClient client, string symbol, CancellationToken ct)
+        {
+            if (_map.TryGetValue(symbol, out var ok)) return ok;
+
+            _ex ??= await client.GetExchangeInfoAsync(ct);
+            var sym = _ex.Symbols.FirstOrDefault(s => s.Symbol.Equals(symbol, StringComparison.OrdinalIgnoreCase))
+                      ?? throw new InvalidOperationException($"exchangeInfo’da {symbol} bulunamadı.");
+
+            var lot = sym.Filters.OfType<LotSizeFilter>().FirstOrDefault() ?? new LotSizeFilter();
+            var mlot = sym.Filters.OfType<MarketLotSizeFilter>().FirstOrDefault();
+            var minNotional = sym.Filters.OfType<MinNotionalFilter>().FirstOrDefault()?.Notional;
+
+            var lev = await client.GetLeverageBracketsAsync(symbol, ct);
+
+            var meta = new SymbolMeta(symbol, lot, mlot, minNotional, lev);
+            _map[symbol] = meta;
+            return meta;
+        }
+    }
+
+    internal sealed record SymbolMeta(
+        string Symbol,
+        LotSizeFilter Lot,
+        MarketLotSizeFilter? MarketLot,
+        decimal? MinNotional,
+        List<LeverageBracket> Brackets)
+    {
+        public decimal? ResolveNotionalCapForLeverage(int leverage)
+        {
+            if (Brackets == null || Brackets.Count == 0) return null;
+            var eligible = Brackets
+                .SelectMany(b => b.Brackets.Select(x => new { x.InitialLeverage, Cap = x.NotionalCap ?? x.MaxNotionalValue }))
+                .Where(x => x.InitialLeverage >= leverage && x.Cap != null)
+                .Select(x => x.Cap!.Value)
+                .DefaultIfEmpty((decimal)0);
+            var minCap = eligible.Min();
+            return minCap == 0 ? null : minCap;
+        }
+    }
+
+    public sealed class ExchangeInfo
+    {
+        public List<SymbolInfo> Symbols { get; set; } = new();
+    }
+
+    public sealed class SymbolInfo
+    {
+        public string Symbol { get; set; } = "";
+        public List<IFilter> Filters { get; set; } = new();
+
+        [JsonPropertyName("filters")]
+        public JsonElement RawFilters { get; set; }
+
+        [JsonConstructor]
+        public SymbolInfo() { }
+
+        [OnDeserialized]
+        public void OnDeserializedMethod()
+        {
+            if (RawFilters.ValueKind != JsonValueKind.Array) return;
+            foreach (var f in RawFilters.EnumerateArray())
+            {
+                var type = f.GetProperty("filterType").GetString();
+                switch (type)
+                {
+                    case "LOT_SIZE":
+                        Filters.Add(new LotSizeFilter
+                        {
+                            MinQty = f.TryGetDecimal("minQty"),
+                            StepSize = f.TryGetDecimal("stepSize")
+                        });
+                        break;
+                    case "MARKET_LOT_SIZE":
+                        Filters.Add(new MarketLotSizeFilter
+                        {
+                            MinQty = f.TryGetDecimal("minQty"),
+                            StepSize = f.TryGetDecimal("stepSize")
+                        });
+                        break;
+                    case "MIN_NOTIONAL":
+                        Filters.Add(new MinNotionalFilter
+                        {
+                            Notional = f.TryGetDecimal("notional")
+                        });
+                        break;
+                }
+            }
+        }
+    }
+
+    public interface IFilter { }
+    public sealed class LotSizeFilter : IFilter
+    {
+        public decimal MinQty { get; set; }
+        public decimal StepSize { get; set; }
+    }
+    public sealed class MarketLotSizeFilter : IFilter
+    {
+        public decimal MinQty { get; set; }
+        public decimal StepSize { get; set; }
+    }
+    public sealed class MinNotionalFilter : IFilter
+    {
+        public decimal Notional { get; set; }
+    }
+
+    public sealed class AccountV3
+    {
+        [JsonPropertyName("availableBalance")] public decimal AvailableBalance { get; set; }
+    }
+
+    public sealed class PositionRisk
+    {
+        public string Symbol { get; set; } = "";
+        [JsonPropertyName("positionSide")] public string PositionSideRaw { get; set; } = "";
+        [JsonPropertyName("positionAmt")] public decimal PositionAmt { get; set; }
+        [JsonPropertyName("entryPrice")] public decimal EntryPrice { get; set; }
+        [JsonPropertyName("markPrice")] public decimal MarkPrice { get; set; }
+        [JsonPropertyName("unRealizedProfit")] public decimal UnrealizedPnl { get; set; }
+        [JsonPropertyName("notional")] public decimal Notional { get; set; }
+        [JsonPropertyName("isolatedWallet")] public decimal IsolatedWallet { get; set; }
+    }
+
+    public sealed class LeverageBracketSingle : LeverageBracket
+    {
+    }
+
+    public class LeverageBracket
+    {
+        public string Symbol { get; set; } = "";
+        [JsonPropertyName("brackets")] public List<BracketRow> Brackets { get; set; } = new();
+    }
+
+    public sealed class BracketRow
+    {
+        [JsonPropertyName("initialLeverage")] public int InitialLeverage { get; set; }
+        [JsonPropertyName("notionalCap")] public decimal? NotionalCap { get; set; }
+        [JsonPropertyName("maxNotionalValue")] public decimal? MaxNotionalValue { get; set; }
+        [JsonPropertyName("maintMarginRatio")] public decimal MaintMarginRatio { get; set; }
+    }
+
+    #endregion
+
+    #region Json helpers
+    internal static class JsonExt
+    {
+        public static decimal GetDecimalString(this JsonElement el)
+        {
+            var s = el.GetString();
+            return decimal.Parse(s!, CultureInfo.InvariantCulture);
+        }
+
+        public static decimal TryGetDecimal(this JsonElement el, string prop)
+        {
+            if (!el.TryGetProperty(prop, out var p)) return 0m;
+            var s = p.GetString();
+            return string.IsNullOrWhiteSpace(s) ? 0m : decimal.Parse(s, CultureInfo.InvariantCulture);
+        }
+    }
+    #endregion
+}

--- a/ViewModels/Trading/OrderPreviewViewModel.cs
+++ b/ViewModels/Trading/OrderPreviewViewModel.cs
@@ -1,0 +1,97 @@
+using System;
+using System.ComponentModel;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using BinanceUsdtTicker.Trading;
+
+namespace BinanceUsdtTicker.ViewModels.Trading
+{
+    public class OrderPreviewViewModel : INotifyPropertyChanged
+    {
+        private string _symbol = "BTCUSDT";
+        private string _orderType = "Market";
+        private string _side = "Buy";
+        private string _margin = "Cross";
+        private string _posSide = "OneWay";
+        private int _leverage = 10;
+        private decimal _walletPercent = 0.25m;
+        private decimal? _limitPrice;
+        private decimal _slipBps = 10m;
+
+        public string Symbol { get => _symbol; set { _symbol = value; OnPropertyChanged(); } }
+        public string OrderType { get => _orderType; set { _orderType = value; OnPropertyChanged(); } }
+        public string Side { get => _side; set { _side = value; OnPropertyChanged(); } }
+        public string MarginMode { get => _margin; set { _margin = value; OnPropertyChanged(); } }
+        public string PositionSide { get => _posSide; set { _posSide = value; OnPropertyChanged(); } }
+        public int Leverage { get => _leverage; set { _leverage = value; OnPropertyChanged(); } }
+        public decimal WalletPercent { get => _walletPercent; set { _walletPercent = value; OnPropertyChanged(); } }
+        public decimal? LimitPrice { get => _limitPrice; set { _limitPrice = value; OnPropertyChanged(); } }
+        public decimal MarketSlippageBps { get => _slipBps; set { _slipBps = value; OnPropertyChanged(); } }
+        public bool IsLimit => OrderType == "Limit";
+
+        private OrderPreview? _preview;
+        public OrderPreview? Preview { get => _preview; set { _preview = value; OnPropertyChanged(); } }
+
+        private readonly OrderPreviewService _service;
+        public ICommand RecalcCommand { get; }
+
+        public OrderPreviewViewModel(string apiKey, string apiSecret)
+        {
+            var http = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+            var client = new BinanceFuturesRestClient(http, apiKey, apiSecret, useTestnet: false);
+            _service = new OrderPreviewService(client);
+            RecalcCommand = new AsyncCommand(RecalcAsync);
+        }
+
+        private async Task RecalcAsync()
+        {
+            try
+            {
+                var req = new OrderPreviewRequest(
+                    Symbol,
+                    OrderType == "Market" ? OrderType.Market : OrderType.Limit,
+                    Side == "Buy" ? OrderSide.Buy : OrderSide.Sell,
+                    PositionSide == "Long" ? BinanceUsdtTicker.Trading.PositionSide.Long :
+                        PositionSide == "Short" ? BinanceUsdtTicker.Trading.PositionSide.Short : BinanceUsdtTicker.Trading.PositionSide.OneWay,
+                    MarginMode == "Isolated" ? BinanceUsdtTicker.Trading.MarginMode.Isolated : BinanceUsdtTicker.Trading.MarginMode.Cross,
+                    Leverage,
+                    WalletPercent,
+                    LimitPrice,
+                    MarketSlippageBps
+                );
+
+                Preview = await _service.ComputeAsync(req, CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                Preview = new OrderPreview
+                {
+                    Symbol = Symbol,
+                    Warnings = new() { ex.Message }
+                };
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+
+    public sealed class AsyncCommand : ICommand
+    {
+        private readonly Func<Task> _handler;
+        private bool _busy;
+        public AsyncCommand(Func<Task> handler) => _handler = handler;
+        public bool CanExecute(object? parameter) => !_busy;
+        public event EventHandler? CanExecuteChanged;
+        public async void Execute(object? parameter)
+        {
+            if (_busy) return; _busy = True(); CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+            try { await _handler(); } finally { _busy = False(); CanExecuteChanged?.Invoke(this, EventArgs.Empty); }
+        }
+        private bool True() => true;
+        private bool False() => false;
+    }
+}

--- a/Views/Trading/OrderPreviewCard.xaml
+++ b/Views/Trading/OrderPreviewCard.xaml
@@ -1,0 +1,102 @@
+<UserControl x:Class="BinanceUsdtTicker.Views.Trading.OrderPreviewCard"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignHeight="420" d:DesignWidth="680">
+    <Border Padding="16" CornerRadius="16" Background="{DynamicResource CardBackgroundBrush}" 
+            BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1">
+        <Grid RowDefinitions="Auto,Auto,Auto,*" ColumnDefinitions="*,*">
+            <StackPanel Orientation="Horizontal" Grid.ColumnSpan="2" Spacing="12">
+                <TextBlock Text="Symbol" VerticalAlignment="Center"/>
+                <TextBox Width="90" Text="{Binding Symbol, UpdateSourceTrigger=PropertyChanged}"/>
+
+                <TextBlock Text="Type" Margin="12,0,0,0" VerticalAlignment="Center"/>
+                <ComboBox Width="100" SelectedItem="{Binding OrderType}">
+                    <ComboBoxItem Content="Market"/>
+                    <ComboBoxItem Content="Limit"/>
+                </ComboBox>
+
+                <TextBlock Text="Side" Margin="12,0,0,0" VerticalAlignment="Center"/>
+                <ComboBox Width="90" SelectedItem="{Binding Side}">
+                    <ComboBoxItem Content="Buy"/>
+                    <ComboBoxItem Content="Sell"/>
+                </ComboBox>
+
+                <TextBlock Text="Leverage" Margin="12,0,0,0" VerticalAlignment="Center"/>
+                <TextBox Width="50" Text="{Binding Leverage}"/>
+
+                <TextBlock Text="Wallet %" Margin="12,0,0,0" VerticalAlignment="Center"/>
+                <Slider Width="120" Minimum="0" Maximum="1" SmallChange="0.01" LargeChange="0.1" Value="{Binding WalletPercent, Mode=TwoWay}"/>
+                <TextBlock Text="{Binding WalletPercent, StringFormat=P0}" VerticalAlignment="Center"/>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" Grid.Row="1" Spacing="12">
+                <TextBlock Text="Margin" VerticalAlignment="Center"/>
+                <ComboBox Width="110" SelectedItem="{Binding MarginMode}">
+                    <ComboBoxItem Content="Cross"/>
+                    <ComboBoxItem Content="Isolated"/>
+                </ComboBox>
+
+                <TextBlock Text="PosMode" Margin="12,0,0,0" VerticalAlignment="Center"/>
+                <ComboBox Width="120" SelectedItem="{Binding PositionSide}">
+                    <ComboBoxItem Content="OneWay"/>
+                    <ComboBoxItem Content="Long"/>
+                    <ComboBoxItem Content="Short"/>
+                </ComboBox>
+
+                <TextBlock Text="Limit Px" Margin="12,0,0,0" VerticalAlignment="Center"/>
+                <TextBox Width="100" IsEnabled="{Binding IsLimit}"
+                         Text="{Binding LimitPrice, UpdateSourceTrigger=PropertyChanged}"/>
+
+                <TextBlock Text="Slip bps" Margin="12,0,0,0" VerticalAlignment="Center"/>
+                <TextBox Width="60" Text="{Binding MarketSlippageBps}"/>
+
+                <Button Content="Hesapla" Margin="12,0,0,0" Command="{Binding RecalcCommand}"/>
+            </StackPanel>
+
+            <Grid Grid.Row="2" ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
+                <TextBlock Grid.Row="0" Grid.Column="0" Text="Last"/>
+                <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Preview.LastPrice}"/>
+
+                <TextBlock Grid.Row="1" Grid.Column="0" Text="Mark"/>
+                <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Preview.MarkPrice}"/>
+
+                <TextBlock Grid.Row="2" Grid.Column="0" Text="Ref Price"/>
+                <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Preview.ReferencePrice}"/>
+
+                <TextBlock Grid.Row="3" Grid.Column="0" Text="IMR (1/x)"/>
+                <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Preview.InitialMarginRate}"/>
+
+                <TextBlock Grid.Row="4" Grid.Column="0" Text="OpenLoss/Unit"/>
+                <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Preview.OpenLossPerUnit}"/>
+
+                <TextBlock Grid.Row="5" Grid.Column="0" Text="Notional Cap"/>
+                <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding Preview.NotionalCap}"/>
+            </Grid>
+
+            <Border Grid.Row="3" Grid.ColumnSpan="2" Margin="0,12,0,0" Padding="12" Background="#0AFFFFFF" CornerRadius="12">
+                <StackPanel>
+                    <TextBlock Text="Öneri" FontWeight="Bold"/>
+                    <UniformGrid Rows="2" Columns="4" Margin="0,6,0,0">
+                        <TextBlock Text="MAX by Balance"/>
+                        <TextBlock Text="{Binding Preview.MaxQtyByBalance}"/>
+                        <TextBlock Text="MAX by Bracket"/>
+                        <TextBlock Text="{Binding Preview.MaxQtyByBracket}"/>
+                        <TextBlock Text="MAX (Final)"/>
+                        <TextBlock Text="{Binding Preview.MaxQtyFinal}"/>
+                        <TextBlock Text="COST (IM + OpenLoss)"/>
+                        <TextBlock Text="{Binding Preview.Cost}"/>
+                    </UniformGrid>
+                    <ItemsControl ItemsSource="{Binding Preview.Warnings}" Margin="0,8,0,0">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Foreground="OrangeRed" Text="•  "><Run/><Run Text="{Binding}"/></TextBlock>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Border>
+</UserControl>

--- a/Views/Trading/OrderPreviewCard.xaml.cs
+++ b/Views/Trading/OrderPreviewCard.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace BinanceUsdtTicker.Views.Trading
+{
+    public partial class OrderPreviewCard : UserControl
+    {
+        public OrderPreviewCard()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add order preview service and REST client targeting Binance futures mainnet
- add view model and WPF control to calculate and display trade quantity suggestions

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68adfd00811083338a8d676242311426