### PR TITLE
Explicitly reference console logging

### DIFF
--- a/ListingWatcherService/ListingWatcherService.csproj
+++ b/ListingWatcherService/ListingWatcherService.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add Microsoft.Extensions.Logging.Console dependency so host uses stable System.Text.Json
- remove unnecessary DiagnosticSource package

## Testing
- `dotnet run --project ListingWatcherService/ListingWatcherService.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.1.99 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68bc44c9c04083339e3cbac90bc4d84a