### PR TITLE
Fix missing UseUrls extension by adding hosting namespace

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using System.Windows.Threading;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 using System.Net.Http.Json;
 


### PR DESCRIPTION
## Summary
- include Microsoft.AspNetCore.Hosting namespace so WebApplicationBuilder can use UseUrls

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba19b131b483338595bcd46eb25ec2