### PR TITLE
Render basic logos for news sources

### DIFF
--- a/Converters/SourceToLogoConverter.cs
+++ b/Converters/SourceToLogoConverter.cs
@@ -17,24 +17,32 @@ namespace BinanceUsdtTicker
             src = src.ToLowerInvariant();
             return src switch
             {
-                "bybit" => CreateLogo(Color.FromRgb(0xF7, 0x93, 0x1A)),
-                "kucoin" => CreateLogo(Color.FromRgb(0x28, 0xD1, 0xA7)),
-                "okx" => CreateLogo(Colors.Black),
+                "bybit" => CreateLogo("B", Color.FromRgb(0xF7, 0x93, 0x1A)),
+                "kucoin" => CreateLogo("K", Color.FromRgb(0x28, 0xD1, 0xA7)),
+                "okx" => CreateLogo("O", Colors.Black),
                 _ => null,
             };
         }
 
-        private static ImageSource CreateLogo(Color background)
+        private static ImageSource CreateLogo(string text, Color background)
         {
             const int size = 32;
             var dv = new DrawingVisual();
             using (var ctx = dv.RenderOpen())
             {
                 ctx.DrawRectangle(new SolidColorBrush(background), null, new Rect(0, 0, size, size));
+
+                var typeface = new Typeface("Segoe UI");
+                var pixelsPerDip = VisualTreeHelper.GetDpi(dv).PixelsPerDip;
+                var ft = new FormattedText(text, CultureInfo.InvariantCulture,
+                    FlowDirection.LeftToRight, typeface, 20, Brushes.White, pixelsPerDip);
+                var p = new Point((size - ft.Width) / 2, (size - ft.Height) / 2);
+                ctx.DrawText(ft, p);
             }
 
             var bmp = new RenderTargetBitmap(size, size, 96, 96, PixelFormats.Pbgra32);
             bmp.Render(dv);
+            bmp.Freeze();
             return bmp;
         }
 


### PR DESCRIPTION
## Summary
- Draw simple text-based logos for Bybit, KuCoin, and OKX news sources so their icons appear in the feed

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6bdb9b4483338ec0e5318ed4fcdc