### PR TITLE
Wrap coin grid headers

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -416,10 +416,22 @@
                       CanUserSortColumns="True"
                       CanUserReorderColumns="True"
                       HeadersVisibility="Column"
-                      ColumnHeaderHeight="32"
+                      ColumnHeaderHeight="Auto"
                       GridLinesVisibility="None"
                       ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="0,0,8,0"
                       SelectionChanged="Grid_SelectionChanged">
+
+                                <DataGrid.ColumnHeaderStyle>
+                                        <Style TargetType="DataGridColumnHeader" BasedOn="{StaticResource {x:Type DataGridColumnHeader}}">
+                                                <Setter Property="ContentTemplate">
+                                                        <Setter.Value>
+                                                                <DataTemplate>
+                                                                        <TextBlock Text="{Binding}" TextWrapping="Wrap" TextAlignment="Center"/>
+                                                                </DataTemplate>
+                                                        </Setter.Value>
+                                                </Setter>
+                                        </Style>
+                                </DataGrid.ColumnHeaderStyle>
 
 				<!-- Satır stili -->
                                 <DataGrid.RowStyle>


### PR DESCRIPTION
## Summary
- allow coin grid column headers to auto-fit by wrapping text

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2bd902cf88333aa05976687759f1a