### PR TITLE
Refine News section layout

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -715,30 +715,31 @@
                                   Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
                                   BorderBrush="{DynamicResource Divider}" VerticalAlignment="Stretch"
                                   VerticalContentAlignment="Top">
-                                <ListView x:Name="NewsList" Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
+                                <DataGrid x:Name="NewsList" Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
+                                          AutoGenerateColumns="False" HeadersVisibility="Column" IsReadOnly="True"
                                           ScrollViewer.VerticalScrollBarVisibility="Auto"
                                           Loaded="NewsList_Loaded" SizeChanged="NewsList_SizeChanged"
                                           VerticalAlignment="Stretch">
-                                        <ListView.ItemContainerStyle>
-                                            <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Type ListViewItem}}">
-                                                <Setter Property="VerticalContentAlignment" Value="Top" />
-                                            </Style>
-                                        </ListView.ItemContainerStyle>
-                                        <ListView.View>
-                                            <GridView>
-                                            <GridViewColumn Header="Kaynak" Width="80" DisplayMemberBinding="{Binding Source}" />
-                                            <GridViewColumn Header="Sembol" Width="80" DisplayMemberBinding="{Binding SymbolsDisplay}" />
-                                            <GridViewColumn Header="Zaman" Width="170" DisplayMemberBinding="{Binding Timestamp, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}" />
-                                            <GridViewColumn Header="Başlık">
-                                                    <GridViewColumn.CellTemplate>
-                                                        <DataTemplate>
-                                                            <TextBlock Text="{Binding Title}" TextWrapping="Wrap"/>
-                                                        </DataTemplate>
-                                                    </GridViewColumn.CellTemplate>
-                                                </GridViewColumn>
-                                            </GridView>
-                                        </ListView.View>
-                                </ListView>
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="Kaynak" Width="80" Binding="{Binding Source}"/>
+                                        <DataGridTextColumn Header="Sembol" Width="80" Binding="{Binding SymbolsDisplay}"/>
+                                        <DataGridTextColumn Header="Zaman" Width="170" Binding="{Binding Timestamp, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}"/>
+                    <DataGridTemplateColumn Header="Başlık" Width="*">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{Binding Title}" TextWrapping="Wrap"/>
+                                    <StackPanel Grid.Column="1" Orientation="Horizontal"/>
+                                </Grid>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                                    </DataGrid.Columns>
+                                </DataGrid>
                         </GroupBox>
 
                         <!-- TOP MOVERS -->

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -113,14 +113,17 @@ namespace BinanceUsdtTicker
             // emir listeleri bağla
             void SetupList(string name, IEnumerable? source = null)
             {
-                if (FindName(name) is ListView lv)
+                if (FindName(name) is ItemsControl ic)
                 {
                     if (source != null)
-                        lv.ItemsSource = source;
+                        ic.ItemsSource = source;
 
-                    lv.Height = screenHeight;
-                    lv.MinHeight = screenHeight;
-                    lv.MaxHeight = screenHeight;
+                    if (ic is FrameworkElement fe)
+                    {
+                        fe.Height = screenHeight;
+                        fe.MinHeight = screenHeight;
+                        fe.MaxHeight = screenHeight;
+                    }
                 }
             }
 
@@ -1258,7 +1261,7 @@ namespace BinanceUsdtTicker
 
         private void AdjustNewsTitleColumnWidth()
         {
-            var newsList = Q<ListView>("NewsList");
+            var newsList = Q<DataGrid>("NewsList");
             if (newsList == null) return;
 
             // Increase the News section height so more items are visible
@@ -1267,17 +1270,15 @@ namespace BinanceUsdtTicker
             newsList.MinHeight = screenHeight;
             newsList.MaxHeight = screenHeight;
 
-            if (newsList.View is not GridView gv) return;
-
-            GridViewColumn? titleCol = gv.Columns.FirstOrDefault(c =>
+            DataGridColumn? titleCol = newsList.Columns.FirstOrDefault(c =>
                 string.Equals(c.Header?.ToString(), "Başlık", StringComparison.OrdinalIgnoreCase));
             if (titleCol == null) return;
 
             double fixedSum = 0;
-            foreach (var col in gv.Columns)
+            foreach (var col in newsList.Columns)
             {
                 if (ReferenceEquals(col, titleCol)) continue;
-                var w = col.Width;
+                var w = col.ActualWidth;
                 if (double.IsNaN(w) || w <= 0) w = 100;
                 fixedSum += w;
             }
@@ -1291,7 +1292,7 @@ namespace BinanceUsdtTicker
                 scroll = SystemParameters.VerticalScrollBarWidth;
 
             double newWidth = Math.Max(100, total - fixedSum - padding - scroll);
-            titleCol.Width = newWidth;
+            titleCol.Width = new DataGridLength(newWidth, DataGridLengthUnitType.Pixel);
         }
 
         private static T? FindDescendant<T>(DependencyObject root) where T : DependencyObject


### PR DESCRIPTION
## Summary
- Replace News ListView with DataGrid for cleaner layout and auto-resizing title column
- Prepare title column with layout for future per-item action buttons
- Generalize list setup helper for ItemsControls and adjust column width logic for DataGrid

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bce4eb6af083338d00787ebd07c307