### PR TITLE
fix: remove invalid Foreground on Border

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -838,7 +838,7 @@
                                 </Border>
                             </TabItem>
                             <TabItem Header="News">
-                                <Border Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}" BorderBrush="{DynamicResource Divider}" BorderThickness="1" VerticalAlignment="Stretch">
+                                <Border Background="{DynamicResource SurfaceAlt}" BorderBrush="{DynamicResource Divider}" BorderThickness="1" VerticalAlignment="Stretch">
                                     <ListView x:Name="NewsList" Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}" ScrollViewer.VerticalScrollBarVisibility="Auto">
                                         <ListView.View>
                                             <GridView>


### PR DESCRIPTION
## Summary
- remove unsupported `Foreground` property from News tab Border

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update && apt-get install -y dotnet-sdk-8.0` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f8f7ac9c83339af9c43858401119