### PR TITLE
Fix open positions table and margin calculation

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -870,7 +870,7 @@
                                 <Expander Grid.Column="0" Header="Emirler" IsExpanded="True" Padding="6,4">
                                         <TabControl Margin="0,6,0,0">
                                                 <TabItem Header="Açık Pozisyonlar">
-                                                        <ListView x:Name="PositionsList">
+                                                        <ListView x:Name="PositionsList" HorizontalContentAlignment="Stretch">
                                                                 <ListView.View>
                                                                         <GridView>
                                                                                 <GridViewColumn Header="Sembol" Width="90">
@@ -897,13 +897,17 @@
                                                                                                 </DataTemplate>
                                                                                         </GridViewColumn.CellTemplate>
                                                                                 </GridViewColumn>
-                                                                                <GridViewColumn Header="Mark/Liq" Width="140">
+                                                                                <GridViewColumn Header="Mark" Width="80">
                                                                                         <GridViewColumn.CellTemplate>
                                                                                                 <DataTemplate>
-                                                                                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                                                                                                <TextBlock Text="{Binding MarkPrice, StringFormat={}{0:#,0.####}}"/>
-                                                                                                                <TextBlock Text="{Binding LiquidationPrice, StringFormat={}{0:#,0.####}}" FontWeight="Bold" Margin="4,0,0,0"/>
-                                                                                                        </StackPanel>
+                                                                                                        <TextBlock Text="{Binding MarkPrice, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="Liq" Width="80">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding LiquidationPrice, StringFormat={}{0:#,0.####}}" FontWeight="Bold" TextAlignment="Right"/>
                                                                                                 </DataTemplate>
                                                                                         </GridViewColumn.CellTemplate>
                                                                                 </GridViewColumn>

--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -430,13 +430,12 @@ namespace BinanceUsdtTicker
                     decimal.TryParse(el.GetProperty("unRealizedProfit").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var pnl);
                     decimal.TryParse(el.GetProperty("markPrice").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var mark);
                     decimal.TryParse(el.GetProperty("liquidationPrice").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var liq);
-                    decimal margin = 0m;
-                    if (el.TryGetProperty("positionInitialMargin", out var imEl))
-                        decimal.TryParse(imEl.GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out margin);
                     var sym = el.GetProperty("symbol").GetString() ?? string.Empty;
                     details.TryGetValue(sym, out var det);
                     if (amt != 0m)
                     {
+                        var lev = det.Lev == 0 ? 1 : det.Lev;
+                        var margin = Math.Abs(mark * amt / lev);
                         positions.Add(new FuturesPosition
                         {
                             Symbol = sym,


### PR DESCRIPTION
## Summary
- show open positions in a cleaner table with separate Mark and Liq columns
- compute margin from mark price to align with Binance values

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b4cbb534833396ecb503fa65e58c