### PR TITLE
Avoid default RSS base URL

### DIFF
--- a/Models/UiSettings.cs
+++ b/Models/UiSettings.cs
@@ -95,7 +95,9 @@ namespace BinanceUsdtTicker.Models
             set { if (_windowsNotification != value) { _windowsNotification = value; OnPropertyChanged(); } }
         }
 
-        private string _baseUrl = "http://localhost:5000";
+        // Base address for optional news feeds.
+        // When left empty, the application skips querying the service.
+        private string _baseUrl = string.Empty;
         public string BaseUrl
         {
             get => _baseUrl;

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Then access the feeds:
 - http://localhost:5000/rss/bybit-new
 - http://localhost:5000/rss/okx-new
 
-To consume these feeds in the main application, set `FreeNewsOptions.RssBaseUrl` to
-the base address of the running script. When this option is left unset, the app
-skips querying the RSS endpoints and no connection attempts are made.
+To consume these feeds in the main application, set `FreeNewsOptions.RssBaseUrl`
+to the base address of the running script. This setting is empty by default, so
+the app skips querying the RSS endpoints and no connection attempts are made
+until you provide a valid URL in the settings window.


### PR DESCRIPTION
## Summary
- Document that the RSS base URL is optional and must be provided by the user
- Clarify in settings model and README that leaving it blank skips news feed lookups

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden / repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b37fef12b88333bc510106faa35b5f