### PR TITLE
fix: avoid sending position side for futures orders

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1547,8 +1547,7 @@ namespace BinanceUsdtTicker
                     isLimit ? "LIMIT" : "MARKET",
                     qty,
                     isLimit ? price : (decimal?)null,
-                    false,
-                    isBuy ? "LONG" : "SHORT");
+                    false);
                 await RefreshTradingDataAsync();
             }
             catch (Exception ex)
@@ -1580,11 +1579,10 @@ namespace BinanceUsdtTicker
             if (qty <= 0m) return;
             try
             {
-                var posSide = pos.PositionAmt > 0 ? "LONG" : "SHORT";
                 if (limitPrice.HasValue)
-                    await _api.PlaceOrderAsync(pos.Symbol, side, "LIMIT", qty, limitPrice.Value, true, posSide);
+                    await _api.PlaceOrderAsync(pos.Symbol, side, "LIMIT", qty, limitPrice.Value, true);
                 else
-                    await _api.PlaceOrderAsync(pos.Symbol, side, "MARKET", qty, null, true, posSide);
+                    await _api.PlaceOrderAsync(pos.Symbol, side, "MARKET", qty, null, true);
 
                 await RefreshTradingDataAsync();
             }


### PR DESCRIPTION
## Summary
- stop including `positionSide` when placing or closing orders so the API uses the account's default mode

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1905e29848333a543e1e8207f8006