### PR TITLE
Remove async from settings handler to silence warning

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -290,7 +290,7 @@ namespace BinanceUsdtTicker
             ApplyCustomColors();
         }
 
-        private async void SettingsButton_Click(object sender, RoutedEventArgs e)
+        private void SettingsButton_Click(object sender, RoutedEventArgs e)
         {
             var win = new SettingsWindow(_ui) { Owner = this };
             if (win.ShowDialog() == true)


### PR DESCRIPTION
## Summary
- remove unnecessary async keyword from Settings button handler

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d86b898483339285fb67ee809dd0