### PR TITLE
Use Turkey time zone for CreatedAt

### DIFF
--- a/ListingWatcherService/ListingWatcherService.cs
+++ b/ListingWatcherService/ListingWatcherService.cs
@@ -212,7 +212,7 @@ BEGIN
         Title NVARCHAR(MAX) NOT NULL,
         Url NVARCHAR(2048) NULL,
         Symbols NVARCHAR(200) NULL,
-        CreatedAt DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
+        CreatedAt DATETIMEOFFSET NOT NULL DEFAULT (SYSDATETIMEOFFSET() AT TIME ZONE 'Turkey Standard Time')
     )
 END";
             await create.ExecuteNonQueryAsync(ct);


### PR DESCRIPTION
## Summary
- store news creation timestamp in Turkey Standard Time using `DATETIMEOFFSET`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6e24ff2c83339314af24c26cfac7