### PR TITLE
Align news list to top

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -713,10 +713,12 @@
                         <!-- NEWS -->
                         <GroupBox Grid.Row="0" Grid.Column="2" Header="News" Margin="0,0,8,0"
                                   Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
-                                  BorderBrush="{DynamicResource Divider}" VerticalAlignment="Stretch">
+                                  BorderBrush="{DynamicResource Divider}" VerticalAlignment="Stretch"
+                                  VerticalContentAlignment="Top">
                                 <ListView x:Name="NewsList" Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
                                           ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                          Loaded="NewsList_Loaded" SizeChanged="NewsList_SizeChanged">
+                                          Loaded="NewsList_Loaded" SizeChanged="NewsList_SizeChanged"
+                                          VerticalAlignment="Stretch">
                                         <ListView.ItemContainerStyle>
                                             <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Type ListViewItem}}">
                                                 <Setter Property="VerticalContentAlignment" Value="Top" />


### PR DESCRIPTION
## Summary
- Align news list from the top by setting GroupBox VerticalContentAlignment to Top and stretching the ListView

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9d52a6dc8333b24087558cd18923