### PR TITLE
Fix invalid ColumnHeaderHeight value in MainWindow DataGrid

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -416,7 +416,6 @@
                       CanUserSortColumns="True"
                       CanUserReorderColumns="True"
                       HeadersVisibility="Column"
-                      ColumnHeaderHeight="Auto"
                       GridLinesVisibility="None"
                       ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="0,0,8,0"
                       SelectionChanged="Grid_SelectionChanged">


### PR DESCRIPTION
## Summary
- remove ColumnHeaderHeight="Auto" from DataGrid so headers size automatically without parsing error

## Testing
- ⚠️ `dotnet build` *(dotnet not installed; apt-get update 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b2be7670948333aefdf0a5d6786316