### PR TITLE
Align News list items to top

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -717,6 +717,11 @@
                                 <ListView x:Name="NewsList" Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
                                           ScrollViewer.VerticalScrollBarVisibility="Auto"
                                           Loaded="NewsList_Loaded" SizeChanged="NewsList_SizeChanged">
+                                        <ListView.ItemContainerStyle>
+                                            <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Type ListViewItem}}">
+                                                <Setter Property="VerticalContentAlignment" Value="Top" />
+                                            </Style>
+                                        </ListView.ItemContainerStyle>
                                         <ListView.View>
                                             <GridView>
                                                 <GridViewColumn Header="Kaynak" Width="80" DisplayMemberBinding="{Binding Source}" />


### PR DESCRIPTION
## Summary
- Align News list items to the top to avoid vertical centering in the News tab

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3342c97388333bbfb91ac873940af