### PR TITLE
Fix Bybit listing watcher endpoint

### DIFF
--- a/ListingWatcherService/ListingWatcherService.cs
+++ b/ListingWatcherService/ListingWatcherService.cs
@@ -67,7 +67,7 @@ public sealed class ListingWatcherService : BackgroundService
 
     private async Task PollBybitAsync(CancellationToken ct)
     {
-        var url = "https://api.bybit.com/v5/announcements/index?locale=en-US&tag=listing&limit=20&page=1";
+        var url = "https://api.bybit.com/v5/public/announcements?locale=en-US&category=listing&pageSize=20&page=1";
 
         using var resp = await _http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
         resp.EnsureSuccessStatusCode();


### PR DESCRIPTION
## Summary
- update Bybit polling URL to new public announcements endpoint

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba252fe9d8833381e2543f675885f2