### PR TITLE
Add missing namespace to ListingWatcherService Program

### DIFF
--- a/ListingWatcherService/Program.cs
+++ b/ListingWatcherService/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using BinanceUsdtTicker;
 
 Host.CreateDefaultBuilder(args)
     .UseWindowsService()


### PR DESCRIPTION
## Summary
- Add `BinanceUsdtTicker` namespace import in ListingWatcherService's Program to resolve missing type error

## Testing
- `dotnet build ListingWatcherService/ListingWatcherService.csproj -c Release` *(fails: `bash: command not found: dotnet`)*
- `apt-get update` *(fails: `403  Forbidden`)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1dec8500833382d41d19eb799f6b