### PR TITLE
Highlight open position side

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -876,7 +876,7 @@
                                                                                 <GridViewColumn Header="Sembol" Width="90">
                                                                                         <GridViewColumn.CellTemplate>
                                                                                                 <DataTemplate>
-                                                                                                        <TextBlock>
+                                                                                                        <TextBlock Foreground="{Binding SideBrush}">
                                                                                                                 <Run Text="{Binding BaseSymbol, Mode=OneWay}"/>
                                                                                                                 <Run Text="/USDT" Foreground="Gray"/>
                                                                                                         </TextBlock>

--- a/Models/FuturesPosition.cs
+++ b/Models/FuturesPosition.cs
@@ -20,6 +20,7 @@ namespace BinanceUsdtTicker.Models
                 _positionAmt = value;
                 OnPropertyChanged(nameof(PositionAmt));
                 OnPropertyChanged(nameof(PositionSize));
+                OnPropertyChanged(nameof(SideBrush));
             }
         }
         public decimal EntryPrice { get; set; }
@@ -116,6 +117,12 @@ namespace BinanceUsdtTicker.Models
 
         public Brush PnlBrush =>
             _unrealizedPnl >= 0m ? Brushes.ForestGreen : Brushes.Red;
+
+        /// <summary>
+        /// Pozisyon yönüne göre sembol rengi.
+        /// </summary>
+        public Brush SideBrush =>
+            _positionAmt >= 0m ? Brushes.Green : Brushes.Red;
 
         public string BaseSymbol =>
             Symbol.EndsWith("USDT", StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
## Summary
- color position symbols green for long and red for short
- add SideBrush property to FuturesPosition with change notifications

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b20634aea08333a94970c460af8f48