### PR TITLE
Expand News section height

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1214,7 +1214,15 @@ namespace BinanceUsdtTicker
         private void AdjustNewsTitleColumnWidth()
         {
             var newsList = Q<ListView>("NewsList");
-            if (newsList?.View is not GridView gv) return;
+            if (newsList == null) return;
+
+            // Increase the News section height so more items are visible
+            double screenHeight = SystemParameters.PrimaryScreenHeight / 3;
+            newsList.Height = screenHeight;
+            newsList.MinHeight = screenHeight;
+            newsList.MaxHeight = screenHeight;
+
+            if (newsList.View is not GridView gv) return;
 
             GridViewColumn? titleCol = gv.Columns.FirstOrDefault(c =>
                 string.Equals(c.Header?.ToString(), "Başlık", StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
## Summary
- Increase News list height to one-third of screen height for better visibility
- Maintain width adjustment logic

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b33589cbf48333a255fa41c07a144c