### PR TITLE
Fix missing OnDeserialized attribute

### DIFF
--- a/Services/Trading/OrderPreviewService.cs
+++ b/Services/Trading/OrderPreviewService.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -380,7 +381,7 @@ namespace BinanceUsdtTicker.Trading
         public SymbolInfo() { }
 
         [OnDeserialized]
-        public void OnDeserializedMethod()
+        public void OnDeserializedMethod(StreamingContext context)
         {
             if (RawFilters.ValueKind != JsonValueKind.Array) return;
             foreach (var f in RawFilters.EnumerateArray())


### PR DESCRIPTION
## Summary
- include System.Runtime.Serialization to use OnDeserialized attribute
- update OnDeserialized callback signature with StreamingContext

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae09faa2988333a523eb273ed906af