### PR TITLE
Add News panel and remove redundant grid columns

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -403,6 +403,7 @@
                                 <ColumnDefinition Width="300"/>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="260"/>
+                                <ColumnDefinition Width="260"/>
                         </Grid.ColumnDefinitions>
 
                         <!-- FİYAT TABLOSU -->
@@ -595,43 +596,8 @@
 						</DataGridTextColumn.ElementStyle>
 					</DataGridTextColumn>
 
-					<!-- Detay kolonları -->
-					<DataGridTextColumn x:Name="ColOpen" Header="Açılış"
-                                        Visibility="Visible"
-                                        Width="0.8*" MinWidth="70"
-                                        Binding="{Binding Open, StringFormat={}{0:#,0.########}}">
-						<DataGridTextColumn.ElementStyle>
-							<Style TargetType="TextBlock">
-								<Setter Property="TextAlignment" Value="Right"/>
-								<Setter Property="TextTrimming" Value="CharacterEllipsis"/>
-							</Style>
-						</DataGridTextColumn.ElementStyle>
-					</DataGridTextColumn>
-					<DataGridTextColumn x:Name="ColHigh" Header="Yüksek"
-                                        Visibility="Visible"
-                                        Width="0.8*" MinWidth="70"
-                                        Binding="{Binding High, StringFormat={}{0:#,0.########}}">
-						<DataGridTextColumn.ElementStyle>
-							<Style TargetType="TextBlock">
-								<Setter Property="TextAlignment" Value="Right"/>
-								<Setter Property="TextTrimming" Value="CharacterEllipsis"/>
-							</Style>
-						</DataGridTextColumn.ElementStyle>
-					</DataGridTextColumn>
-					<DataGridTextColumn x:Name="ColLow" Header="Düşük"
-                                        Visibility="Visible"
-                                        Width="0.8*" MinWidth="70"
-                                        Binding="{Binding Low, StringFormat={}{0:#,0.########}}">
-						<DataGridTextColumn.ElementStyle>
-							<Style TargetType="TextBlock">
-								<Setter Property="TextAlignment" Value="Right"/>
-								<Setter Property="TextTrimming" Value="CharacterEllipsis"/>
-							</Style>
-						</DataGridTextColumn.ElementStyle>
-					</DataGridTextColumn>
-
-					<!-- Hacim -->
-					<DataGridTextColumn x:Name="ColVol" Header="Hacim"
+                                        <!-- Hacim -->
+                                        <DataGridTextColumn x:Name="ColVol" Header="Hacim"
                                         Width="1.3*" MinWidth="110"
                                         Binding="{Binding Volume, StringFormat={}{0:#,0.##}}">
 						<DataGridTextColumn.ElementStyle>
@@ -730,8 +696,17 @@
                                 </StackPanel>
                         </GroupBox>
 
+                        <!-- NEWS -->
+                        <GroupBox Grid.Row="0" Grid.Column="2" Header="News" Margin="0,0,8,0"
+                      Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
+                      VerticalAlignment="Stretch" BorderBrush="{DynamicResource Divider}">
+                                <Grid>
+                                        <TextBlock Text="News feed coming soon." HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                </Grid>
+                        </GroupBox>
+
                         <!-- TOP MOVERS -->
-                        <GroupBox Grid.Row="0" Grid.Column="2" Header="Top Movers" Margin="0,0,8,0"
+                        <GroupBox Grid.Row="0" Grid.Column="3" Header="Top Movers" Margin="0,0,8,0"
                       Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
                       VerticalAlignment="Stretch" BorderBrush="{DynamicResource Divider}">
 				<Grid>
@@ -861,7 +836,7 @@
 			</GroupBox>
 
                         <!-- ALARM VE CÜZDAN -->
-                        <Grid Grid.Row="1" Grid.ColumnSpan="3">
+                        <Grid Grid.Row="1" Grid.ColumnSpan="4">
                                   <Grid.ColumnDefinitions>
                                           <ColumnDefinition Width="3*"/>
                                           <ColumnDefinition Width="*"/>


### PR DESCRIPTION
## Summary
- remove Open/High/Low columns from main price grid
- add new News panel placeholder and shift Top Movers to the right
- update layout to include additional column and expand footer span

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b9b90ce083338452432e39c8f832