### PR TITLE
fix: remove unsupported Foreground property

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -732,7 +732,7 @@
                                 </Border>
                             </TabItem>
                             <TabItem Header="Top Movers">
-                                <Border Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}" BorderBrush="{DynamicResource Divider}" BorderThickness="1" VerticalAlignment="Stretch">
+                                <Border Background="{DynamicResource SurfaceAlt}" BorderBrush="{DynamicResource Divider}" BorderThickness="1" VerticalAlignment="Stretch">
                                     <Grid>
                                         <Grid.RowDefinitions>
                                                 <RowDefinition Height="Auto"/>


### PR DESCRIPTION
## Summary
- remove unsupported Foreground attribute from Top Movers border

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b318902a8883338a2395a0f7f05815