### PR TITLE
Add System.ServiceProcess.ServiceController dependency

### DIFF
--- a/ListingWatcherService/ListingWatcherService.csproj
+++ b/ListingWatcherService/ListingWatcherService.csproj
@@ -12,5 +12,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- include System.ServiceProcess.ServiceController package so Windows service can load ServiceController assembly at runtime

## Testing
- `dotnet build ListingWatcherService/ListingWatcherService.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4edad21c8333b1cdc0400fe6a42a