### PR TITLE
Expand news panel and adjust coin grid widths

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -402,7 +402,7 @@
                                 <!-- Futures panel expanded for better usability -->
                                 <ColumnDefinition Width="300"/>
                                 <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="260"/>
+                                <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="260"/>
                         </Grid.ColumnDefinitions>
 
@@ -522,7 +522,7 @@
                                         <!-- 2) Sembol -->
                                         <DataGridTemplateColumn x:Name="ColSymbol"
                                             Header="Sembol"
-                                            Width="1.2*" MinWidth="100">
+                                            Width="1*" MinWidth="90">
 						<DataGridTemplateColumn.CellTemplate>
 							<DataTemplate>
 								<TextBlock>
@@ -609,7 +609,7 @@
 
                                         <!-- Hacim -->
                                         <DataGridTextColumn x:Name="ColVol" Header="Hacim"
-                                        Width="1.3*" MinWidth="110"
+                                        Width="1*" MinWidth="100"
                                         Binding="{Binding Volume, StringFormat={}{0:#,0.##}}">
 						<DataGridTextColumn.ElementStyle>
 							<Style TargetType="TextBlock">


### PR DESCRIPTION
## Summary
- Expand the News section by switching its grid column to a flexible width so it shares space with the coin grid
- Narrow the symbol and volume columns in the coin grid to free up space

## Testing
- ❌ `dotnet build` *(command not found: dotnet)*
- ❌ `apt-get update` *(The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b30e9024cc8333a58f4772baa6adc4