### PR TITLE
Integrate MahApps Metro DataGrid style

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -5,11 +5,15 @@
 	<Application.Resources>
 		<ResourceDictionary>
 			<ResourceDictionary.MergedDictionaries>
-				<!-- Styles first (uses DynamicResource), then default theme -->
+                                <!-- MahApps.Metro styles -->
+                                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml"/>
+                                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.DataGrid.xaml"/>
+
+                                <!-- Styles first (uses DynamicResource), then default theme -->
                                 <ResourceDictionary Source="Themes/Styles.Toolbar.xaml"/>
                                 <ResourceDictionary Source="Themes/Styles.Base.xaml"/>
                                 <ResourceDictionary Source="Themes/Light.xaml"/>
-			</ResourceDictionary.MergedDictionaries>
-		</ResourceDictionary>
-	</Application.Resources>
+                        </ResourceDictionary.MergedDictionaries>
+                </ResourceDictionary>
+        </Application.Resources>
 </Application>

--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1823.32" />
+    <PackageReference Include="MahApps.Metro" Version="2.4.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -405,6 +405,7 @@
 
                         <!-- FİYAT TABLOSU -->
                         <DataGrid x:Name="Grid"
+                      Style="{DynamicResource MahApps.Styles.DataGrid.Azure}"
                       Grid.Row="0" Grid.Column="1"
                       AutoGenerateColumns="False"
                       EnableRowVirtualization="True"
@@ -412,8 +413,6 @@
                       CanUserSortColumns="True"
                       CanUserReorderColumns="True"
                       HeadersVisibility="Column"
-                      Background="{DynamicResource SurfaceAlt}"
-                      Foreground="{DynamicResource OnSurface}"
                       GridLinesVisibility="None"
                       ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="0,0,8,0"
                       SelectionChanged="Grid_SelectionChanged">


### PR DESCRIPTION
## Summary
- Add MahApps.Metro package for modern DataGrid styles
- Merge MahApps resource dictionaries in App.xaml
- Apply Azure-themed MahApps DataGrid style to the main coin grid

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b227d1234483339939b1f6f0d3eb23