### PR TITLE
Remove CryptoPanic integration

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -40,7 +40,6 @@ public partial class App : Application
         // does not expose LoadDefaultUiSettings().
         var settings = global::BinanceUsdtTicker.MainWindow.LoadDefaultUiSettings();
         _newsOptions.PollInterval = TimeSpan.FromSeconds(5);
-        _newsOptions.CryptoPanicToken = string.Empty;
         _newsOptions.RssBaseUrl = string.IsNullOrWhiteSpace(settings.BaseUrl)
             ? "http://localhost:5005"
             : settings.BaseUrl;

--- a/Models/FreeNewsOptions.cs
+++ b/Models/FreeNewsOptions.cs
@@ -5,7 +5,6 @@ namespace BinanceUsdtTicker
     public class FreeNewsOptions
     {
         public TimeSpan PollInterval { get; set; } = TimeSpan.FromMinutes(1);
-        public string? CryptoPanicToken { get; set; }
         public string? RssBaseUrl { get; set; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ The `ListingWatcherService` project polls several exchange announcement APIs
 and writes new listings directly to a SQL database. Configure the database
 connection string with the `BINANCE_DB_CONNECTION` environment variable;
 otherwise it connects to `KARAKAYA-MSI\\KARAKAYADB` using the SQL login
-`sa` with password `Lhya!812`. If you also set `CRYPTO_PANIC_TOKEN` the
-service will poll CryptoPanic for general news and store those items in the
-same table.
+`sa` with password `Lhya!812`.
 
 You can run the service as a console app for testing:
 

--- a/Services/FreeNewsHubService.cs
+++ b/Services/FreeNewsHubService.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -47,8 +46,6 @@ namespace BinanceUsdtTicker
                         items.AddRange(await FetchRssAsync($"{baseUrl}/rss/kucoin-new", "kucoin"));
                         items.AddRange(await FetchRssAsync($"{baseUrl}/rss/okx-new", "okx"));
                     }
-                    if (!string.IsNullOrEmpty(_options.CryptoPanicToken))
-                        items.AddRange(await FetchCryptoPanicAsync(_options.CryptoPanicToken));
 
                     foreach (var item in items)
                     {
@@ -108,34 +105,6 @@ namespace BinanceUsdtTicker
             catch (Exception ex)
             {
                 Console.Error.WriteLine($"{source} RSS fetch error: {ex}");
-            }
-            return list;
-        }
-
-        private async Task<IList<NewsItem>> FetchCryptoPanicAsync(string token)
-        {
-            var list = new List<NewsItem>();
-            try
-            {
-                var url = $"https://cryptopanic.com/api/v1/posts/?auth_token={token}&public=true";
-                var json = await _httpClient.GetStringAsync(url);
-                using var doc = JsonDocument.Parse(json);
-                if (doc.RootElement.TryGetProperty("results", out var results))
-                {
-                    foreach (var el in results.EnumerateArray())
-                    {
-                        var id = el.GetProperty("id").GetInt32();
-                        var title = el.GetProperty("title").GetString() ?? string.Empty;
-                        var link = el.GetProperty("url").GetString() ?? string.Empty;
-                        var publishedAt = el.GetProperty("published_at").GetDateTime();
-                        var type = Classify(title);
-                        list.Add(new NewsItem(id: $"cp::{id}", source: "cryptopanic", timestamp: publishedAt, title: title, body: null, link: link, type: type, symbols: ExtractSymbols(title)));
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"CryptoPanic fetch error: {ex}");
             }
             return list;
         }


### PR DESCRIPTION
## Summary
- drop CryptoPanic news support from options and services
- remove CryptoPanic polling from listing watcher
- update docs after removing CryptoPanic integration

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bc768ecfdc83339ca09d5840b41e63