### PR TITLE
fix: update Bybit listing API endpoint

### DIFF
--- a/ListingWatcherService/ListingWatcherService.cs
+++ b/ListingWatcherService/ListingWatcherService.cs
@@ -67,7 +67,7 @@ public sealed class ListingWatcherService : BackgroundService
 
     private async Task PollBybitAsync(CancellationToken ct)
     {
-        var url = "https://api.bybit.com/v5/public/announcements?locale=en-US&category=listing&pageSize=20&page=1";
+        var url = "https://api.bybit.com/v5/announcement/index?locale=en-US&category=listing&pageSize=20&page=1";
         using var resp = await _http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
         resp.EnsureSuccessStatusCode();
 


### PR DESCRIPTION
## Summary
- fix Bybit listings poller to use current announcement endpoint

## Testing
- `dotnet build ListingWatcherService/ListingWatcherService.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba217802008333811a99f638d820cc