### PR TITLE
Adjust star/chart column widths and header colors

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -472,8 +472,8 @@
                                 <DataGrid.Columns>
 
 					<!-- 0) ⭐ Favori -->
-					<DataGridTemplateColumn x:Name="ColStar"
-                                            Header="★" Width="32"
+                                        <DataGridTemplateColumn x:Name="ColStar"
+                                            Header="★" Width="48"
                                             IsReadOnly="True" CanUserSort="False">
 						<DataGridTemplateColumn.CellTemplate>
 							<DataTemplate>
@@ -495,7 +495,7 @@
 
                                         <!-- 1) Grafik -->
                                         <DataGridTemplateColumn x:Name="ColChart"
-                                            Header="Grafik" Width="32"
+                                            Header="Grafik" Width="48"
                                             IsReadOnly="True" CanUserSort="False">
                                                 <DataGridTemplateColumn.CellTemplate>
                                                         <DataTemplate>

--- a/Themes/Dark.xaml
+++ b/Themes/Dark.xaml
@@ -9,7 +9,7 @@
     <SolidColorBrush x:Key="Divider"        Color="#FF2E3239"/>
 
     <SolidColorBrush x:Key="HeaderBg"       Color="#FF0B0E11"/>
-    <SolidColorBrush x:Key="HeaderFg"       Color="#FFEAECEF"/>
+    <SolidColorBrush x:Key="HeaderFg"       Color="#FFFFFFFF"/>
     <SolidColorBrush x:Key="HeaderBorder"   Color="#FF2E3239"/>
 
     <SolidColorBrush x:Key="RowBg"          Color="#FF181A20"/>

--- a/Themes/Light.xaml
+++ b/Themes/Light.xaml
@@ -9,7 +9,7 @@
     <SolidColorBrush x:Key="Divider"        Color="#FFE5E7EB"/>
 
     <SolidColorBrush x:Key="HeaderBg"       Color="#FFF3F4F6"/>
-    <SolidColorBrush x:Key="HeaderFg"       Color="#FF111827"/>
+    <SolidColorBrush x:Key="HeaderFg"       Color="#FF000000"/>
     <SolidColorBrush x:Key="HeaderBorder"   Color="#FFE5E7EB"/>
 
     <SolidColorBrush x:Key="RowBg"          Color="#FFFFFFFF"/>


### PR DESCRIPTION
## Summary
- Widen star and chart columns for easier interaction
- Boost header text contrast in light and dark themes

## Testing
- ⚠️ `dotnet build` *(dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2361ca4408333a55e7cd23f2a9753