### PR TITLE
Handle forbidden HTTP responses gracefully

### DIFF
--- a/ListingWatcherService/ListingWatcherService.cs
+++ b/ListingWatcherService/ListingWatcherService.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Net;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Data.SqlClient;
@@ -77,6 +78,11 @@ public sealed class ListingWatcherService : BackgroundService
         var url = "https://api.bybit.com/v5/announcements/index?locale=en-US&type=new_crypto&limit=20";
 
         using var resp = await _http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
+        if (resp.StatusCode == HttpStatusCode.Forbidden)
+        {
+            _logger.LogWarning("Forbidden when polling Bybit: {Url}", url);
+            return;
+        }
         resp.EnsureSuccessStatusCode();
 
         using var stream = await resp.Content.ReadAsStreamAsync(ct);
@@ -118,6 +124,11 @@ public sealed class ListingWatcherService : BackgroundService
 
         var url = $"https://cryptopanic.com/api/v1/posts/?auth_token={token}&public=true";
         using var resp = await _http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
+        if (resp.StatusCode == HttpStatusCode.Forbidden)
+        {
+            _logger.LogWarning("Forbidden when polling CryptoPanic: {Url}", url);
+            return;
+        }
         resp.EnsureSuccessStatusCode();
 
         using var stream = await resp.Content.ReadAsStreamAsync(ct);
@@ -143,6 +154,11 @@ public sealed class ListingWatcherService : BackgroundService
     {
         var url = "https://api.kucoin.com/api/v3/announcements?annType=new-listings&lang=en_US&pageSize=20&currentPage=1";
         using var resp = await _http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
+        if (resp.StatusCode == HttpStatusCode.Forbidden)
+        {
+            _logger.LogWarning("Forbidden when polling KuCoin: {Url}", url);
+            return;
+        }
         resp.EnsureSuccessStatusCode();
 
         using var stream = await resp.Content.ReadAsStreamAsync(ct);
@@ -165,6 +181,11 @@ public sealed class ListingWatcherService : BackgroundService
     {
         var url = "https://www.okx.com/api/v5/support/announcements?annType=announcements-new-listings&page=1";
         using var resp = await _http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
+        if (resp.StatusCode == HttpStatusCode.Forbidden)
+        {
+            _logger.LogWarning("Forbidden when polling OKX: {Url}", url);
+            return;
+        }
         resp.EnsureSuccessStatusCode();
 
         using var stream = await resp.Content.ReadAsStreamAsync(ct);

--- a/NewListingsRss.cs
+++ b/NewListingsRss.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Net;
 using System.Text;
 using System.Text.Json;
 using System.Xml;
@@ -24,6 +25,8 @@ MapRssEndpoint(
     {
         var url = $"https://api.kucoin.com/api/v3/announcements?annType=new-listings&lang={Uri.EscapeDataString(lang)}&pageSize={pageSize}&currentPage={page}";
         using var resp = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ctx.RequestAborted);
+        if (resp.StatusCode == HttpStatusCode.Forbidden)
+            return new List<FeedItem>();
         resp.EnsureSuccessStatusCode();
 
         using var stream = await resp.Content.ReadAsStreamAsync(ctx.RequestAborted);
@@ -57,6 +60,8 @@ MapRssEndpoint(
         // we only fetch the first page with the requested limit.
         var url = $"https://api.bybit.com/v5/announcements/index?locale={Uri.EscapeDataString(lang)}&type=new_crypto&limit={pageSize}";
         using var resp = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ctx.RequestAborted);
+        if (resp.StatusCode == HttpStatusCode.Forbidden)
+            return new List<FeedItem>();
         resp.EnsureSuccessStatusCode();
 
         using var stream = await resp.Content.ReadAsStreamAsync(ctx.RequestAborted);
@@ -87,6 +92,8 @@ MapRssEndpoint(
     {
         var url = $"https://www.okx.com/api/v5/support/announcements?annType=announcements-new-listings&page={page}";
         using var resp = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ctx.RequestAborted);
+        if (resp.StatusCode == HttpStatusCode.Forbidden)
+            return new List<FeedItem>();
         resp.EnsureSuccessStatusCode();
 
         using var stream = await resp.Content.ReadAsStreamAsync(ctx.RequestAborted);

--- a/Services/BinanceRestClientBase.cs
+++ b/Services/BinanceRestClientBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
@@ -56,6 +57,11 @@ namespace BinanceUsdtTicker
             using var response = await _http.SendAsync(request, ct);
             var content = await response.Content.ReadAsStringAsync(ct);
 
+            if (response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                return content;
+            }
+
             if (!response.IsSuccessStatusCode)
             {
                 throw new HttpRequestException(
@@ -71,6 +77,9 @@ namespace BinanceUsdtTicker
         protected async Task<string> SendAsync(HttpMethod method, string endpoint, CancellationToken ct = default)
         {
             using var response = await _http.SendAsync(new HttpRequestMessage(method, endpoint), ct);
+            if (response.StatusCode == HttpStatusCode.Forbidden)
+                return await response.Content.ReadAsStringAsync(ct);
+
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync(ct);
         }


### PR DESCRIPTION
## Summary
- avoid throwing exceptions on 403 responses in Binance REST client
- return empty items for 403 responses in KuCoin, Bybit, and OKX RSS endpoints
- log and skip polling when Bybit, CryptoPanic, KuCoin, or OKX return 403

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7562ef6c8333b81a670ffd4af6ae