### PR TITLE
Fix LoadDefaultUiSettings reference in startup

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -27,7 +27,10 @@ public partial class App : Application
     {
         await UpdateUsdtSymbolsFileAsync();
 
-        var settings = MainWindow.LoadDefaultUiSettings();
+        // Use the fully qualified type name to avoid resolving to the
+        // Application.MainWindow property which is of type Window and
+        // does not expose LoadDefaultUiSettings().
+        var settings = global::BinanceUsdtTicker.MainWindow.LoadDefaultUiSettings();
         _newsOptions.PollInterval = TimeSpan.FromSeconds(5);
         _newsOptions.CryptoPanicToken = string.Empty;
         _newsOptions.RssBaseUrl = settings.BaseUrl;


### PR DESCRIPTION
## Summary
- avoid compile error by using the fully qualified MainWindow type when loading default UI settings

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b37ea9985883338026834016882837