### PR TITLE
Split multi-symbol news items

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -61,21 +61,34 @@ public partial class App : Application
 
     private void OnNewsReceived(object? sender, NewsItem item)
     {
-        if (!_usdtSymbols.Overlaps(item.Symbols))
-            return;
+        foreach (var sym in item.Symbols)
+        {
+            if (!_usdtSymbols.Contains(sym))
+                continue;
 
-        if (Current.Dispatcher.CheckAccess())
-        {
-            if (Current.MainWindow is MainWindow mw)
-                mw.AddNewsItem(item);
-        }
-        else
-        {
-            _ = Current.Dispatcher.InvokeAsync(() =>
+            var singleItem = new NewsItem(
+                id: item.Id + "::" + sym,
+                source: item.Source,
+                timestamp: item.Timestamp,
+                title: item.Title,
+                body: item.Body,
+                link: item.Link,
+                type: item.Type,
+                symbols: new[] { sym });
+
+            if (Current.Dispatcher.CheckAccess())
             {
                 if (Current.MainWindow is MainWindow mw)
-                    mw.AddNewsItem(item);
-            });
+                    mw.AddNewsItem(singleItem);
+            }
+            else
+            {
+                _ = Current.Dispatcher.InvokeAsync(() =>
+                {
+                    if (Current.MainWindow is MainWindow mw)
+                        mw.AddNewsItem(singleItem);
+                });
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Expand news handling to break out each symbol into its own news entry.
- Cross-check each symbol against the Binance USDT symbol list before displaying.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b366aed4088333b1e1e2e4913afbb6