### PR TITLE
Fix DataGrid column header property to restore build

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -415,7 +415,7 @@
                       CanUserSortColumns="True"
                       CanUserReorderColumns="True"
                       HeadersVisibility="Column"
-                      materialDesign:DataGridAssist.ColumnHeaderHeight="32"
+                      ColumnHeaderHeight="32"
                       GridLinesVisibility="None"
                       ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="0,0,8,0"
                       SelectionChanged="Grid_SelectionChanged">


### PR DESCRIPTION
## Summary
- Replace `DataGridAssist.ColumnHeaderHeight` with standard `ColumnHeaderHeight` on price grid

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b23531be748333b9ab76f6c8cea0b8