### PR TITLE
Handle JSON errors on news endpoint

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 using System.Net.Http.Json;
+using System.Text.Json;
 
 namespace BinanceUsdtTicker;
 
@@ -60,7 +61,16 @@ public partial class App : Application
 
         app.MapPost("/news", async (HttpContext ctx) =>
         {
-            var payload = await ctx.Request.ReadFromJsonAsync<ListingNotification>();
+            ListingNotification? payload;
+            try
+            {
+                payload = await ctx.Request.ReadFromJsonAsync<ListingNotification>();
+            }
+            catch (JsonException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+
             if (payload != null)
             {
                 var item = new NewsItem(


### PR DESCRIPTION
## Summary
- respond with BadRequest when /news JSON payload is invalid
- add System.Text.Json import for JsonException handling

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1f893e34833380ba8383ab6a7880