### PR TITLE
Update SQL connection to new server

### DIFF
--- a/ListingWatcherService/ListingWatcherService.cs
+++ b/ListingWatcherService/ListingWatcherService.cs
@@ -36,7 +36,7 @@ public sealed class ListingWatcherService : BackgroundService
         _http.DefaultRequestHeaders.UserAgent.ParseAdd("ListingWatcher/1.0");
         _connectionString =
             Environment.GetEnvironmentVariable("BINANCE_DB_CONNECTION") ??
-            "Server=(localdb)\\MSSQLLocalDB;Database=BinanceUsdtTicker;Trusted_Connection=True;";
+            "Server=KARAKAYA-MSI\\KARAKAYADB;Database=KARAKAYADB;User Id=sa;Password=Lhya!812;TrustServerCertificate=True;";
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ value from the settings window if your service runs elsewhere.
 The `ListingWatcherService` project polls several exchange announcement APIs
 and writes new listings directly to a SQL database. Configure the database
 connection string with the `BINANCE_DB_CONNECTION` environment variable;
-otherwise a localdb instance named `BinanceUsdtTicker` is used.
+otherwise it connects to `KARAKAYA-MSI\\KARAKAYADB` using the SQL login
+`sa` with password `Lhya!812`.
 
 You can run the service as a console app for testing:
 


### PR DESCRIPTION
## Summary
- point default connection string to KARAKAYA-MSI\\KARAKAYADB with sa credentials
- document the new default database connection in README

## Testing
- `dotnet build ListingWatcherService/ListingWatcherService.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6b9b29548333a96987e23f8ecd68