### PR TITLE
Centralize account data refresh and defer history updates

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -868,7 +868,7 @@
 
                                 <!-- EMIR VE POZISYONLAR -->
                                 <Expander Grid.Column="0" Header="Emirler" IsExpanded="True" Padding="6,4">
-                                        <TabControl Margin="0,6,0,0">
+                                        <TabControl x:Name="AccountTab" Margin="0,6,0,0" SelectionChanged="AccountTab_SelectionChanged">
                                                 <TabItem Header="Açık Pozisyonlar">
                                                         <ListView x:Name="PositionsList" HorizontalContentAlignment="Stretch">
                                                                 <ListView.View>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -154,9 +154,7 @@ namespace BinanceUsdtTicker
                 ApplyColumnLayoutFromSettings();
                 EnsureSpecialColumnsOrder(); // ★ -> Sembol
                 await InitializeAsync();
-                await LoadWalletAsync();
-                await LoadOpenPositionsAsync();
-                await LoadOpenOrdersAsync();
+                await RefreshAccountDataAsync();
                 await LoadOrderHistoryAsync();
                 await LoadTradeHistoryAsync();
             };
@@ -373,12 +371,16 @@ namespace BinanceUsdtTicker
             catch { }
         }
 
-        private async void RefreshTimer_Tick(object? sender, EventArgs e)
+        private async Task RefreshAccountDataAsync()
         {
+            await LoadWalletAsync();
             await LoadOpenPositionsAsync();
             await LoadOpenOrdersAsync();
-            await LoadOrderHistoryAsync();
-            await LoadTradeHistoryAsync();
+        }
+
+        private async void RefreshTimer_Tick(object? sender, EventArgs e)
+        {
+            await RefreshAccountDataAsync();
         }
 
         private void UpdatePositionPnls()
@@ -1371,6 +1373,22 @@ namespace BinanceUsdtTicker
         {
             if (e.Source is TabControl)
                 UpdatePriceAndSize();
+        }
+
+        private async void AccountTab_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (e.Source is TabControl tc && tc.SelectedItem is TabItem item)
+            {
+                var header = item.Header as string;
+                if (string.Equals(header, "Emir Geçmişi", StringComparison.OrdinalIgnoreCase))
+                {
+                    await LoadOrderHistoryAsync();
+                }
+                else if (string.Equals(header, "Trade Geçmişi", StringComparison.OrdinalIgnoreCase))
+                {
+                    await LoadTradeHistoryAsync();
+                }
+            }
         }
 
         private void UpdateLimitPrice()


### PR DESCRIPTION
## Summary
- Centralize wallet, position, and open order refresh into `RefreshAccountDataAsync`
- Load account history only on startup or when switching tabs via new `AccountTab` handler

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b20871a450833398305278f3576dd1