### PR TITLE
Fix RssBridge compilation for minimal API integration

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -29,4 +29,8 @@
     <None Include="NewListingsRss.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
 </Project>

--- a/RssBridge.Program.cs
+++ b/RssBridge.Program.cs
@@ -4,6 +4,13 @@ using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Xml;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Logging.ClearProviders();


### PR DESCRIPTION
## Summary
- reference ASP.NET Core shared framework for RssBridge
- add missing usings for ASP.NET and HTTP types

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b383a4b5108333b5b187e9c398b84f