### PR TITLE
Add 3-second retry delay for listing polls

### DIFF
--- a/ListingWatcherService/ListingWatcherService.cs
+++ b/ListingWatcherService/ListingWatcherService.cs
@@ -66,6 +66,14 @@ public sealed class ListingWatcherService : BackgroundService
             {
                 _logger.LogError(ex, "Polling failed");
             }
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(3), ct);
+            }
+            catch (OperationCanceledException)
+            {
+                // Ignore cancellation to allow graceful shutdown
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- slow down listing watcher polling with a 3-second delay between attempts

## Testing
- `dotnet build BinanceUsdtTicker.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository access 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc77cfd8208333aaa858df2975a4b3