### PR TITLE
Switch Bybit listings to announcements index endpoint

### DIFF
--- a/ListingWatcherService/ListingWatcherService.cs
+++ b/ListingWatcherService/ListingWatcherService.cs
@@ -68,8 +68,9 @@ public sealed class ListingWatcherService : BackgroundService
     private async Task PollBybitAsync(CancellationToken ct)
     {
         // Bybit changed the listings endpoint to /v5/announcements/index.
-        // The previous /v5/public/announcements path now returns 404.
-        var url = "https://api.bybit.com/v5/announcements/index?locale=en-US&tag=listing&limit=20&page=1";
+        // Use type=new_crypto to retrieve recent listing announcements.
+        // The API is cursor based, so we simply request the first page.
+        var url = "https://api.bybit.com/v5/announcements/index?locale=en-US&type=new_crypto&limit=20";
 
         using var resp = await _http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
         resp.EnsureSuccessStatusCode();

--- a/NewListingsRss.cs
+++ b/NewListingsRss.cs
@@ -47,12 +47,15 @@ MapRssEndpoint(
     "/rss/bybit-new",
     defaultLang: "en-US",
     channelTitle: "Bybit – New Listings (Unofficial RSS)",
-    channelLink: "https://announcement.bybit.com/en-US/?category=Listing",
+    channelLink: "https://announcements.bybit.com/en-US/?type=new_crypto",
     generator: "BybitNewListingsRSS/1.0",
     descFactory: lang => $"New Listings announcements via Bybit API (lang={lang})",
     fetch: async (ctx, lang, pageSize, page) =>
     {
-        var url = $"https://api.bybit.com/v5/public/announcements?locale={Uri.EscapeDataString(lang)}&category=listing&pageSize={pageSize}&page={page}";
+        // Bybit exposes new listings via the announcements index endpoint
+        // with type=new_crypto. The API is cursor based, but for simplicity
+        // we only fetch the first page with the requested limit.
+        var url = $"https://api.bybit.com/v5/announcements/index?locale={Uri.EscapeDataString(lang)}&type=new_crypto&limit={pageSize}";
         using var resp = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ctx.RequestAborted);
         resp.EnsureSuccessStatusCode();
 

--- a/RssBridge.Program.cs
+++ b/RssBridge.Program.cs
@@ -75,7 +75,7 @@ public static class RssBridgeProgram
                         if (root.TryGetProperty("result", out var result) && result.TryGetProperty("list", out var list))
                         {
                             ctx.Response.ContentType = "application/rss+xml; charset=utf-8";
-                            await WriteRss(ctx.Response.Body, "Bybit – New Crypto", "https://announcements.bybit.com/en/?category=new_crypto&page=1", list, MapBybit);
+                            await WriteRss(ctx.Response.Body, "Bybit – New Crypto", "https://announcements.bybit.com/en-US/?type=new_crypto", list, MapBybit);
                             return Results.Empty;
                         }
                         return Results.Problem(title: "Bybit JSON unexpected", statusCode: 502);
@@ -159,9 +159,10 @@ public static class RssBridgeProgram
     {
         var id = it.TryGetProperty("id", out var pId) ? pId.GetString() ?? Guid.NewGuid().ToString("n") : Guid.NewGuid().ToString("n");
         var title = it.TryGetProperty("title", out var pTitle) ? pTitle.GetString() ?? "(no title)" : "(no title)";
-        var desc = it.TryGetProperty("content", out var pDesc) ? pDesc.GetString() : null;
-        var url = it.TryGetProperty("url", out var pUrl) ? pUrl.GetString() : null;
-        var ts = it.TryGetProperty("dateTimestamp", out var pTs) && long.TryParse(pTs.GetString(), out var t)
+        // The new announcements API exposes description/link/createdAt fields.
+        var desc = it.TryGetProperty("description", out var pDesc) ? pDesc.GetString() : null;
+        var url = it.TryGetProperty("link", out var pUrl) ? pUrl.GetString() : null;
+        var ts = it.TryGetProperty("createdAt", out var pTs) && long.TryParse(pTs.GetString(), out var t)
             ? DateTimeOffset.FromUnixTimeMilliseconds(t)
             : DateTimeOffset.UtcNow;
         return new FeedItem(id, title, desc, url, ts);


### PR DESCRIPTION
## Summary
- Update Bybit RSS bridge and watcher to call the `/v5/announcements/index` endpoint with `type=new_crypto`
- Adjust Bybit RSS mapping for new JSON fields and link

## Testing
- `dotnet build ListingWatcherService/ListingWatcherService.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden to apt repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68bc06ea084c8333b8fa1e0b9378c80e