### PR TITLE
feat(ui): apply material design grid styling

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -4,10 +4,16 @@
              StartupUri="MainWindow.xaml">
 	<Application.Resources>
 		<ResourceDictionary>
-			<ResourceDictionary.MergedDictionaries>
+                        <ResourceDictionary.MergedDictionaries>
                                 <!-- MahApps.Metro styles -->
                                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml"/>
                                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.DataGrid.xaml"/>
+
+                                <!-- Material Design styles -->
+                                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml"/>
+                                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml"/>
+                                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.Blue.xaml"/>
+                                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml"/>
 
                                 <!-- Styles first (uses DynamicResource), then default theme -->
                                 <ResourceDictionary Source="Themes/Styles.Toolbar.xaml"/>

--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -11,6 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1823.32" />
     <PackageReference Include="MahApps.Metro" Version="2.4.9" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.9.0" />
+    <PackageReference Include="MaterialDesignColors" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
         xmlns:local="clr-namespace:BinanceUsdtTicker"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
         Title="Binance USDT Canlı Fiyatlar"
         Height="680" Width="1100" MinHeight="500" MinWidth="900"
         Background="{DynamicResource Surface}"
@@ -62,23 +63,23 @@
                 </Style>
 
                 <!-- DataGrid başlığı -->
-                <Style TargetType="DataGridColumnHeader">
-			<Setter Property="Background"  Value="{DynamicResource HeaderBg}"/>
-			<Setter Property="Foreground"  Value="{DynamicResource HeaderFg}"/>
-			<Setter Property="BorderBrush" Value="{DynamicResource HeaderBorder}"/>
-			<Setter Property="BorderThickness" Value="0,0,1,1"/>
-			<Setter Property="FontWeight"  Value="SemiBold"/>
-			<Setter Property="HorizontalContentAlignment" Value="Center"/>
-			<Setter Property="Padding" Value="6,3"/>
-			<Style.Triggers>
-				<Trigger Property="IsMouseOver" Value="True">
-					<Setter Property="Background" Value="{DynamicResource HeaderHoverBg}"/>
-				</Trigger>
-				<Trigger Property="IsPressed" Value="True">
-					<Setter Property="Background" Value="{DynamicResource HeaderHoverBg}"/>
-				</Trigger>
-			</Style.Triggers>
-		</Style>
+                <Style TargetType="DataGridColumnHeader" BasedOn="{StaticResource MaterialDesignDataGridColumnHeader}">
+                        <Setter Property="Background"  Value="{DynamicResource HeaderBg}"/>
+                        <Setter Property="Foreground"  Value="{DynamicResource HeaderFg}"/>
+                        <Setter Property="BorderBrush" Value="{DynamicResource HeaderBorder}"/>
+                        <Setter Property="BorderThickness" Value="0,0,1,1"/>
+                        <Setter Property="FontWeight"  Value="SemiBold"/>
+                        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                        <Setter Property="Padding" Value="6,3"/>
+                        <Style.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                        <Setter Property="Background" Value="{DynamicResource HeaderHoverBg}"/>
+                                </Trigger>
+                                <Trigger Property="IsPressed" Value="True">
+                                        <Setter Property="Background" Value="{DynamicResource HeaderHoverBg}"/>
+                                </Trigger>
+                        </Style.Triggers>
+                </Style>
 
 		<!-- GridView başlığı -->
 		<Style TargetType="{x:Type GridViewColumnHeader}">
@@ -159,7 +160,7 @@
                 </Style>
 
 		<!-- DataGrid hücre -->
-                <Style TargetType="DataGridCell">
+                <Style TargetType="DataGridCell" BasedOn="{StaticResource MaterialDesignDataGridCell}">
                         <Setter Property="BorderBrush" Value="{DynamicResource Divider}"/>
                         <Style.Triggers>
                                 <Trigger Property="IsSelected" Value="True">
@@ -169,7 +170,7 @@
                         </Style.Triggers>
                 </Style>
 
-                <Style TargetType="DataGridRowHeader">
+                <Style TargetType="DataGridRowHeader" BasedOn="{StaticResource MaterialDesignDataGridRowHeader}">
                         <Setter Property="Background"  Value="{DynamicResource SurfaceAlt}"/>
                         <Setter Property="Foreground"  Value="{DynamicResource OnSurface}"/>
                         <Setter Property="BorderBrush" Value="{DynamicResource Divider}"/>
@@ -405,7 +406,7 @@
 
                         <!-- FİYAT TABLOSU -->
                         <DataGrid x:Name="Grid"
-                      Style="{DynamicResource MahApps.Styles.DataGrid.Azure}"
+                      Style="{DynamicResource MaterialDesignDataGrid}"
                       Grid.Row="0" Grid.Column="1"
                       AutoGenerateColumns="False"
                       EnableRowVirtualization="True"
@@ -419,7 +420,7 @@
 
 				<!-- Satır stili -->
                                 <DataGrid.RowStyle>
-                                        <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                                        <Style TargetType="DataGridRow" BasedOn="{StaticResource MaterialDesignDataGridRow}">
                                                 <Style.Triggers>
                                                         <!-- Renklendirme -->
                                                        <DataTrigger Binding="{Binding IsMove3Plus}" Value="True">
@@ -447,7 +448,7 @@
 
                                 <!-- Hücre stili -->
                                 <DataGrid.CellStyle>
-                                        <Style TargetType="DataGridCell" BasedOn="{StaticResource {x:Type DataGridCell}}">
+                                        <Style TargetType="DataGridCell" BasedOn="{StaticResource MaterialDesignDataGridCell}">
                                                 <Style.Triggers>
                                                         <DataTrigger Binding="{Binding IsMove3Plus}" Value="True">
                                                                 <Setter Property="Foreground" Value="{DynamicResource Up3Fg}"/>

--- a/Windows/ManageAlertsWindow.xaml
+++ b/Windows/ManageAlertsWindow.xaml
@@ -3,6 +3,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:BinanceUsdtTicker"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
         Title="Alarmları Yönet"
         Width="760" Height="420"
         WindowStartupLocation="CenterOwner"
@@ -23,6 +24,7 @@
 
         <!-- ALARM LİSTESİ -->
         <DataGrid x:Name="Grid"
+                  Style="{DynamicResource MaterialDesignDataGrid}"
                   Grid.Row="0"
                   ItemsSource="{Binding WorkingAlerts}"
                   AutoGenerateColumns="False"
@@ -41,11 +43,11 @@
 
             <DataGrid.Resources>
                 <!-- Single-click edit -->
-                <Style TargetType="DataGridCell">
+                <Style TargetType="DataGridCell" BasedOn="{StaticResource MaterialDesignDataGridCell}">
                     <EventSetter Event="PreviewMouseLeftButtonDown" Handler="Grid_CellPreviewMouseLeftButtonDown"/>
                 </Style>
                 <!-- Extra spacing between rows -->
-                <Style TargetType="DataGridRow">
+                <Style TargetType="DataGridRow" BasedOn="{StaticResource MaterialDesignDataGridRow}">
                     <Setter Property="Margin" Value="0,3"/>
                 </Style>
             </DataGrid.Resources>


### PR DESCRIPTION
## Summary
- add Material Design theme packages and resources
- restyle main and alert grids with MaterialDesignDataGrid for a modern look

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b229004d2c83338f964d8278249a44