### PR TITLE
Delay news hub startup until window is ready

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Threading;
 
 namespace BinanceUsdtTicker;
 
@@ -7,9 +9,14 @@ public partial class App : Application
 {
     private FreeNewsHubService? _newsHub;
 
-    protected override async void OnStartup(StartupEventArgs e)
+    protected override void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);
+        Dispatcher.InvokeAsync(StartNewsHubAsync, DispatcherPriority.ApplicationIdle);
+    }
+
+    private async Task StartNewsHubAsync()
+    {
         _newsHub = new FreeNewsHubService(new FreeNewsOptions
         {
             PollInterval = TimeSpan.FromSeconds(5),


### PR DESCRIPTION
## Summary
- Ensure news service starts after main window initialization to avoid missing items

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b343254ad88333905d3eae4cabbd1c