### PR TITLE
Integrate free news hub service

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,3 +1,33 @@
+using System;
+using System.Windows;
+
 namespace BinanceUsdtTicker;
 
-public partial class App : System.Windows.Application { }
+public partial class App : Application
+{
+    private FreeNewsHubService? _newsHub;
+
+    protected override async void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+        _newsHub = new FreeNewsHubService(new FreeNewsOptions
+        {
+            PollInterval = TimeSpan.FromSeconds(5),
+            CryptoPanicToken = string.Empty
+        });
+        await _newsHub.StartAsync();
+        _newsHub.NewsReceived += OnNewsReceived;
+    }
+
+    private void OnNewsReceived(object? sender, NewsItem item)
+    {
+        // TODO: handle incoming news items (e.g., update UI or log)
+    }
+
+    protected override async void OnExit(ExitEventArgs e)
+    {
+        if (_newsHub != null)
+            await _newsHub.DisposeAsync();
+        base.OnExit(e);
+    }
+}

--- a/Enums.cs
+++ b/Enums.cs
@@ -3,4 +3,5 @@ namespace BinanceUsdtTicker
     public enum FilterMode { All, Positive, Negative }
     public enum ThemeKind { Light, Dark }
     public enum QuickFilter { None, Pos3Plus, Neg3Minus }
+    public enum NewsType { General, Listing, Delisting, Maintenance, Regulatory }
 }

--- a/Models/FreeNewsOptions.cs
+++ b/Models/FreeNewsOptions.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace BinanceUsdtTicker
+{
+    public class FreeNewsOptions
+    {
+        public TimeSpan PollInterval { get; set; } = TimeSpan.FromMinutes(1);
+        public string? CryptoPanicToken { get; set; }
+    }
+}

--- a/Models/NewsItem.cs
+++ b/Models/NewsItem.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace BinanceUsdtTicker
+{
+    public class NewsItem : EventArgs
+    {
+        public NewsItem(string id, string source, DateTime timestamp, string title, string? body, string link, NewsType type, IReadOnlyList<string> symbols)
+        {
+            Id = id;
+            Source = source;
+            Timestamp = timestamp;
+            Title = title;
+            Body = body;
+            Link = link;
+            Type = type;
+            Symbols = symbols;
+        }
+
+        public string Id { get; }
+        public string Source { get; }
+        public DateTime Timestamp { get; }
+        public string Title { get; }
+        public string? Body { get; }
+        public string Link { get; }
+        public NewsType Type { get; }
+        public IReadOnlyList<string> Symbols { get; }
+    }
+}

