### PR TITLE
Add dynamic logos for Bybit, KuCoin and OKX news items

### DIFF
--- a/Converters/SourceToLogoConverter.cs
+++ b/Converters/SourceToLogoConverter.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace BinanceUsdtTicker
+{
+    public class SourceToLogoConverter : IValueConverter
+    {
+        public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is not string src)
+                return null;
+
+            src = src.ToLowerInvariant();
+            return src switch
+            {
+                "bybit" => CreateLogo("BYBIT", Color.FromRgb(0xF7, 0x93, 0x1A), Colors.White),
+                "kucoin" => CreateLogo("KUCOIN", Color.FromRgb(0x28, 0xD1, 0xA7), Colors.White),
+                "okx" => CreateLogo("OKX", Colors.Black, Colors.White),
+                _ => null,
+            };
+        }
+
+        private static ImageSource CreateLogo(string text, Color background, Color foreground)
+        {
+            var ft = new FormattedText(
+                text,
+                CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight,
+                new Typeface("Segoe UI", FontStyles.Normal, FontWeights.Bold, FontStretches.Normal),
+                16,
+                new SolidColorBrush(foreground),
+                1.0);
+
+            var width = Math.Ceiling(ft.Width) + 4;
+            var height = Math.Ceiling(ft.Height) + 4;
+
+            var dv = new DrawingVisual();
+            using (var ctx = dv.RenderOpen())
+            {
+                ctx.DrawRectangle(new SolidColorBrush(background), null, new Rect(0, 0, width, height));
+                ctx.DrawText(ft, new System.Windows.Point(2, 2));
+            }
+
+            var bmp = new RenderTargetBitmap((int)width, (int)height, 96, 96, PixelFormats.Pbgra32);
+            bmp.Render(dv);
+            return bmp;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => throw new NotSupportedException();
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -12,6 +12,7 @@
 	<!-- ========== RESOURCES ========== -->
         <Window.Resources>
                 <local:SideToBrushConverter x:Key="SideToBrush"/>
+                <local:SourceToLogoConverter x:Key="SourceToLogo"/>
                 <!-- Şeffaf yıldız -->
                 <Style x:Key="StarToggleStyle" TargetType="ToggleButton">
 			<Setter Property="OverridesDefaultStyle" Value="True"/>
@@ -730,7 +731,10 @@
                                             <materialDesign:Card Margin="4" Padding="8" Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}">
                                                 <StackPanel>
                                                     <!-- Source -->
-                                                    <TextBlock Text="{Binding Source}" FontWeight="Bold" Margin="0,0,0,4"/>
+                                                    <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                                                        <Image Source="{Binding Source, Converter={StaticResource SourceToLogo}}" Width="24" Height="24" Margin="0,0,4,0"/>
+                                                        <TextBlock Text="{Binding Source}" FontWeight="Bold" VerticalAlignment="Center"/>
+                                                    </StackPanel>
                                                     <!-- Time and title -->
                                                     <StackPanel Orientation="Horizontal">
                                                         <TextBlock Text="{Binding Timestamp, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}"/>


### PR DESCRIPTION
## Summary
- generate simple logos for Bybit, KuCoin and OKX sources at runtime
- show these logos beside the news source label in the feed

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd661ca0148333afa5678a3fb45705