### PR TITLE
Fix news feed retrieval by setting user agent

### DIFF
--- a/Services/FreeNewsHubService.cs
+++ b/Services/FreeNewsHubService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -22,6 +23,7 @@ namespace BinanceUsdtTicker
         public FreeNewsHubService(FreeNewsOptions options)
         {
             _options = options;
+            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (compatible; BinanceUsdtTicker)");
         }
 
         public Task StartAsync()


### PR DESCRIPTION
## Summary
- Add user-agent header to FreeNewsHubService's HttpClient so requests resemble a browser

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b337221d548333b34a31992bdcf7fd