### PR TITLE
Allow 64 char API credentials in settings

### DIFF
--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -119,11 +119,11 @@
                 <StackPanel Margin="10">
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
                         <TextBlock Text="API Key:" Width="120" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding BinanceApiKey}" Width="300"/>
+                        <TextBox Text="{Binding BinanceApiKey}" Width="300" MaxLength="64"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="Secret Key:" Width="120" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding BinanceApiSecret}" Width="300"/>
+                        <TextBox Text="{Binding BinanceApiSecret}" Width="300" MaxLength="64"/>
                     </StackPanel>
                 </StackPanel>
             </TabItem>


### PR DESCRIPTION
## Summary
- allow full-length 64 character Binance API keys and secrets in the settings window

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository access 403)*

------
https://chatgpt.com/codex/tasks/task_e_68af0d8ce8488333b643f88ecee064b3