### PR TITLE
Poll news sources every second

### DIFF
--- a/ListingWatcherService/ListingWatcherService.cs
+++ b/ListingWatcherService/ListingWatcherService.cs
@@ -59,7 +59,8 @@ public sealed class ListingWatcherService : BackgroundService
 
             try
             {
-                await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
+                // Check news sources frequently.
+                await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
             }
             catch (TaskCanceledException)
             {


### PR DESCRIPTION
## Summary
- Increase ListingWatcherService polling frequency to once per second to capture news quickly and persist to the database.

## Testing
- `dotnet build ListingWatcherService/ListingWatcherService.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7227e0c883338c0123e0a3d0acd7