### PR TITLE
Remove unsupported Foreground attribute from Top Movers Border

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -710,8 +710,8 @@
                         <!-- TOP MOVERS -->
                         <TabControl Grid.Row="0" Grid.Column="3" Margin="0,0,8,0">
                             <TabItem Header="Top Movers">
-                                <Border Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}" BorderBrush="{DynamicResource Divider}" BorderThickness="1" VerticalAlignment="Stretch">
-                                <Grid>
+                                <Border Background="{DynamicResource SurfaceAlt}" BorderBrush="{DynamicResource Divider}" BorderThickness="1" VerticalAlignment="Stretch">
+                                    <Grid>
                                         <Grid.RowDefinitions>
                                                 <RowDefinition Height="Auto"/>
                                                 <RowDefinition Height="Auto"/>


### PR DESCRIPTION
## Summary
- remove invalid `Foreground` attribute from Top Movers border to fix XAML build error

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f852f150833382487879a24ce216