### PR TITLE
Correct ROI calculation and display position metrics

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -922,10 +922,17 @@
                                                                                         </GridViewColumn.CellTemplate>
                                                                                 </GridViewColumn>
                                                                                 <GridViewColumn Header="x" Width="40" DisplayMemberBinding="{Binding Leverage}"/>
-                                                                                <GridViewColumn Header="Marjin" Width="80">
+                                                                                <GridViewColumn Header="Pozisyon boyutu" Width="100">
                                                                                         <GridViewColumn.CellTemplate>
                                                                                                 <DataTemplate>
-                                                                                                        <TextBlock Text="{Binding InitialMargin, StringFormat={}{0:#,0.##}}" TextAlignment="Right"/>
+                                                                                                        <TextBlock Text="{Binding PositionSize, StringFormat={}{0:#,0.##}}" TextAlignment="Right"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="Giriş tutarı" Width="80">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding EntryAmount, StringFormat={}{0:#,0.##}}" TextAlignment="Right"/>
                                                                                                 </DataTemplate>
                                                                                         </GridViewColumn.CellTemplate>
                                                                                 </GridViewColumn>

--- a/Models/FuturesPosition.cs
+++ b/Models/FuturesPosition.cs
@@ -10,7 +10,18 @@ namespace BinanceUsdtTicker.Models
     public class FuturesPosition : INotifyPropertyChanged
     {
         public string Symbol { get; set; } = string.Empty;
-        public decimal PositionAmt { get; set; }
+        private decimal _positionAmt;
+        public decimal PositionAmt
+        {
+            get => _positionAmt;
+            set
+            {
+                if (_positionAmt == value) return;
+                _positionAmt = value;
+                OnPropertyChanged(nameof(PositionAmt));
+                OnPropertyChanged(nameof(PositionSize));
+            }
+        }
         public decimal EntryPrice { get; set; }
 
         private decimal _unrealizedPnl;
@@ -31,17 +42,17 @@ namespace BinanceUsdtTicker.Models
         public string MarginType { get; set; } = string.Empty;
 
         /// <summary>
-        /// Pozisyonun kullandığı başlangıç marjı (USDT).
+        /// Pozisyonun girişte kullanılan tutarı (USDT).
         /// </summary>
-        private decimal _initialMargin;
-        public decimal InitialMargin
+        private decimal _entryAmount;
+        public decimal EntryAmount
         {
-            get => _initialMargin;
+            get => _entryAmount;
             set
             {
-                if (_initialMargin == value) return;
-                _initialMargin = value;
-                OnPropertyChanged(nameof(InitialMargin));
+                if (_entryAmount == value) return;
+                _entryAmount = value;
+                OnPropertyChanged(nameof(EntryAmount));
                 OnPropertyChanged(nameof(RoiPercent));
             }
         }
@@ -58,6 +69,7 @@ namespace BinanceUsdtTicker.Models
                 if (_markPrice == value) return;
                 _markPrice = value;
                 OnPropertyChanged(nameof(MarkPrice));
+                OnPropertyChanged(nameof(PositionSize));
             }
         }
 
@@ -77,10 +89,15 @@ namespace BinanceUsdtTicker.Models
         }
 
         /// <summary>
+        /// Pozisyon boyutu (notional değeri).
+        /// </summary>
+        public decimal PositionSize => Math.Abs(_markPrice * _positionAmt);
+
+        /// <summary>
         /// Pozisyonun Yatırım Getiri yüzdesi.
         /// </summary>
         public decimal RoiPercent =>
-            _initialMargin != 0m ? _unrealizedPnl / _initialMargin * 100m : 0m;
+            _entryAmount != 0m ? _unrealizedPnl / _entryAmount * 100m : 0m;
 
         private decimal? _closeLimitPrice;
         /// <summary>


### PR DESCRIPTION
## Summary
- calculate leverage directly from position data to fix ROI
- show live-updating position size and new entry amount field

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b1b6b21fc083338e1de571bd96cdf0