### PR TITLE
Make news feed URL optional

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -29,8 +29,7 @@ public partial class App : Application
         _newsHub = new FreeNewsHubService(new FreeNewsOptions
         {
             PollInterval = TimeSpan.FromSeconds(5),
-            CryptoPanicToken = string.Empty,
-            RssBaseUrl = "http://localhost:5000"
+            CryptoPanicToken = string.Empty
         });
         _newsHub.NewsReceived += OnNewsReceived;
         await _newsHub.StartAsync();

--- a/Models/FreeNewsOptions.cs
+++ b/Models/FreeNewsOptions.cs
@@ -6,6 +6,6 @@ namespace BinanceUsdtTicker
     {
         public TimeSpan PollInterval { get; set; } = TimeSpan.FromMinutes(1);
         public string? CryptoPanicToken { get; set; }
-        public string RssBaseUrl { get; set; } = "http://localhost:5000";
+        public string? RssBaseUrl { get; set; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ Then access the feeds:
 - http://localhost:5000/rss/kucoin-new
 - http://localhost:5000/rss/bybit-new
 - http://localhost:5000/rss/okx-new
+
+To consume these feeds in the main application, set `FreeNewsOptions.RssBaseUrl` to
+the base address of the running script. When this option is left unset, the app
+skips querying the RSS endpoints and no connection attempts are made.

--- a/Services/FreeNewsHubService.cs
+++ b/Services/FreeNewsHubService.cs
@@ -40,10 +40,13 @@ namespace BinanceUsdtTicker
                 try
                 {
                     var items = new List<NewsItem>();
-                    var baseUrl = _options.RssBaseUrl.TrimEnd('/');
-                    items.AddRange(await FetchRssAsync($"{baseUrl}/rss/bybit-new", "bybit"));
-                    items.AddRange(await FetchRssAsync($"{baseUrl}/rss/kucoin-new", "kucoin"));
-                    items.AddRange(await FetchRssAsync($"{baseUrl}/rss/okx-new", "okx"));
+                    var baseUrl = _options.RssBaseUrl?.TrimEnd('/');
+                    if (!string.IsNullOrEmpty(baseUrl))
+                    {
+                        items.AddRange(await FetchRssAsync($"{baseUrl}/rss/bybit-new", "bybit"));
+                        items.AddRange(await FetchRssAsync($"{baseUrl}/rss/kucoin-new", "kucoin"));
+                        items.AddRange(await FetchRssAsync($"{baseUrl}/rss/okx-new", "okx"));
+                    }
                     if (!string.IsNullOrEmpty(_options.CryptoPanicToken))
                         items.AddRange(await FetchCryptoPanicAsync(_options.CryptoPanicToken));
 


### PR DESCRIPTION
## Summary
- Allow news feed base URL to be unset to avoid unwanted localhost connections
- Skip RSS polling when base URL is empty
- Document how to configure optional RSS feed service

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b37afd47cc833395886f1adcc6fc08