### PR TITLE
Fix order placement missing position side parameter

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1541,7 +1541,14 @@ namespace BinanceUsdtTicker
             {
                 await _api.SetMarginTypeAsync(symbol, margin);
                 await _api.SetLeverageAsync(symbol, leverage);
-                await _api.PlaceOrderAsync(symbol, side, isLimit ? "LIMIT" : "MARKET", qty, isLimit ? price : (decimal?)null);
+                await _api.PlaceOrderAsync(
+                    symbol,
+                    side,
+                    isLimit ? "LIMIT" : "MARKET",
+                    qty,
+                    isLimit ? price : (decimal?)null,
+                    false,
+                    isBuy ? "LONG" : "SHORT");
                 await RefreshTradingDataAsync();
             }
             catch (Exception ex)
@@ -1573,10 +1580,11 @@ namespace BinanceUsdtTicker
             if (qty <= 0m) return;
             try
             {
+                var posSide = pos.PositionAmt > 0 ? "LONG" : "SHORT";
                 if (limitPrice.HasValue)
-                    await _api.PlaceOrderAsync(pos.Symbol, side, "LIMIT", qty, limitPrice.Value, true);
+                    await _api.PlaceOrderAsync(pos.Symbol, side, "LIMIT", qty, limitPrice.Value, true, posSide);
                 else
-                    await _api.PlaceOrderAsync(pos.Symbol, side, "MARKET", qty, null, true);
+                    await _api.PlaceOrderAsync(pos.Symbol, side, "MARKET", qty, null, true, posSide);
 
                 await RefreshTradingDataAsync();
             }

--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -329,7 +329,7 @@ namespace BinanceUsdtTicker
             catch { }
         }
 
-        public async Task PlaceOrderAsync(string symbol, string side, string type, decimal quantity, decimal? price = null, bool reduceOnly = false)
+        public async Task PlaceOrderAsync(string symbol, string side, string type, decimal quantity, decimal? price = null, bool reduceOnly = false, string? positionSide = null)
         {
             var query = new Dictionary<string, string>
             {
@@ -344,6 +344,8 @@ namespace BinanceUsdtTicker
                 query["timeInForce"] = "GTC";
             if (reduceOnly)
                 query["reduceOnly"] = "true";
+            if (!string.IsNullOrEmpty(positionSide))
+                query["positionSide"] = positionSide.ToUpperInvariant();
 
             await SendSignedAsync(HttpMethod.Post, "/fapi/v1/order", query);
         }


### PR DESCRIPTION
## Summary
- support hedge mode by allowing position-side in order requests
- pass correct LONG/SHORT side when placing or closing positions

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b18199dfb88333ba66d5f57e6cec46