--- a/Services/FreeNewsHubService.cs
+++ b/Services/FreeNewsHubService.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BinanceUsdtTicker
+{
+    public class FreeNewsHubService : IAsyncDisposable
+    {
+        private readonly FreeNewsOptions _options;
+        private readonly HttpClient _httpClient = new();
+        private readonly HashSet<string> _dedup = new(StringComparer.Ordinal);
+        private CancellationTokenSource? _cts;
+        private Task? _loop;
+
+        public event EventHandler<NewsItem>? NewsReceived;
+
+        public FreeNewsHubService(FreeNewsOptions options)
+        {
+            _options = options;
+        }
+
+        public Task StartAsync()
+        {
+            _cts = new CancellationTokenSource();
+            _loop = Task.Run(() => PollAsync(_cts.Token));
+            return Task.CompletedTask;
+        }
+
+        private async Task PollAsync(CancellationToken ct)
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    var items = new List<NewsItem>();
+                    items.AddRange(await FetchBybitAsync());
+                    items.AddRange(await FetchKuCoinAsync());
+                    items.AddRange(await FetchOkxAsync());
+                    if (!string.IsNullOrEmpty(_options.CryptoPanicToken))
+                        items.AddRange(await FetchCryptoPanicAsync(_options.CryptoPanicToken));
+
+                    foreach (var item in items)
+                    {
+                        if (_dedup.Add(item.Id))
+                            NewsReceived?.Invoke(this, item);
+                    }
+                }
+                catch
+                {
+                    // ignore
+                }
+
+                try
+                {
+                    await Task.Delay(_options.PollInterval, ct);
+                }
+                catch (TaskCanceledException)
+                {
+                    break;
+                }
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_cts != null)
+            {
+                _cts.Cancel();
+                if (_loop != null)
+                {
+                    try { await _loop; } catch { }
+                }
+                _cts.Dispose();
+            }
+            _httpClient.Dispose();
+        }
+
+        private async Task<IList<NewsItem>> FetchBybitAsync()
+        {
+            var list = new List<NewsItem>();
+            try
+            {
+                var html = await _httpClient.GetStringAsync("https://announcements.bybit.com/en-US/?category=new-listing");
+                var rx = new Regex("<a[^>]+href=\"(?<link>/en-US/article/[^"]+)\"[^>]*>(?<title>[^<]+)</a>.*?<time[^>]+datetime=\"(?<time>[^"]+)\"", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+                foreach (Match m in rx.Matches(html))
+                {
+                    var link = "https://announcements.bybit.com" + m.Groups["link"].Value;
+                    var title = HtmlDecode(m.Groups["title"].Value.Trim());
+                    if (DateTime.TryParse(m.Groups["time"].Value, out var ts))
+                    {
+                        var type = Classify(title);
+                        list.Add(new NewsItem(id: $"bybit::{link}", source: "bybit", timestamp: ts, title: title, body: null, link: link, type: type, symbols: ExtractSymbols(title)));
+                    }
+                }
+            }
+            catch { }
+            return list;
+        }
+
+        private async Task<IList<NewsItem>> FetchKuCoinAsync()
+        {
+            var list = new List<NewsItem>();
+            try
+            {
+                var html = await _httpClient.GetStringAsync("https://www.kucoin.com/news/categories/listing");
+                var rx = new Regex("<a[^>]+href=\"(?<link>/news/[^"]+)\"[^>]*>(?<title>[^<]+)</a>.*?<time[^>]*>(?<time>[^<]+)</time>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+                foreach (Match m in rx.Matches(html))
+                {
+                    var link = "https://www.kucoin.com" + m.Groups["link"].Value;
+                    var title = HtmlDecode(m.Groups["title"].Value.Trim());
+                    if (DateTime.TryParse(m.Groups["time"].Value, out var ts))
+                    {
+                        var type = Classify(title);
+                        list.Add(new NewsItem(id: $"kucoin::{link}", source: "kucoin", timestamp: ts, title: title, body: null, link: link, type: type, symbols: ExtractSymbols(title)));
+                    }
+                }
+            }
+            catch { }
+            return list;
+        }
+
+        private async Task<IList<NewsItem>> FetchOkxAsync()
+        {
+            var list = new List<NewsItem>();
+            try
+            {
+                var html = await _httpClient.GetStringAsync("https://www.okx.com/announcements/category/listing");
+                var rx = new Regex("<a[^>]+href=\"(?<link>[^"]+)\"[^>]*class=\"[^\"]*announcement-item[^\"]*\"[^>]*>\\s*<div[^>]*class=\"[^\"]*title[^\"]*\">(?<title>[^<]+)</div>\\s*<div[^>]*class=\"[^\"]*time[^\"]*\">(?<time>[^<]+)</div>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+                foreach (Match m in rx.Matches(html))
+                {
+                    var link = "https://www.okx.com" + m.Groups["link"].Value;
+                    var title = HtmlDecode(m.Groups["title"].Value.Trim());
+                    if (DateTime.TryParse(m.Groups["time"].Value, out var ts))
+                    {
+                        var type = Classify(title);
+                        list.Add(new NewsItem(id: $"okx::{link}", source: "okx", timestamp: ts, title: title, body: null, link: link, type: type, symbols: ExtractSymbols(title)));
+                    }
+                }
+            }
+            catch { }
+            return list;
+        }
+
+        private async Task<IList<NewsItem>> FetchCryptoPanicAsync(string token)
+        {
+            var list = new List<NewsItem>();
+            try
+            {
+                var url = $"https://cryptopanic.com/api/v1/posts/?auth_token={token}&public=true";
+                var json = await _httpClient.GetStringAsync(url);
+                using var doc = JsonDocument.Parse(json);
+                if (doc.RootElement.TryGetProperty("results", out var results))
+                {
+                    foreach (var el in results.EnumerateArray())
+                    {
+                        var id = el.GetProperty("id").GetInt32();
+                        var title = el.GetProperty("title").GetString() ?? string.Empty;
+                        var link = el.GetProperty("url").GetString() ?? string.Empty;
+                        var publishedAt = el.GetProperty("published_at").GetDateTime();
+                        var type = Classify(title);
+                        list.Add(new NewsItem(id: $"cp::{id}", source: "cryptopanic", timestamp: publishedAt, title: title, body: null, link: link, type: type, symbols: ExtractSymbols(title)));
+                    }
+                }
+            }
+            catch { }
+            return list;
+        }
+
+        private static string HtmlDecode(string text) => System.Net.WebUtility.HtmlDecode(text);
+
+        private static NewsType Classify(string t)
+        {
+            var tl = t.ToLowerInvariant();
+            if (tl.Contains("delist")) return NewsType.Delisting;
+            if (tl.Contains("list")) return NewsType.Listing;
+            if (tl.Contains("mainten")) return NewsType.Maintenance;
+            if (tl.Contains("sec") || tl.Contains("lawsuit") || tl.Contains("regulat")) return NewsType.Regulatory;
+            return NewsType.General;
+        }
+
+        private static readonly Regex UsdtSym = new(@"\b([A-Z0-9]{2,15})(?:/|-)?USDT\b", RegexOptions.Compiled);
+        private static IReadOnlyList<string> ExtractSymbols(string text)
+            => UsdtSym.Matches(text).Select(x => x.Groups[1].Value + "USDT").Distinct().ToList();
+    }
+}


### PR DESCRIPTION
## Summary
- add FreeNewsHubService polling Bybit, KuCoin, OKX and CryptoPanic
- wire service at application startup with graceful disposal
- introduce NewsItem models, options, and NewsType enum

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2da88a2f883339d5b1a8f3584bfcf