### PR TITLE
Quantize order params to symbol precision

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1525,6 +1525,10 @@ namespace BinanceUsdtTicker
                     price = px;
             }
 
+            var filters = await _api.GetSymbolFiltersAsync(symbol);
+            if (filters.TickSize > 0m)
+                price = Math.Floor(price / filters.TickSize) * filters.TickSize;
+
             var sizeSlider = tab?.SelectedIndex == 0 ? Q<Slider>("LimitSizeSlider") : Q<Slider>("MarketSizeSlider");
             var percent = (decimal)(sizeSlider?.Value ?? 0d) / 100m;
             var levSlider = Q<Slider>("LeverageSlider");
@@ -1533,6 +1537,8 @@ namespace BinanceUsdtTicker
 
             decimal notional = usdt.Available * leverage * percent;
             decimal qty = price > 0m ? notional / price : 0m;
+            if (filters.StepSize > 0m)
+                qty = Math.Floor(qty / filters.StepSize) * filters.StepSize;
             if (qty <= 0m) return;
 
             var crossBtn = Q<ToggleButton>("CrossMarginButton");

--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -331,7 +331,7 @@ namespace BinanceUsdtTicker
             catch { }
         }
 
-        private async Task<(decimal TickSize, decimal StepSize)> GetSymbolFiltersAsync(string symbol)
+        public async Task<(decimal TickSize, decimal StepSize)> GetSymbolFiltersAsync(string symbol)
         {
             if (_symbolFilters.TryGetValue(symbol, out var f))
                 return f;


### PR DESCRIPTION
## Summary
- Expose symbol precision filters for reuse
- Quantize limit price and order quantity based on Binance tick and step sizes before placing orders

## Testing
- ⚠️ `dotnet build` *(command failed: dotnet not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b1d16aa2048333b8da1e749e62d339