### PR TITLE
Refactor news view into card layout

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -721,51 +721,49 @@
                                   Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
                                   BorderBrush="{DynamicResource Divider}" VerticalAlignment="Stretch"
                                   VerticalContentAlignment="Top" HorizontalContentAlignment="Stretch">
-                                <DataGrid x:Name="NewsList" Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
-                                          AutoGenerateColumns="False" HeadersVisibility="Column" IsReadOnly="True"
+                                <ListView x:Name="NewsList" Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
                                           ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                          Loaded="NewsList_Loaded" SizeChanged="NewsList_SizeChanged"
-                                          VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
-                                    <DataGrid.Columns>
-                                        <DataGridTextColumn Header="Kaynak" Width="80" Binding="{Binding Source}"/>
-                                        <DataGridTextColumn Header="Sembol" Width="80" Binding="{Binding SymbolsDisplay}"/>
-                                        <DataGridTextColumn Header="Zaman" Width="170" Binding="{Binding Timestamp, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}"/>
-                    <DataGridTemplateColumn Header="Başlık" Width="*">
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate>
-                                <StackPanel>
-                                    <!-- News headline -->
-                                    <TextBlock Text="{Binding Title}" TextWrapping="Wrap"/>
-
-                                    <!-- Buttons for each symbol -->
-                                    <ItemsControl ItemsSource="{Binding Symbols}">
-                                        <ItemsControl.ItemTemplate>
-                                            <DataTemplate>
-                                                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                                                    <!-- Symbol label -->
-                                                    <TextBlock Text="{Binding}" Margin="0,0,6,0"/>
-                                                    <UniformGrid Rows="2" Columns="4">
-                                                        <!-- 4 green buy buttons -->
-                                                        <Button Content="%25" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
-                                                        <Button Content="%50" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
-                                                        <Button Content="%75" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
-                                                        <Button Content="%100" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
-                                                        <!-- 4 red sell buttons -->
-                                                        <Button Content="%25" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
-                                                        <Button Content="%50" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
-                                                        <Button Content="%75" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
-                                                        <Button Content="%100" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
-                                                    </UniformGrid>
+                                          VirtualizingStackPanel.IsVirtualizing="True"
+                                          VirtualizingStackPanel.VirtualizationMode="Recycling">
+                                    <ListView.ItemTemplate>
+                                        <DataTemplate>
+                                            <materialDesign:Card Margin="4" Padding="8" Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}">
+                                                <StackPanel>
+                                                    <!-- Source -->
+                                                    <TextBlock Text="{Binding Source}" FontWeight="Bold" Margin="0,0,0,4"/>
+                                                    <!-- Time and title -->
+                                                    <StackPanel Orientation="Horizontal">
+                                                        <TextBlock Text="{Binding Timestamp, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}"/>
+                                                        <TextBlock Text="{Binding Title}" TextWrapping="Wrap" Margin="8,0,0,0"/>
+                                                    </StackPanel>
+                                                    <!-- Buttons for each symbol -->
+                                                    <ItemsControl ItemsSource="{Binding Symbols}" Margin="0,4,0,0">
+                                                        <ItemsControl.ItemTemplate>
+                                                            <DataTemplate>
+                                                                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                                                                    <!-- Symbol label -->
+                                                                    <TextBlock Text="{Binding}" Margin="0,0,6,0"/>
+                                                                    <UniformGrid Rows="2" Columns="4">
+                                                                        <!-- 4 green buy buttons -->
+                                                                        <Button Content="%25" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
+                                                                        <Button Content="%50" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
+                                                                        <Button Content="%75" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
+                                                                        <Button Content="%100" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
+                                                                        <!-- 4 red sell buttons -->
+                                                                        <Button Content="%25" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
+                                                                        <Button Content="%50" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
+                                                                        <Button Content="%75" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
+                                                                        <Button Content="%100" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
+                                                                    </UniformGrid>
+                                                                </StackPanel>
+                                                            </DataTemplate>
+                                                        </ItemsControl.ItemTemplate>
+                                                    </ItemsControl>
                                                 </StackPanel>
-                                            </DataTemplate>
-                                        </ItemsControl.ItemTemplate>
-                                    </ItemsControl>
-                                </StackPanel>
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>
-                                    </DataGrid.Columns>
-                                </DataGrid>
+                                            </materialDesign:Card>
+                                        </DataTemplate>
+                                    </ListView.ItemTemplate>
+                                </ListView>
                         </GroupBox>
 
                         <!-- TOP MOVERS -->

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1225,9 +1225,6 @@ namespace BinanceUsdtTicker
         private void AlertList_Loaded(object sender, RoutedEventArgs e) => AdjustAlertMsgColumnWidth();
         private void AlertList_SizeChanged(object sender, SizeChangedEventArgs e) => AdjustAlertMsgColumnWidth();
 
-        private void NewsList_Loaded(object sender, RoutedEventArgs e) => AdjustNewsTitleColumnWidth();
-        private void NewsList_SizeChanged(object sender, SizeChangedEventArgs e) => AdjustNewsTitleColumnWidth();
-
         private void AdjustAlertMsgColumnWidth()
         {
             var alertList = Q<ListView>("AlertList");
@@ -1257,42 +1254,6 @@ namespace BinanceUsdtTicker
 
             double newWidth = Math.Max(120, total - fixedSum - padding - scroll);
             msgCol.Width = newWidth;
-        }
-
-        private void AdjustNewsTitleColumnWidth()
-        {
-            var newsList = Q<DataGrid>("NewsList");
-            if (newsList == null) return;
-
-            // Increase the News section height so more items are visible
-            double screenHeight = SystemParameters.PrimaryScreenHeight / 3;
-            newsList.Height = screenHeight;
-            newsList.MinHeight = screenHeight;
-            newsList.MaxHeight = screenHeight;
-
-            DataGridColumn? titleCol = newsList.Columns.FirstOrDefault(c =>
-                string.Equals(c.Header?.ToString(), "Başlık", StringComparison.OrdinalIgnoreCase));
-            if (titleCol == null) return;
-
-            double fixedSum = 0;
-            foreach (var col in newsList.Columns)
-            {
-                if (ReferenceEquals(col, titleCol)) continue;
-                var w = col.ActualWidth;
-                if (double.IsNaN(w) || w <= 0) w = 100;
-                fixedSum += w;
-            }
-
-            double total = newsList.ActualWidth;
-            double padding = 35;
-
-            double scroll = 0;
-            var sv = FindDescendant<ScrollViewer>(newsList);
-            if (sv != null && sv.ComputedVerticalScrollBarVisibility == Visibility.Visible)
-                scroll = SystemParameters.VerticalScrollBarWidth;
-
-            double newWidth = Math.Max(100, total - fixedSum - padding - scroll);
-            titleCol.Width = new DataGridLength(newWidth, DataGridLengthUnitType.Pixel);
         }
 
         private static T? FindDescendant<T>(DependencyObject root) where T : DependencyObject


### PR DESCRIPTION
## Summary
- Replace news DataGrid with card-based ListView
- Remove obsolete DataGrid sizing handlers

## Testing
- ⚠️ `dotnet build` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd63314dec8333ba9612a99309ac3f