### PR TITLE
Fix Microsoft.Data namespace compile error

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="MahApps.Metro" Version="2.4.9" />
     <PackageReference Include="MaterialDesignThemes" Version="4.9.0" />
     <PackageReference Include="MaterialDesignColors" Version="2.1.4" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
   </ItemGroup>
 
   <!-- Prevent the worker service project from being compiled into the WPF application -->


### PR DESCRIPTION
## Summary
- update Microsoft.Data.SqlClient to 5.2.0 for .NET 8 compatibility

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc987de9f48333b6a5c71e5a6bc147