### PR TITLE
Show symbol and date in news list

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -724,9 +724,10 @@
                                         </ListView.ItemContainerStyle>
                                         <ListView.View>
                                             <GridView>
-                                                <GridViewColumn Header="Kaynak" Width="80" DisplayMemberBinding="{Binding Source}" />
-                                                <GridViewColumn Header="Zaman" Width="120" DisplayMemberBinding="{Binding Timestamp, StringFormat={}{0:HH:mm:ss}}" />
-                                                <GridViewColumn Header="Başlık">
+                                            <GridViewColumn Header="Kaynak" Width="80" DisplayMemberBinding="{Binding Source}" />
+                                            <GridViewColumn Header="Sembol" Width="80" DisplayMemberBinding="{Binding SymbolsDisplay}" />
+                                            <GridViewColumn Header="Zaman" Width="170" DisplayMemberBinding="{Binding Timestamp, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}" />
+                                            <GridViewColumn Header="Başlık">
                                                     <GridViewColumn.CellTemplate>
                                                         <DataTemplate>
                                                             <TextBlock Text="{Binding Title}" TextWrapping="Wrap"/>

--- a/Models/NewsItem.cs
+++ b/Models/NewsItem.cs
@@ -25,5 +25,6 @@ namespace BinanceUsdtTicker
         public string Link { get; }
         public NewsType Type { get; }
         public IReadOnlyList<string> Symbols { get; }
+        public string SymbolsDisplay => string.Join(", ", Symbols);
     }
 }


### PR DESCRIPTION
## Summary
- display joined symbols for each news item
- include full date and time in news list view

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b33f9c453c833387e656089f76eb28