### PR TITLE
Fix DateTime casting when loading news

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -218,9 +218,10 @@ namespace BinanceUsdtTicker
                     var title = reader.GetString(2);
                     var url = reader.IsDBNull(3) ? string.Empty : reader.GetString(3);
                     var symbolsStr = reader.IsDBNull(4) ? string.Empty : reader.GetString(4);
-                    var created = reader.GetDateTimeOffset(5);
+                    var created = reader.GetDateTime(5);
                     var symbols = symbolsStr.Split(',', StringSplitOptions.RemoveEmptyEntries);
-                    items.Add(new NewsItem(id, source, created.UtcDateTime, title, null, url, NewsType.Listing, symbols));
+                    var createdUtc = DateTime.SpecifyKind(created, DateTimeKind.Utc);
+                    items.Add(new NewsItem(id, source, createdUtc, title, null, url, NewsType.Listing, symbols));
                 }
 
                 Dispatcher.Invoke(() =>


### PR DESCRIPTION
## Summary
- read CreatedAt using `GetDateTime` and convert to UTC instead of `GetDateTimeOffset`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9c8e5bb083338361eea0ef581617