### PR TITLE
Conditionally use Windows service hosting

### DIFF
--- a/ListingWatcherService/ListingWatcherService.csproj
+++ b/ListingWatcherService/ListingWatcherService.csproj
@@ -12,6 +12,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.0" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.*" />
   </ItemGroup>
 </Project>

--- a/ListingWatcherService/Program.cs
+++ b/ListingWatcherService/Program.cs
@@ -1,10 +1,16 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ListingWatcher;
+using System;
 
-Host.CreateDefaultBuilder(args)
-    .UseWindowsService()
-    .ConfigureServices(services =>
+var builder = Host.CreateDefaultBuilder(args);
+
+if (OperatingSystem.IsWindows())
+{
+    builder.UseWindowsService();
+}
+
+builder.ConfigureServices(services =>
     {
         services.AddHostedService<ListingWatcherService>();
     })


### PR DESCRIPTION
## Summary
- Avoid loading Windows service hosting on non-Windows platforms by checking the OS before calling `UseWindowsService`
- Use a wildcard package version for `System.ServiceProcess.ServiceController`

## Testing
- `dotnet build ListingWatcherService/ListingWatcherService.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc519040b883338e890c00699cdf13