### PR TITLE
Fix order preview compile errors

### DIFF
--- a/Services/Trading/OrderPreviewService.cs
+++ b/Services/Trading/OrderPreviewService.cs
@@ -109,7 +109,11 @@ namespace BinanceUsdtTicker.Trading
             };
 
             var meta = await _cache.GetOrLoadAsync(_client, symbol, ct);
-            var lot = r.OrderType == OrderType.Market ? meta.MarketLot : meta.Lot;
+            var lot = r.OrderType == OrderType.Market
+                ? (meta.MarketLot != null
+                    ? new LotSizeFilter { MinQty = meta.MarketLot.MinQty, StepSize = meta.MarketLot.StepSize }
+                    : meta.Lot)
+                : meta.Lot;
             var minNotional = meta.MinNotional;
 
             decimal usable;

--- a/ViewModels/Trading/OrderPreviewViewModel.cs
+++ b/ViewModels/Trading/OrderPreviewViewModel.cs
@@ -52,7 +52,7 @@ namespace BinanceUsdtTicker.ViewModels.Trading
             {
                 var req = new OrderPreviewRequest(
                     Symbol,
-                    OrderType == "Market" ? OrderType.Market : OrderType.Limit,
+                    OrderType == "Market" ? BinanceUsdtTicker.Trading.OrderType.Market : BinanceUsdtTicker.Trading.OrderType.Limit,
                     Side == "Buy" ? OrderSide.Buy : OrderSide.Sell,
                     PositionSide == "Long" ? BinanceUsdtTicker.Trading.PositionSide.Long :
                         PositionSide == "Short" ? BinanceUsdtTicker.Trading.PositionSide.Short : BinanceUsdtTicker.Trading.PositionSide.OneWay,


### PR DESCRIPTION
## Summary
- Qualify order type enums to avoid name collision with string property
- Normalize lot filter selection between market and limit orders

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 - cannot install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0b377fe88333b1f4b8eb82ec6be1