### PR TITLE
Fix cross-thread access when handling news updates

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -21,8 +21,19 @@ public partial class App : Application
 
     private void OnNewsReceived(object? sender, NewsItem item)
     {
-        if (Current.MainWindow is MainWindow mw)
-            mw.AddNewsItem(item);
+        if (Current.Dispatcher.CheckAccess())
+        {
+            if (Current.MainWindow is MainWindow mw)
+                mw.AddNewsItem(item);
+        }
+        else
+        {
+            _ = Current.Dispatcher.InvokeAsync(() =>
+            {
+                if (Current.MainWindow is MainWindow mw)
+                    mw.AddNewsItem(item);
+            });
+        }
     }
 
     protected override async void OnExit(ExitEventArgs e)


### PR DESCRIPTION
## Summary
- marshal incoming news items onto the UI dispatcher before updating the main window

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b33e96612c8333a9da2fe1602e3e0d