### PR TITLE
Fix missing news display by subscribing before start

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -15,8 +15,8 @@ public partial class App : Application
             PollInterval = TimeSpan.FromSeconds(5),
             CryptoPanicToken = string.Empty
         });
-        await _newsHub.StartAsync();
         _newsHub.NewsReceived += OnNewsReceived;
+        await _newsHub.StartAsync();
     }
 
     private void OnNewsReceived(object? sender, NewsItem item)


### PR DESCRIPTION
## Summary
- Subscribe to FreeNewsHubService events before starting the service so initial news items display

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b33d68a5a88333bc540ed35ccb5cfa