### PR TITLE
Integrate TreeNews feed into News section

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -711,9 +711,20 @@
                         <GroupBox Grid.Row="0" Grid.Column="2" Header="News" Margin="0,0,8,0"
                       Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
                       VerticalAlignment="Stretch" BorderBrush="{DynamicResource Divider}">
-                                <Grid>
-                                        <TextBlock Text="News feed coming soon." HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                </Grid>
+                                <ListView x:Name="NewsList"
+                              Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
+                              ScrollViewer.VerticalScrollBarVisibility="Auto"
+                              VirtualizingStackPanel.IsVirtualizing="True"
+                              VirtualizingStackPanel.VirtualizationMode="Recycling">
+                                        <ListView.ItemTemplate>
+                                                <DataTemplate>
+                                                        <StackPanel Margin="0,2">
+                                                                <TextBlock Text="{Binding Title}" TextWrapping="Wrap"/>
+                                                                <TextBlock Text="{Binding Symbols}" FontSize="11" Foreground="Gray"/>
+                                                        </StackPanel>
+                                                </DataTemplate>
+                                        </ListView.ItemTemplate>
+                                </ListView>
                         </GroupBox>
 
                         <!-- TOP MOVERS -->


### PR DESCRIPTION
## Summary
- Replace placeholder with a News list and bind it to incoming TreeNews items
- Wire up TreeTokyoNewsService to populate the News list and cleanly manage lifecycle

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cc3206188333b1745a942ab68548