### PR TITLE
chore: upgrade SqlClient to fix security advisory

### DIFF
--- a/ListingWatcherService/ListingWatcherService.csproj
+++ b/ListingWatcherService/ListingWatcherService.csproj
@@ -8,6 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- upgrade Microsoft.Data.SqlClient to 5.2.0

## Testing
- `dotnet publish ListingWatcherService/ListingWatcherService.csproj -c Release -r win-x64 --self-contained false -o /tmp/publish` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc332506ec833398dce92647b5b8b9