### PR TITLE
Filter news items for known coins

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -184,8 +184,16 @@ namespace BinanceUsdtTicker
 
         public void AddNewsItem(NewsItem item)
         {
-            if (item.Symbols.Count == 0)
+            // Sadece coin listesinde yer alan sembolleri göster
+            var validSymbols = item.Symbols.Where(s => _rowBySymbol.ContainsKey(s)).ToList();
+            if (validSymbols.Count == 0)
                 return;
+
+            // Semboller filtrelenmişse, haberi yeni liste ile oluştur
+            if (validSymbols.Count != item.Symbols.Count)
+            {
+                item = new NewsItem(item.Id, item.Source, item.Timestamp, item.Title, item.Body, item.Link, item.Type, validSymbols);
+            }
 
             Dispatcher.Invoke(() =>
             {


### PR DESCRIPTION
## Summary
- Only display news items referencing symbols present in the ticker list
- Drop or trim news entries containing unknown symbols

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b34122329483338ad070ac43fc7a05