### PR TITLE
Display ROI and mark/liquidation prices for positions

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -897,12 +897,23 @@
                                                                                                 </DataTemplate>
                                                                                         </GridViewColumn.CellTemplate>
                                                                                 </GridViewColumn>
-                                                                                <GridViewColumn Header="PNL" Width="80">
+                                                                                <GridViewColumn Header="Mark/Liq" Width="140">
                                                                                         <GridViewColumn.CellTemplate>
                                                                                                 <DataTemplate>
-                                                                                                        <TextBlock Text="{Binding UnrealizedPnl, StringFormat={}{0:#,0.##}}"
-                                                       TextAlignment="Right"
-                                                       Foreground="{Binding PnlBrush}"/>
+                                                                                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                                                                                                <TextBlock Text="{Binding MarkPrice, StringFormat={}{0:#,0.####}}"/>
+                                                                                                                <TextBlock Text="{Binding LiquidationPrice, StringFormat={}{0:#,0.####}}" FontWeight="Bold" Margin="4,0,0,0"/>
+                                                                                                        </StackPanel>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="PNL" Width="120">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                                                                                                <TextBlock Text="{Binding UnrealizedPnl, StringFormat={}{0:#,0.##}}" Foreground="{Binding PnlBrush}"/>
+                                                                                                                <TextBlock Text="{Binding RoiPercent, StringFormat={}{0:#,0.##}%}" Foreground="{Binding PnlBrush}" Margin="4,0,0,0"/>
+                                                                                                        </StackPanel>
                                                                                                 </DataTemplate>
                                                                                         </GridViewColumn.CellTemplate>
                                                                                 </GridViewColumn>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -385,7 +385,8 @@ namespace BinanceUsdtTicker
             {
                 if (_rowBySymbol.TryGetValue(pos.Symbol, out var row))
                 {
-                    pos.UnrealizedPnl = (row.Price - pos.EntryPrice) * pos.PositionAmt;
+                    pos.MarkPrice = row.Price;
+                    pos.UnrealizedPnl = (pos.MarkPrice - pos.EntryPrice) * pos.PositionAmt;
                 }
             }
         }

--- a/Models/FuturesPosition.cs
+++ b/Models/FuturesPosition.cs
@@ -23,6 +23,7 @@ namespace BinanceUsdtTicker.Models
                 _unrealizedPnl = value;
                 OnPropertyChanged(nameof(UnrealizedPnl));
                 OnPropertyChanged(nameof(PnlBrush));
+                OnPropertyChanged(nameof(RoiPercent));
             }
         }
 
@@ -32,7 +33,54 @@ namespace BinanceUsdtTicker.Models
         /// <summary>
         /// Pozisyonun kullandığı başlangıç marjı (USDT).
         /// </summary>
-        public decimal InitialMargin { get; set; }
+        private decimal _initialMargin;
+        public decimal InitialMargin
+        {
+            get => _initialMargin;
+            set
+            {
+                if (_initialMargin == value) return;
+                _initialMargin = value;
+                OnPropertyChanged(nameof(InitialMargin));
+                OnPropertyChanged(nameof(RoiPercent));
+            }
+        }
+
+        private decimal _markPrice;
+        /// <summary>
+        /// Pozisyon için mevcut anlık mark fiyatı.
+        /// </summary>
+        public decimal MarkPrice
+        {
+            get => _markPrice;
+            set
+            {
+                if (_markPrice == value) return;
+                _markPrice = value;
+                OnPropertyChanged(nameof(MarkPrice));
+            }
+        }
+
+        private decimal _liquidationPrice;
+        /// <summary>
+        /// Pozisyonun tasfiye fiyatı.
+        /// </summary>
+        public decimal LiquidationPrice
+        {
+            get => _liquidationPrice;
+            set
+            {
+                if (_liquidationPrice == value) return;
+                _liquidationPrice = value;
+                OnPropertyChanged(nameof(LiquidationPrice));
+            }
+        }
+
+        /// <summary>
+        /// Pozisyonun Yatırım Getiri yüzdesi.
+        /// </summary>
+        public decimal RoiPercent =>
+            _initialMargin != 0m ? _unrealizedPnl / _initialMargin * 100m : 0m;
 
         private decimal? _closeLimitPrice;
         /// <summary>

--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -428,6 +428,8 @@ namespace BinanceUsdtTicker
                     decimal.TryParse(el.GetProperty("positionAmt").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var amt);
                     decimal.TryParse(el.GetProperty("entryPrice").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var entry);
                     decimal.TryParse(el.GetProperty("unRealizedProfit").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var pnl);
+                    decimal.TryParse(el.GetProperty("markPrice").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var mark);
+                    decimal.TryParse(el.GetProperty("liquidationPrice").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var liq);
                     decimal margin = 0m;
                     if (el.TryGetProperty("positionInitialMargin", out var imEl))
                         decimal.TryParse(imEl.GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out margin);
@@ -441,6 +443,8 @@ namespace BinanceUsdtTicker
                             PositionAmt = amt,
                             EntryPrice = entry,
                             UnrealizedPnl = pnl,
+                            MarkPrice = mark,
+                            LiquidationPrice = liq,
                             Leverage = det.Lev,
                             MarginType = det.Mt,
                             InitialMargin = margin


### PR DESCRIPTION
## Summary
- show mark price next to entry and bold liquidation price
- include ROI percentage beside position PnL

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b196662ea48333bd0a120cc66ae294