### PR TITLE
Fix regex patterns in news service

### DIFF
--- a/Services/FreeNewsHubService.cs
+++ b/Services/FreeNewsHubService.cs
@@ -86,7 +86,9 @@ namespace BinanceUsdtTicker
             try
             {
                 var html = await _httpClient.GetStringAsync("https://announcements.bybit.com/en-US/?category=new-listing");
-                var rx = new Regex("<a[^>]+href=\"(?<link>/en-US/article/[^"]+)\"[^>]*>(?<title>[^<]+)</a>.*?<time[^>]+datetime=\"(?<time>[^"]+)\"", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+                var rx = new Regex(
+                    @"<a[^>]+href=""(?<link>/en-US/article/[^""]+)""[^>]*>(?<title>[^<]+)</a>.*?<time[^>]+datetime=""(?<time>[^""]+)""",
+                    RegexOptions.IgnoreCase | RegexOptions.Singleline);
                 foreach (Match m in rx.Matches(html))
                 {
                     var link = "https://announcements.bybit.com" + m.Groups["link"].Value;
@@ -108,7 +110,9 @@ namespace BinanceUsdtTicker
             try
             {
                 var html = await _httpClient.GetStringAsync("https://www.kucoin.com/news/categories/listing");
-                var rx = new Regex("<a[^>]+href=\"(?<link>/news/[^"]+)\"[^>]*>(?<title>[^<]+)</a>.*?<time[^>]*>(?<time>[^<]+)</time>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+                var rx = new Regex(
+                    @"<a[^>]+href=""(?<link>/news/[^""]+)""[^>]*>(?<title>[^<]+)</a>.*?<time[^>]*>(?<time>[^<]+)</time>",
+                    RegexOptions.IgnoreCase | RegexOptions.Singleline);
                 foreach (Match m in rx.Matches(html))
                 {
                     var link = "https://www.kucoin.com" + m.Groups["link"].Value;
@@ -130,7 +134,9 @@ namespace BinanceUsdtTicker
             try
             {
                 var html = await _httpClient.GetStringAsync("https://www.okx.com/announcements/category/listing");
-                var rx = new Regex("<a[^>]+href=\"(?<link>[^"]+)\"[^>]*class=\"[^\"]*announcement-item[^\"]*\"[^>]*>\\s*<div[^>]*class=\"[^\"]*title[^\"]*\">(?<title>[^<]+)</div>\\s*<div[^>]*class=\"[^\"]*time[^\"]*\">(?<time>[^<]+)</div>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+                var rx = new Regex(
+                    @"<a[^>]+href=""(?<link>[^""]+)""[^>]*class=""[^""]*announcement-item[^""]*""[^>]*>\s*<div[^>]*class=""[^""]*title[^""]*"">(?<title>[^<]+)</div>\s*<div[^>]*class=""[^""]*time[^""]*"">(?<time>[^<]+)</div>",
+                    RegexOptions.IgnoreCase | RegexOptions.Singleline);
                 foreach (Match m in rx.Matches(html))
                 {
                     var link = "https://www.okx.com" + m.Groups["link"].Value;


### PR DESCRIPTION
## Summary
- switch Bybit, KuCoin, and OKX announcement scrapers to verbatim regex strings

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dc467554833383bf8375f75004fb