### PR TITLE
fix: close namespace scope

### DIFF
--- a/Services/Trading/OrderPreviewService.cs
+++ b/Services/Trading/OrderPreviewService.cs
@@ -264,3 +264,5 @@ namespace BinanceUsdtTicker.Trading
     }
 
 #endregion
+
+}


### PR DESCRIPTION
## Summary
- add missing closing brace for BinanceUsdtTicker.Trading namespace

## Testing
- `dotnet restore` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b21e5743b883339f6f098e20a1140b