### PR TITLE
Fix leverage bracket dictionary instantiation

### DIFF
--- a/Services/Trading/OrderPreviewService.cs
+++ b/Services/Trading/OrderPreviewService.cs
@@ -271,7 +271,11 @@ namespace BinanceUsdtTicker.Trading
 
         public async Task<List<LeverageBracket>> GetLeverageBracketsAsync(string symbol, CancellationToken ct)
         {
-            var s = await SendSignedAsync(HttpMethod.Get, "/fapi/v1/leverageBracket", new() { ["symbol"] = symbol }, ct);
+            var s = await SendSignedAsync(
+                HttpMethod.Get,
+                "/fapi/v1/leverageBracket",
+                new Dictionary<string, string> { ["symbol"] = symbol },
+                ct);
             if (s.TrimStart().StartsWith("["))
                 return JsonSerializer.Deserialize<List<LeverageBracket>>(s, JsonOptions) ?? new();
             var one = JsonSerializer.Deserialize<LeverageBracketSingle>(s, JsonOptions);


### PR DESCRIPTION
## Summary
- use concrete `Dictionary<string,string>` when building leverage bracket request
- format leverage bracket API call over multiple lines for clarity

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b20d3ea07083339d2254d90bdd2712