### PR TITLE
Fix missing Services namespace

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -19,7 +19,6 @@ using System.Windows.Controls.Primitives; // ToggleButton burada
 using System.Windows.Threading; // en üstte varsa gerekmez
 using WinForms = System.Windows.Forms;
 using BinanceUsdtTicker.Models;
-using BinanceUsdtTicker.Services;
 
 namespace BinanceUsdtTicker
 {


### PR DESCRIPTION
## Summary
- fix compile error by removing nonexistent Services namespace from MainWindow

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d746b05883339dab93b7d94cebd3