### PR TITLE
Use System.Data.SqlClient for database access

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="MahApps.Metro" Version="2.4.9" />
     <PackageReference Include="MaterialDesignThemes" Version="4.9.0" />
     <PackageReference Include="MaterialDesignColors" Version="2.1.4" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 
   <!-- Prevent the worker service project from being compiled into the WPF application -->

--- a/ListingWatcherService/ListingWatcherService.cs
+++ b/ListingWatcherService/ListingWatcherService.cs
@@ -8,7 +8,7 @@ using System.Net;
 using System.Threading.Channels;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Data.SqlClient;
+using System.Data.SqlClient;
 
 namespace ListingWatcher;
 

--- a/ListingWatcherService/ListingWatcherService.csproj
+++ b/ListingWatcherService/ListingWatcherService.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.*" />
   </ItemGroup>

--- a/Services/NewsDbService.cs
+++ b/Services/NewsDbService.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Data.SqlClient;
+using System.Data.SqlClient;
 
 namespace BinanceUsdtTicker
 {


### PR DESCRIPTION
## Summary
- Replace `Microsoft.Data.SqlClient` usage with `System.Data.SqlClient`
- Update project references to point to `System.Data.SqlClient` package

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc954c1f7083339249de1d0a946b2a