### PR TITLE
Use Binance Futures production API

### DIFF
--- a/Services/Trading/OrderPreviewService.cs
+++ b/Services/Trading/OrderPreviewService.cs
@@ -230,12 +230,12 @@ namespace BinanceUsdtTicker.Trading
         private readonly string _apiSecret;
         private readonly string _baseUrl;
 
-        public BinanceFuturesRestClient(HttpClient http, string apiKey, string apiSecret, bool useTestnet = false)
+        public BinanceFuturesRestClient(HttpClient http, string apiKey, string apiSecret)
         {
             _http = http;
             _apiKey = apiKey;
             _apiSecret = apiSecret;
-            _baseUrl = useTestnet ? "https://testnet.binancefuture.com" : "https://fapi.binance.com";
+            _baseUrl = "https://fapi.binance.com";
         }
 
         public async Task<decimal> GetLastPriceAsync(string symbol, CancellationToken ct)

--- a/ViewModels/Trading/OrderPreviewViewModel.cs
+++ b/ViewModels/Trading/OrderPreviewViewModel.cs
@@ -41,7 +41,7 @@ namespace BinanceUsdtTicker.ViewModels.Trading
         public OrderPreviewViewModel(string apiKey, string apiSecret)
         {
             var http = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
-            var client = new BinanceFuturesRestClient(http, apiKey, apiSecret, useTestnet: false);
+            var client = new BinanceFuturesRestClient(http, apiKey, apiSecret);
             _service = new OrderPreviewService(client);
             RecalcCommand = new AsyncCommand(RecalcAsync);
         }


### PR DESCRIPTION
## Summary
- remove testnet option and always target `https://fapi.binance.com`
- adjust OrderPreviewViewModel to match new client constructor

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68af0f4951ac8333ace16a22adaceb16