### PR TITLE
fix: reference missing WPF types

### DIFF
--- a/Converters/SourceToLogoConverter.cs
+++ b/Converters/SourceToLogoConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -29,7 +30,7 @@ namespace BinanceUsdtTicker
                 text,
                 CultureInfo.InvariantCulture,
                 FlowDirection.LeftToRight,
-                new Typeface("Segoe UI", FontStyles.Normal, FontWeights.Bold, FontStretches.Normal),
+                new Typeface(new FontFamily("Segoe UI"), FontStyles.Normal, FontWeights.Bold, FontStretches.Normal),
                 16,
                 new SolidColorBrush(foreground),
                 1.0);


### PR DESCRIPTION
## Summary
- import System.Windows to use FlowDirection, FontStyles, FontWeights, etc.
- construct Typeface with FontFamily to satisfy WPF API

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bd67f94be48333895d5fb3ee8fc504