### PR TITLE
Allow configuring listing listener address via env var

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -52,7 +52,10 @@ public partial class App : Application
     {
         var builder = WebApplication.CreateBuilder(Array.Empty<string>());
         builder.Logging.ClearProviders();
-        builder.WebHost.UseUrls("http://localhost:5005");
+
+        var listenUrl = Environment.GetEnvironmentVariable("NEWS_LISTEN_URL")
+            ?? "http://localhost:5005";
+        builder.WebHost.UseUrls(listenUrl);
         var app = builder.Build();
 
         app.MapPost("/news", async (HttpContext ctx) =>

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ set NEWS_NOTIFY_URL=http://app-host:5005/news   # Windows
 export NEWS_NOTIFY_URL=http://app-host:5005/news # Linux/macOS
 ```
 
+If the desktop application itself needs to accept connections from other
+machines, configure its listener address with `NEWS_LISTEN_URL` before
+launching the app. For example, to listen on all interfaces:
+
+```bash
+set NEWS_LISTEN_URL=http://0.0.0.0:5005   # Windows
+export NEWS_LISTEN_URL=http://0.0.0.0:5005 # Linux/macOS
+```
+
 You can run the service as a console app for testing:
 
 ```bash


### PR DESCRIPTION
## Summary
- allow configuring listing listener address with `NEWS_LISTEN_URL`
- document `NEWS_LISTEN_URL` environment variable

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc129b3db4833383fca76712fa6c7c