### PR TITLE
Fix MaterialDesignColors package downgrade

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1823.32" />
     <PackageReference Include="MahApps.Metro" Version="2.4.9" />
     <PackageReference Include="MaterialDesignThemes" Version="4.9.0" />
-    <PackageReference Include="MaterialDesignColors" Version="2.1.2" />
+    <PackageReference Include="MaterialDesignColors" Version="2.1.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Align MaterialDesignColors package with MaterialDesignThemes dependency

## Testing
- `dotnet restore` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b231829e20833397167e13f86f9778