### PR TITLE
Skip news entries without symbols

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -184,6 +184,9 @@ namespace BinanceUsdtTicker
 
         public void AddNewsItem(NewsItem item)
         {
+            if (item.Symbols.Count == 0)
+                return;
+
             Dispatcher.Invoke(() =>
             {
                 if (_newsItems.Any(n => n.Id == item.Id))


### PR DESCRIPTION
## Summary
- avoid displaying news items that lack symbol data

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b340644f448333ab9175393000b43d