### PR TITLE
Use NewListingsRss for news feed

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -29,7 +29,8 @@ public partial class App : Application
         _newsHub = new FreeNewsHubService(new FreeNewsOptions
         {
             PollInterval = TimeSpan.FromSeconds(5),
-            CryptoPanicToken = string.Empty
+            CryptoPanicToken = string.Empty,
+            RssBaseUrl = "http://localhost:5000"
         });
         _newsHub.NewsReceived += OnNewsReceived;
         await _newsHub.StartAsync();

--- a/Models/FreeNewsOptions.cs
+++ b/Models/FreeNewsOptions.cs
@@ -6,5 +6,6 @@ namespace BinanceUsdtTicker
     {
         public TimeSpan PollInterval { get; set; } = TimeSpan.FromMinutes(1);
         public string? CryptoPanicToken { get; set; }
+        public string RssBaseUrl { get; set; } = "http://localhost:5000";
     }
 }


### PR DESCRIPTION
## Summary
- fetch listing announcements via NewListingsRss RSS endpoints
- allow configuring feed service URL
- wire app startup to use the RSS-based news hub

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3797f9c988333b5f3747b728446f9