### PR TITLE
Split central area between coin list and news feed

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -402,7 +402,7 @@
                                 <!-- Futures panel expanded for better usability -->
                                 <ColumnDefinition Width="300"/>
                                 <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="260"/>
+                                <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="260"/>
                         </Grid.ColumnDefinitions>
 


### PR DESCRIPTION
## Summary
- Split middle section between coin list and news by giving both columns equal width

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 and not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2bc2ca6f08333a8762cdfe13b77c0