### PR TITLE
refactor: centralize common model logic

### DIFF
--- a/Models/AlertHit.cs
+++ b/Models/AlertHit.cs
@@ -18,8 +18,6 @@ namespace BinanceUsdtTicker
                 ? string.Empty
                 : TimeZoneInfo.ConvertTimeFromUtc(TimestampUtc, TimeZoneInfo.Local).ToString("HH:mm:ss");
 
-        public string BaseSymbol => Symbol?.EndsWith("USDT", StringComparison.OrdinalIgnoreCase) == true
-            ? Symbol[..^4]
-            : Symbol ?? string.Empty;
+        public string BaseSymbol => Symbol.ToBaseSymbol();
     }
 }

--- a/Models/BindableBase.cs
+++ b/Models/BindableBase.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace BinanceUsdtTicker
+{
+    public abstract class BindableBase : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+        protected void OnPropertyChanged([CallerMemberName] string? name = null) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/Models/FuturesOrder.cs
+++ b/Models/FuturesOrder.cs
@@ -14,9 +14,6 @@ namespace BinanceUsdtTicker.Models
         public string Status { get; set; } = string.Empty;
         public DateTime Time { get; set; }
 
-        public string BaseSymbol =>
-            Symbol.EndsWith("USDT", StringComparison.OrdinalIgnoreCase)
-                ? Symbol[..^4]
-                : Symbol;
+        public string BaseSymbol => Symbol.ToBaseSymbol();
     }
 }

--- a/Models/FuturesPosition.cs
+++ b/Models/FuturesPosition.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel;
 using System.Windows.Media;
 
 namespace BinanceUsdtTicker.Models
@@ -7,7 +6,7 @@ namespace BinanceUsdtTicker.Models
     /// <summary>
     /// Temel vadeli işlem pozisyon bilgisi.
     /// </summary>
-    public class FuturesPosition : INotifyPropertyChanged
+    public class FuturesPosition : BindableBase
     {
         public string Symbol { get; set; } = string.Empty;
         private decimal _positionAmt;
@@ -124,13 +123,6 @@ namespace BinanceUsdtTicker.Models
         public Brush SideBrush =>
             _positionAmt >= 0m ? Brushes.Green : Brushes.Red;
 
-        public string BaseSymbol =>
-            Symbol.EndsWith("USDT", StringComparison.OrdinalIgnoreCase)
-                ? Symbol[..^4]
-                : Symbol;
-
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged(string name) =>
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        public string BaseSymbol => Symbol.ToBaseSymbol();
     }
 }

--- a/Models/FuturesTrade.cs
+++ b/Models/FuturesTrade.cs
@@ -15,10 +15,7 @@ namespace BinanceUsdtTicker.Models
         public decimal RealizedPnl { get; set; }
         public DateTime Time { get; set; }
 
-        public string BaseSymbol =>
-            Symbol.EndsWith("USDT", StringComparison.OrdinalIgnoreCase)
-                ? Symbol[..^4]
-                : Symbol;
+        public string BaseSymbol => Symbol.ToBaseSymbol();
 
         public decimal NetProfit => RealizedPnl - Fee;
     }

--- a/Models/SymbolExtensions.cs
+++ b/Models/SymbolExtensions.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace BinanceUsdtTicker
+{
+    public static class SymbolExtensions
+    {
+        public static string ToBaseSymbol(this string? symbol)
+        {
+            if (string.IsNullOrWhiteSpace(symbol))
+                return string.Empty;
+
+            return symbol.EndsWith("USDT", StringComparison.OrdinalIgnoreCase)
+                ? symbol[..^4]
+                : symbol;
+        }
+    }
+}

--- a/Models/TickerRow.cs
+++ b/Models/TickerRow.cs
@@ -1,16 +1,11 @@
 ﻿using System;
-using System.ComponentModel;
-
 namespace BinanceUsdtTicker
-{
-    public class TickerRow : INotifyPropertyChanged
+{ 
+    public class TickerRow : BindableBase
     {
         public string Symbol { get; set; } = string.Empty;
 
-        public string BaseSymbol =>
-            !string.IsNullOrEmpty(Symbol) && Symbol.EndsWith("USDT", StringComparison.OrdinalIgnoreCase)
-                ? Symbol[..^4]
-                : Symbol;
+        public string BaseSymbol => Symbol.ToBaseSymbol();
 
         private decimal _price;
         public decimal Price
@@ -132,9 +127,5 @@ namespace BinanceUsdtTicker
                 ChangeSinceStartPercent = 0m;
             }
         }
-
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged(string name) =>
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
     }
 }

--- a/Models/UiSettings.cs
+++ b/Models/UiSettings.cs
@@ -1,10 +1,8 @@
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
 
 namespace BinanceUsdtTicker.Models
 {
-    public class UiSettings : INotifyPropertyChanged
+    public class UiSettings : BindableBase
     {
         private string _theme = "Light";
         public string Theme
@@ -111,8 +109,5 @@ namespace BinanceUsdtTicker.Models
             set { if (_binanceApiSecret != value) { _binanceApiSecret = value; OnPropertyChanged(); } }
         }
 
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string? name = null) =>
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
     }
 }

--- a/Models/WalletAsset.cs
+++ b/Models/WalletAsset.cs
@@ -1,9 +1,6 @@
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-
 namespace BinanceUsdtTicker.Models
 {
-    public class WalletAsset : INotifyPropertyChanged
+    public class WalletAsset : BindableBase
     {
         private string _asset = string.Empty;
         public string Asset
@@ -26,8 +23,5 @@ namespace BinanceUsdtTicker.Models
             set { if (_available != value) { _available = value; OnPropertyChanged(); } }
         }
 
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string? name = null) =>
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
     }
 }


### PR DESCRIPTION
## Summary
- add `BindableBase` to share property change notifications
- introduce `SymbolExtensions.ToBaseSymbol` and refactor models to use it
- simplify models by inheriting `BindableBase`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2099f6ff883339c693ad9a68a270e