### PR TITLE
Enlarge exchange logos and remove text labels

### DIFF
--- a/Converters/SourceToLogoConverter.cs
+++ b/Converters/SourceToLogoConverter.cs
@@ -26,7 +26,7 @@ namespace BinanceUsdtTicker
 
         private static ImageSource CreateLogo(string text, Color background)
         {
-            const int size = 32;
+            const int size = 64;
             var dv = new DrawingVisual();
             using (var ctx = dv.RenderOpen())
             {
@@ -35,7 +35,7 @@ namespace BinanceUsdtTicker
                 var typeface = new Typeface("Segoe UI");
                 var pixelsPerDip = VisualTreeHelper.GetDpi(dv).PixelsPerDip;
                 var ft = new FormattedText(text, CultureInfo.InvariantCulture,
-                    FlowDirection.LeftToRight, typeface, 20, Brushes.White, pixelsPerDip);
+                    FlowDirection.LeftToRight, typeface, 40, Brushes.White, pixelsPerDip);
                 var p = new Point((size - ft.Width) / 2, (size - ft.Height) / 2);
                 ctx.DrawText(ft, p);
             }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -731,10 +731,7 @@
                                             <materialDesign:Card Margin="4" Padding="8" Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}">
                                                 <StackPanel>
                                                     <!-- Source -->
-                                                    <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-                                                        <Image Source="{Binding Source, Converter={StaticResource SourceToLogo}}" Width="32" Height="32" Margin="0,0,4,0"/>
-                                                        <TextBlock Text="{Binding Source}" FontWeight="Bold" VerticalAlignment="Center"/>
-                                                    </StackPanel>
+                                                    <Image Source="{Binding Source, Converter={StaticResource SourceToLogo}}" Width="64" Height="64" Margin="0,0,0,4"/>
                                                     <!-- Time and title -->
                                                     <StackPanel Orientation="Horizontal">
                                                         <TextBlock Text="{Binding Timestamp, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}"/>


### PR DESCRIPTION
## Summary
- Enlarge generated exchange logos to 64x64
- Remove Bybit/KuCoin/OKX text labels so only logos show

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 and unsigned)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6d7fddfc8333bcf4ba43491dfced