### PR TITLE
Add DiagnosticSource dependency to worker service

### DIFF
--- a/ListingWatcherService/ListingWatcherService.csproj
+++ b/ListingWatcherService/ListingWatcherService.csproj
@@ -10,5 +10,6 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- explicitly reference System.Diagnostics.DiagnosticSource so published worker includes required assembly

## Testing
- `dotnet build ListingWatcherService/ListingWatcherService.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3df7774c8333959bde3e0701b910