### PR TITLE
Use Microsoft.Data.SqlClient and fix NewsDbService symbol list

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="MahApps.Metro" Version="2.4.9" />
     <PackageReference Include="MaterialDesignThemes" Version="4.9.0" />
     <PackageReference Include="MaterialDesignColors" Version="2.1.4" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
   </ItemGroup>
 
   <!-- Prevent the worker service project from being compiled into the WPF application -->

--- a/Services/NewsDbService.cs
+++ b/Services/NewsDbService.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace BinanceUsdtTicker
 {
@@ -49,7 +51,7 @@ namespace BinanceUsdtTicker
                         var url = reader.IsDBNull(3) ? string.Empty : reader.GetString(3);
                         var symbolsStr = reader.IsDBNull(4) ? string.Empty : reader.GetString(4);
                         var created = reader.GetDateTimeOffset(5);
-                        var symbols = symbolsStr.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                        IReadOnlyList<string> symbols = symbolsStr.Split(',', StringSplitOptions.RemoveEmptyEntries).ToList();
                         var item = new NewsItem(id: id, source: source, timestamp: created.UtcDateTime, title: title, body: null, link: url, type: NewsType.Listing, symbols: symbols);
                         NewsReceived?.Invoke(this, item);
                         if (created > _lastTimestamp)


### PR DESCRIPTION
## Summary
- swap System.Data.SqlClient for Microsoft.Data.SqlClient
- ensure NewsDbService builds symbol lists correctly

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc96fab5548333b96a5beb22ce4443