### PR TITLE
Revert MainWindow Foreground removal

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -732,7 +732,7 @@
                                 </Border>
                             </TabItem>
                             <TabItem Header="Top Movers">
-                                <Border Background="{DynamicResource SurfaceAlt}" BorderBrush="{DynamicResource Divider}" BorderThickness="1" VerticalAlignment="Stretch">
+                                <Border Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}" BorderBrush="{DynamicResource Divider}" BorderThickness="1" VerticalAlignment="Stretch">
                                     <Grid>
                                         <Grid.RowDefinitions>
                                                 <RowDefinition Height="Auto"/>


### PR DESCRIPTION
## Summary
- restore `Foreground` on Top Movers border to undo prior change

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b326bc5c908333b3a275e6e639f6ff