### PR TITLE
Enlarge trading buttons for readability

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -746,15 +746,15 @@
                                                     <TextBlock Text="{Binding}" Margin="0,0,6,0"/>
                                                     <UniformGrid Rows="2" Columns="4">
                                                         <!-- 4 green buy buttons -->
-                                                        <Button Content="%25" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="56" Height="32" FontSize="14"/>
-                                                        <Button Content="%50" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="56" Height="32" FontSize="14"/>
-                                                        <Button Content="%75" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="56" Height="32" FontSize="14"/>
-                                                        <Button Content="%100" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="56" Height="32" FontSize="14"/>
+                                                        <Button Content="%25" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
+                                                        <Button Content="%50" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
+                                                        <Button Content="%75" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
+                                                        <Button Content="%100" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
                                                         <!-- 4 red sell buttons -->
-                                                        <Button Content="%25" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="56" Height="32" FontSize="14"/>
-                                                        <Button Content="%50" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="56" Height="32" FontSize="14"/>
-                                                        <Button Content="%75" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="56" Height="32" FontSize="14"/>
-                                                        <Button Content="%100" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="56" Height="32" FontSize="14"/>
+                                                        <Button Content="%25" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
+                                                        <Button Content="%50" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
+                                                        <Button Content="%75" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
+                                                        <Button Content="%100" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
                                                     </UniformGrid>
                                                 </StackPanel>
                                             </DataTemplate>


### PR DESCRIPTION
## Summary
- Increase news symbol trade buttons size to 72x40
- Use larger, bold text for better legibility

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5dcc26988333894cc24e5a770fa9