### PR TITLE
Decouple listing watcher service from desktop app

### DIFF
--- a/ListingWatcherService/ListingWatcherService.csproj
+++ b/ListingWatcherService/ListingWatcherService.csproj
@@ -4,6 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OutputType>Exe</OutputType>
+    <RootNamespace>ListingWatcher</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />

--- a/ListingWatcherService/Program.cs
+++ b/ListingWatcherService/Program.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using BinanceUsdtTicker;
+using ListingWatcher;
 
 Host.CreateDefaultBuilder(args)
     .UseWindowsService()

--- a/README.md
+++ b/README.md
@@ -39,24 +39,9 @@ value from the settings window if your service runs elsewhere.
 ## Listing Watcher Windows Service
 
 The `ListingWatcherService` project polls several exchange announcement APIs
-and sends new listings to the main application via HTTP. By default the service
-posts updates to `http://localhost:5005/news`, which is where the desktop app
-listens for incoming items.  When running the service on another machine, set
-the destination with the `NEWS_NOTIFY_URL` environment variable:
-
-```bash
-set NEWS_NOTIFY_URL=http://app-host:5005/news   # Windows
-export NEWS_NOTIFY_URL=http://app-host:5005/news # Linux/macOS
-```
-
-If the desktop application itself needs to accept connections from other
-machines, configure its listener address with `NEWS_LISTEN_URL` before
-launching the app. For example, to listen on all interfaces:
-
-```bash
-set NEWS_LISTEN_URL=http://0.0.0.0:5005   # Windows
-export NEWS_LISTEN_URL=http://0.0.0.0:5005 # Linux/macOS
-```
+and writes new listings directly to a SQL database. Configure the database
+connection string with the `BINANCE_DB_CONNECTION` environment variable;
+otherwise a localdb instance named `BinanceUsdtTicker` is used.
 
 You can run the service as a console app for testing:
 


### PR DESCRIPTION
## Summary
- remove HTTP notification dependency so ListingWatcherService only writes to DB
- set ListingWatcherService's root namespace and update docs

## Testing
- `dotnet build ListingWatcherService/ListingWatcherService.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3822d76c8333be3cf9d44c32e10f