### PR TITLE
Fix open positions retrieval endpoint

### DIFF
--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -398,7 +398,7 @@ namespace BinanceUsdtTicker
         /// </summary>
         public async Task<IList<FuturesPosition>> GetOpenPositionsAsync()
         {
-            var json = await SendSignedAsync(HttpMethod.Get, "/fapi/v3/positionRisk");
+            var json = await SendSignedAsync(HttpMethod.Get, "/fapi/v2/positionRisk");
             var positions = new List<FuturesPosition>();
 
             try


### PR DESCRIPTION
## Summary
- correct endpoint for fetching position risk to ensure open positions are retrieved properly

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b864e8288333801c097aa21e1dd9