### PR TITLE
Ensure News tab columns fit

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -712,12 +712,13 @@
                                   Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
                                   VerticalAlignment="Stretch" BorderBrush="{DynamicResource Divider}">
                             <ListView x:Name="NewsList" Background="{DynamicResource SurfaceAlt}"
-                                      Foreground="{DynamicResource OnSurface}" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                      Foreground="{DynamicResource OnSurface}" ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                      Loaded="NewsList_Loaded" SizeChanged="NewsList_SizeChanged">
                                 <ListView.View>
                                     <GridView>
                                         <GridViewColumn Header="Kaynak" Width="80" DisplayMemberBinding="{Binding Source}" />
                                         <GridViewColumn Header="Zaman" Width="120" DisplayMemberBinding="{Binding Timestamp, StringFormat={}{0:HH:mm:ss}}" />
-                                        <GridViewColumn Header="Başlık" Width="200">
+                                        <GridViewColumn Header="Başlık">
                                             <GridViewColumn.CellTemplate>
                                                 <DataTemplate>
                                                     <TextBlock Text="{Binding Title}" TextWrapping="Wrap"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1177,6 +1177,9 @@ namespace BinanceUsdtTicker
         private void AlertList_Loaded(object sender, RoutedEventArgs e) => AdjustAlertMsgColumnWidth();
         private void AlertList_SizeChanged(object sender, SizeChangedEventArgs e) => AdjustAlertMsgColumnWidth();
 
+        private void NewsList_Loaded(object sender, RoutedEventArgs e) => AdjustNewsTitleColumnWidth();
+        private void NewsList_SizeChanged(object sender, SizeChangedEventArgs e) => AdjustNewsTitleColumnWidth();
+
         private void AdjustAlertMsgColumnWidth()
         {
             var alertList = Q<ListView>("AlertList");
@@ -1206,6 +1209,36 @@ namespace BinanceUsdtTicker
 
             double newWidth = Math.Max(120, total - fixedSum - padding - scroll);
             msgCol.Width = newWidth;
+        }
+
+        private void AdjustNewsTitleColumnWidth()
+        {
+            var newsList = Q<ListView>("NewsList");
+            if (newsList?.View is not GridView gv) return;
+
+            GridViewColumn? titleCol = gv.Columns.FirstOrDefault(c =>
+                string.Equals(c.Header?.ToString(), "Başlık", StringComparison.OrdinalIgnoreCase));
+            if (titleCol == null) return;
+
+            double fixedSum = 0;
+            foreach (var col in gv.Columns)
+            {
+                if (ReferenceEquals(col, titleCol)) continue;
+                var w = col.Width;
+                if (double.IsNaN(w) || w <= 0) w = 100;
+                fixedSum += w;
+            }
+
+            double total = newsList.ActualWidth;
+            double padding = 35;
+
+            double scroll = 0;
+            var sv = FindDescendant<ScrollViewer>(newsList);
+            if (sv != null && sv.ComputedVerticalScrollBarVisibility == Visibility.Visible)
+                scroll = SystemParameters.VerticalScrollBarWidth;
+
+            double newWidth = Math.Max(100, total - fixedSum - padding - scroll);
+            titleCol.Width = newWidth;
         }
 
         private static T? FindDescendant<T>(DependencyObject root) where T : DependencyObject


### PR DESCRIPTION
## Summary
- Dynamically size the news title column so source, time, and title fit within the News tab.
- Hook into News list Loaded and SizeChanged events to adjust widths automatically.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b310e94c348333a976f0c310309134