### PR TITLE
Add missing System usings for RssBridge program

### DIFF
--- a/RssBridge.Program.cs
+++ b/RssBridge.Program.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using System;
+using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Xml;


### PR DESCRIPTION
## Summary
- add explicit System and IO usings to RssBridge.Program to resolve DateTimeOffset and Stream references

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b382fc4240833389fb478563a40a94