### PR TITLE
fix: remove explicit DiagnosticSource reference

### DIFF
--- a/ListingWatcherService/ListingWatcherService.csproj
+++ b/ListingWatcherService/ListingWatcherService.csproj
@@ -10,6 +10,5 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- remove redundant System.Diagnostics.DiagnosticSource package reference to allow host to load correct version

## Testing
- `dotnet build ListingWatcherService/ListingWatcherService.csproj` (fails: command not found: dotnet)
- `apt-get update` (fails: repository not signed)

------
https://chatgpt.com/codex/tasks/task_e_68bc3c4a753c83338aef34e1e667654f