### PR TITLE
Display message box on wallet info fetch errors

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -341,7 +341,10 @@ namespace BinanceUsdtTicker
                     _walletAssets.Add(b);
                 UpdateCostAndMax();
             }
-            catch { }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, ex.Message, "Hata", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
 
         private async Task LoadOpenPositionsAsync()

--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -64,8 +64,20 @@ namespace BinanceUsdtTicker
                             list.Add(new WalletAsset { Asset = asset, Balance = balance, Available = available });
                     }
                 }
+                else if (doc.RootElement.TryGetProperty("msg", out var msg))
+                {
+                    throw new Exception(msg.GetString() ?? "Bilinmeyen hata");
+                }
+                else
+                {
+                    throw new Exception("Beklenmeyen yanıt alındı.");
+                }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                throw new Exception($"Cüzdan bilgileri alınırken hata oluştu: {ex.Message}", ex);
+            }
+
             return list;
         }
 


### PR DESCRIPTION
## Summary
- surface Binance API wallet errors by throwing descriptive exceptions
- show error message box when wallet info cannot be loaded

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af129e857c8333aaeb2d7bfe73ca0a