### PR TITLE
Exclude KuCoin RSS script from build

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -24,4 +24,9 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Remove="KuCoinNewListingsRss.cs" />
+    <None Include="KuCoinNewListingsRss.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- prevent KuCoinNewListingsRss.cs from compiling with the WPF app by removing it from compilation and including it as a non-compiling file

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b355470d848333af4cd8332ef1b312