### PR TITLE
Fix MaterialDesign pack URI

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -10,8 +10,8 @@
                                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.DataGrid.xaml"/>
 
                                 <!-- Material Design styles -->
-                                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes;component/Themes/MaterialDesignTheme.Light.xaml"/>
-                                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes;component/Themes/MaterialDesignTheme.Defaults.xaml"/>
+                                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml"/>
+                                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml"/>
                                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.Blue.xaml"/>
                                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml"/>
 


### PR DESCRIPTION
## Summary
- fix MaterialDesignThemes resource dictionary references to point at MaterialDesignThemes.Wpf assembly

## Testing
- `dotnet build` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68b232cce1c88333ae839f400f2c19a4