### PR TITLE
Poll news sources every second

### DIFF
--- a/ListingWatcherService/ListingWatcherService.cs
+++ b/ListingWatcherService/ListingWatcherService.cs
@@ -43,7 +43,8 @@ public sealed class ListingWatcherService : BackgroundService
     {
         await EnsureDatabaseAsync(stoppingToken);
 
-        while (!stoppingToken.IsCancellationRequested)
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+        while (await timer.WaitForNextTickAsync(stoppingToken))
         {
             try
             {
@@ -55,15 +56,6 @@ public sealed class ListingWatcherService : BackgroundService
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Polling failed");
-            }
-
-            try
-            {
-                await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
-            }
-            catch (TaskCanceledException)
-            {
-                break;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace delay-based loop with PeriodicTimer so ListingWatcherService polls every second continuously

## Testing
- `apt-get update` *(fails: repository is not signed; 403 Forbidden)*
- `dotnet build ListingWatcherService/ListingWatcherService.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7227e0c883338c0123e0a3d0acd7