### PR TITLE
Avoid default RSS base URL

### DIFF
--- a/Models/UiSettings.cs
+++ b/Models/UiSettings.cs
@@ -95,7 +95,7 @@ namespace BinanceUsdtTicker.Models
             set { if (_windowsNotification != value) { _windowsNotification = value; OnPropertyChanged(); } }
         }
 
-        private string _baseUrl = "http://localhost:5000";
+        private string _baseUrl = string.Empty;
         public string BaseUrl
         {
             get => _baseUrl;


### PR DESCRIPTION
## Summary
- Prevent automatic connection attempts to localhost RSS feed by leaving `UiSettings.BaseUrl` empty by default

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b37fef12b88333bc510106faa35b5f