### PR TITLE
Arrange news action buttons vertically and enlarge

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -744,17 +744,17 @@
                                                 <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                                                     <!-- Symbol label -->
                                                     <TextBlock Text="{Binding}" Margin="0,0,6,0"/>
-                                                    <UniformGrid Rows="1" Columns="8">
+                                                    <UniformGrid Rows="2" Columns="4">
                                                         <!-- 4 green buy buttons -->
-                                                        <Button Content="%25" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Padding="4,2"/>
-                                                        <Button Content="%50" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Padding="4,2"/>
-                                                        <Button Content="%75" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Padding="4,2"/>
-                                                        <Button Content="%100" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Padding="4,2"/>
+                                                        <Button Content="%25" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="56" Height="32" FontSize="14"/>
+                                                        <Button Content="%50" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="56" Height="32" FontSize="14"/>
+                                                        <Button Content="%75" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="56" Height="32" FontSize="14"/>
+                                                        <Button Content="%100" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="56" Height="32" FontSize="14"/>
                                                         <!-- 4 red sell buttons -->
-                                                        <Button Content="%25" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Padding="4,2"/>
-                                                        <Button Content="%50" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Padding="4,2"/>
-                                                        <Button Content="%75" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Padding="4,2"/>
-                                                        <Button Content="%100" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Padding="4,2"/>
+                                                        <Button Content="%25" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="56" Height="32" FontSize="14"/>
+                                                        <Button Content="%50" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="56" Height="32" FontSize="14"/>
+                                                        <Button Content="%75" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="56" Height="32" FontSize="14"/>
+                                                        <Button Content="%100" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="56" Height="32" FontSize="14"/>
                                                     </UniformGrid>
                                                 </StackPanel>
                                             </DataTemplate>


### PR DESCRIPTION
## Summary
- Display sell buttons underneath buy buttons for each news symbol
- Increase action button size for better usability

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5ce49bf883338020639d110330df