### PR TITLE
Use exchange-specific timestamp fields

### DIFF
--- a/ListingWatcherService/ListingWatcherService.cs
+++ b/ListingWatcherService/ListingWatcherService.cs
@@ -172,7 +172,8 @@ public sealed class ListingWatcherService : BackgroundService
 
             var stableId = urlItem ?? rawId;
             _logger.LogInformation("Bybit new listing: {Title} {Url}", title, urlItem);
-            var cTimeMs = el.TryGetProperty("createdAt", out var pTime) && long.TryParse(pTime.GetString(), out var t)
+            // Bybit exposes the announcement timestamp as "dateTimestamp"
+            var cTimeMs = el.TryGetProperty("dateTimestamp", out var pTime) && long.TryParse(pTime.GetString(), out var t)
                 ? t
                 : DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             await ProcessListingAsync("bybit", stableId, title, urlItem, DateTimeOffset.FromUnixTimeMilliseconds(cTimeMs), ct);

--- a/NewListingsRss.cs
+++ b/NewListingsRss.cs
@@ -75,7 +75,10 @@ MapRssEndpoint(
             var title = it.TryGetProperty("title", out var pTitle) ? pTitle.GetString() ?? "(no title)" : "(no title)";
             var desc = it.TryGetProperty("description", out var pDesc) ? pDesc.GetString() : null;
             var urlItem = it.TryGetProperty("link", out var pUrl) ? pUrl.GetString() : null;
-            var cTimeMs = it.TryGetProperty("createdAt", out var pTime) && long.TryParse(pTime.GetString(), out var t) ? t : DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            // Bybit provides announcement timestamps in the "dateTimestamp" field
+            var cTimeMs = it.TryGetProperty("dateTimestamp", out var pTime) && long.TryParse(pTime.GetString(), out var t)
+                ? t
+                : DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             list.Add(new FeedItem(id, title, desc, urlItem, DateTimeOffset.FromUnixTimeMilliseconds(cTimeMs)));
         }
         return list;

--- a/RssBridge.Program.cs
+++ b/RssBridge.Program.cs
@@ -159,10 +159,10 @@ public static class RssBridgeProgram
     {
         var id = it.TryGetProperty("id", out var pId) ? pId.GetString() ?? Guid.NewGuid().ToString("n") : Guid.NewGuid().ToString("n");
         var title = it.TryGetProperty("title", out var pTitle) ? pTitle.GetString() ?? "(no title)" : "(no title)";
-        // The new announcements API exposes description/link/createdAt fields.
+        // The new announcements API exposes description/link/dateTimestamp fields.
         var desc = it.TryGetProperty("description", out var pDesc) ? pDesc.GetString() : null;
         var url = it.TryGetProperty("link", out var pUrl) ? pUrl.GetString() : null;
-        var ts = it.TryGetProperty("createdAt", out var pTs) && long.TryParse(pTs.GetString(), out var t)
+        var ts = it.TryGetProperty("dateTimestamp", out var pTs) && long.TryParse(pTs.GetString(), out var t)
             ? DateTimeOffset.FromUnixTimeMilliseconds(t)
             : DateTimeOffset.UtcNow;
         return new FeedItem(id, title, desc, url, ts);


### PR DESCRIPTION
## Summary
- read Bybit listing timestamps from `dateTimestamp`
- document exchange date fields in RSS bridge and watcher

## Testing
- `dotnet build ListingWatcherService/ListingWatcherService.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 403 Forbidden from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9fe936c88333947432a9356bd2d8