### PR TITLE
Fix missing model namespace in BinanceApiService

### DIFF
--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Threading;
 using System.Text.Json.Serialization;
 using System.Globalization;
+using BinanceUsdtTicker.Models;
 
 
 namespace BinanceUsdtTicker


### PR DESCRIPTION
## Summary
- reference Models namespace in BinanceApiService so model types resolve

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b21fc4deec83338c92a712789d7390