### PR TITLE
Implement long/short trading actions and position closing controls

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -715,12 +715,12 @@
                                                         <ColumnDefinition Width="*"/>
                                                 </Grid.ColumnDefinitions>
                                                 <StackPanel Grid.Column="0" Margin="0,0,4,0">
-                                                        <Button x:Name="BuyButton" Content="Buy/Long" Background="#2ecc71" Foreground="White" FontWeight="Bold" Height="40"/>
+                                                        <Button x:Name="BuyButton" Content="Buy/Long" Background="#2ecc71" Foreground="White" FontWeight="Bold" Height="40" Click="BuyButton_Click"/>
                                                         <TextBlock x:Name="BuyCostText" Margin="0,4,0,0" Text="Cost 0 USDT"/>
                                                         <TextBlock x:Name="BuyMaxText" Text="Max 0 USDT"/>
                                                 </StackPanel>
                                                 <StackPanel Grid.Column="1" Margin="4,0,0,0">
-                                                        <Button x:Name="SellButton" Content="Sell/Short" Background="#e74c3c" Foreground="White" FontWeight="Bold" Height="40"/>
+                                                        <Button x:Name="SellButton" Content="Sell/Short" Background="#e74c3c" Foreground="White" FontWeight="Bold" Height="40" Click="SellButton_Click"/>
                                                         <TextBlock x:Name="SellCostText" Margin="0,4,0,0" Text="Cost 0 USDT"/>
                                                         <TextBlock x:Name="SellMaxText" Text="Max 0 USDT"/>
                                                 </StackPanel>
@@ -908,6 +908,16 @@
                                                                                 </GridViewColumn>
                                                                                 <GridViewColumn Header="x" Width="40" DisplayMemberBinding="{Binding Leverage}"/>
                                                                                 <GridViewColumn Header="Marjin" Width="70" DisplayMemberBinding="{Binding MarginType}"/>
+                                                                                <GridViewColumn Header="Kapat" Width="120">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <StackPanel Orientation="Horizontal">
+                                                                                                                <Button Content="Limit" Margin="0,0,4,0" Tag="{Binding}" Click="ClosePositionLimit_Click"/>
+                                                                                                                <Button Content="Market" Tag="{Binding}" Click="ClosePositionMarket_Click"/>
+                                                                                                        </StackPanel>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
                                                                         </GridView>
                                                                 </ListView.View>
                                                         </ListView>

--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -305,6 +305,49 @@ namespace BinanceUsdtTicker
             }
         }
 
+        public async Task SetLeverageAsync(string symbol, int leverage)
+        {
+            var query = new Dictionary<string, string>
+            {
+                ["symbol"] = symbol,
+                ["leverage"] = leverage.ToString(CultureInfo.InvariantCulture)
+            };
+            await SendSignedAsync(HttpMethod.Post, "/fapi/v1/leverage", query);
+        }
+
+        public async Task SetMarginTypeAsync(string symbol, string marginType)
+        {
+            var query = new Dictionary<string, string>
+            {
+                ["symbol"] = symbol,
+                ["marginType"] = marginType.ToUpperInvariant()
+            };
+            try
+            {
+                await SendSignedAsync(HttpMethod.Post, "/fapi/v1/marginType", query);
+            }
+            catch { }
+        }
+
+        public async Task PlaceOrderAsync(string symbol, string side, string type, decimal quantity, decimal? price = null, bool reduceOnly = false)
+        {
+            var query = new Dictionary<string, string>
+            {
+                ["symbol"] = symbol,
+                ["side"] = side.ToUpperInvariant(),
+                ["type"] = type.ToUpperInvariant(),
+                ["quantity"] = quantity.ToString(CultureInfo.InvariantCulture)
+            };
+            if (price.HasValue)
+                query["price"] = price.Value.ToString(CultureInfo.InvariantCulture);
+            if (type.Equals("LIMIT", StringComparison.OrdinalIgnoreCase))
+                query["timeInForce"] = "GTC";
+            if (reduceOnly)
+                query["reduceOnly"] = "true";
+
+            await SendSignedAsync(HttpMethod.Post, "/fapi/v1/order", query);
+        }
+
         /// <summary>
         /// Hesaptaki açık pozisyonları döner.
         /// </summary>


### PR DESCRIPTION
## Summary
- Wire Long and Short buttons to place limit or market orders using current futures settings.
- Add close position controls in the open positions list for limit and market exits.
- Extend Binance API helper with leverage, margin type, and order submission methods and refresh UI data after each trade.

## Testing
- ⚠️ `dotnet build` – command not found; `apt-get update` failed with 403 so dependencies couldn't be installed.


------
https://chatgpt.com/codex/tasks/task_e_68b17f9601f483338ccfa8766c9ccd06