### PR TITLE
Remove unsupported StackPanel spacing property

### DIFF
--- a/Views/Trading/OrderPreviewCard.xaml
+++ b/Views/Trading/OrderPreviewCard.xaml
@@ -17,7 +17,7 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <StackPanel Orientation="Horizontal" Grid.ColumnSpan="2" Spacing="12">
+            <StackPanel Orientation="Horizontal" Grid.ColumnSpan="2">
                 <TextBlock Text="Symbol" VerticalAlignment="Center"/>
                 <TextBox Width="90" Text="{Binding Symbol, UpdateSourceTrigger=PropertyChanged}"/>
 
@@ -41,7 +41,7 @@
                 <TextBlock Text="{Binding WalletPercent, StringFormat=P0}" VerticalAlignment="Center"/>
             </StackPanel>
 
-            <StackPanel Orientation="Horizontal" Grid.Row="1" Spacing="12">
+            <StackPanel Orientation="Horizontal" Grid.Row="1">
                 <TextBlock Text="Margin" VerticalAlignment="Center"/>
                 <ComboBox Width="110" SelectedItem="{Binding MarginMode}">
                     <ComboBoxItem Content="Cross"/>


### PR DESCRIPTION
## Summary
- Remove unsupported `Spacing` property from horizontal `StackPanel`s to prevent XAML compilation errors

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae08af2cfc8333b04c4ac3eeeecb3f