### PR TITLE
Guard Windows-specific logging setup

### DIFF
--- a/ListingWatcherService/Program.cs
+++ b/ListingWatcherService/Program.cs
@@ -2,13 +2,17 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ListingWatcher;
+using System;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-builder.Services.AddWindowsService(o => o.ServiceName = "Binance Watcher");
-
 builder.Logging.ClearProviders();
-builder.Logging.AddEventLog(o => o.SourceName = "ListingWatcherService");
+
+if (OperatingSystem.IsWindows())
+{
+    builder.Services.AddWindowsService(o => o.ServiceName = "Binance Watcher");
+    builder.Logging.AddEventLog(o => o.SourceName = "ListingWatcherService");
+}
 
 builder.Services.AddHostedService<ListingWatcherService>();
 


### PR DESCRIPTION
## Summary
- avoid CA1416 warnings by only configuring Windows services and event log when on Windows

## Testing
- `dotnet build ListingWatcherService/ListingWatcherService.csproj -c Debug` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8638a3608333a694291611b3a94c