### PR TITLE
Default news feed to localhost

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -41,7 +41,9 @@ public partial class App : Application
         var settings = global::BinanceUsdtTicker.MainWindow.LoadDefaultUiSettings();
         _newsOptions.PollInterval = TimeSpan.FromSeconds(5);
         _newsOptions.CryptoPanicToken = string.Empty;
-        _newsOptions.RssBaseUrl = settings.BaseUrl;
+        _newsOptions.RssBaseUrl = string.IsNullOrWhiteSpace(settings.BaseUrl)
+            ? "http://localhost:5005"
+            : settings.BaseUrl;
 
         _newsHub = new FreeNewsHubService(_newsOptions);
 

--- a/Models/UiSettings.cs
+++ b/Models/UiSettings.cs
@@ -95,7 +95,7 @@ namespace BinanceUsdtTicker.Models
             set { if (_windowsNotification != value) { _windowsNotification = value; OnPropertyChanged(); } }
         }
 
-        private string _baseUrl = string.Empty;
+        private string _baseUrl = "http://localhost:5005";
         public string BaseUrl
         {
             get => _baseUrl;

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Then access the feeds:
 - http://localhost:5000/rss/okx-new
 
 To consume these feeds in the main application, set `FreeNewsOptions.RssBaseUrl`
-to the base address of the running script. This setting is empty by default, so
-the app skips querying the RSS endpoints and no connection attempts are made
-until you provide a valid URL in the settings window.
+to the base address of the running script. The desktop app now defaults to
+`http://localhost:5005`, matching the feed script's default port. Adjust this
+value from the settings window if your service runs elsewhere.
 
 ## Listing Watcher Windows Service
 


### PR DESCRIPTION
## Summary
- default news RSS base URL to http://localhost:5005 so news loads without extra setup
- update UI settings to include default feed location and revise README documentation

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bc208de4e88333bdfee98c2dc676f8