### PR TITLE
Improve signed request error handling

### DIFF
--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -422,8 +422,15 @@ namespace BinanceUsdtTicker
             var request = new HttpRequestMessage(method, url);
             request.Headers.Add("X-MBX-APIKEY", _apiKey);
             var response = await _http.SendAsync(request);
-            response.EnsureSuccessStatusCode();
-            return await response.Content.ReadAsStringAsync();
+            var content = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException(
+                    $"Response status code does not indicate success: {(int)response.StatusCode} ({response.StatusCode}). Content: {content}");
+            }
+
+            return content;
         }
 
         private string Sign(string queryString)


### PR DESCRIPTION
## Summary
- Handle non-success HTTP responses by reading content and including it in thrown exception for signed Binance API requests

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden while fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b183e0c8a883338ccec955e9c2dbc4