### PR TITLE
Fix leverage bracket type mismatch

### DIFF
--- a/Services/Trading/OrderPreviewService.cs
+++ b/Services/Trading/OrderPreviewService.cs
@@ -248,7 +248,7 @@ namespace BinanceUsdtTicker.Trading
         LotSizeFilter Lot,
         MarketLotSizeFilter? MarketLot,
         decimal? MinNotional,
-        List<LeverageBracket> Brackets)
+        IList<LeverageBracket> Brackets)
     {
         public decimal? ResolveNotionalCapForLeverage(int leverage)
         {


### PR DESCRIPTION
## Summary
- Align `SymbolMeta` leverage bracket type with API method

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2236c85e88333a028cb6ffe6c4451