### PR TITLE
Fix Border Foreground property causing XAML build failure

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -732,7 +732,7 @@
                                 </Border>
                             </TabItem>
                             <TabItem Header="Top Movers">
-                                <Border Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}" BorderBrush="{DynamicResource Divider}" BorderThickness="1" VerticalAlignment="Stretch">
+                                <Border Background="{DynamicResource SurfaceAlt}" TextElement.Foreground="{DynamicResource OnSurface}" BorderBrush="{DynamicResource Divider}" BorderThickness="1" VerticalAlignment="Stretch">
                                     <Grid>
                                         <Grid.RowDefinitions>
                                                 <RowDefinition Height="Auto"/>


### PR DESCRIPTION
## Summary
- replace invalid `Foreground` attribute on Border with `TextElement.Foreground` in MainWindow

## Testing
- `dotnet build BinanceUsdtTicker.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b328e320548333a50d69922d4b2304