### PR TITLE
fix: use FontFamily when creating typefaces

### DIFF
--- a/Converters/SourceToLogoConverter.cs
+++ b/Converters/SourceToLogoConverter.cs
@@ -32,7 +32,7 @@ namespace BinanceUsdtTicker
             {
                 ctx.DrawRectangle(Brushes.Black, null, new Rect(0, 0, size, size));
 
-                var typeface = new Typeface("Segoe UI", FontStyles.Normal, FontWeights.Bold, FontStretches.Normal);
+                var typeface = new Typeface(new FontFamily("Segoe UI"), FontStyles.Normal, FontWeights.Bold, FontStretches.Normal);
                 var dpi = VisualTreeHelper.GetDpi(dv).PixelsPerDip;
 
                 var part1 = new FormattedText("BYB", CultureInfo.InvariantCulture, FlowDirection.LeftToRight, typeface, 24, Brushes.White, dpi);
@@ -62,7 +62,7 @@ namespace BinanceUsdtTicker
             {
                 ctx.DrawRectangle(Brushes.White, null, new Rect(0, 0, size, size));
 
-                var typeface = new Typeface("Segoe UI", FontStyles.Normal, FontWeights.Bold, FontStretches.Normal);
+                var typeface = new Typeface(new FontFamily("Segoe UI"), FontStyles.Normal, FontWeights.Bold, FontStretches.Normal);
                 var dpi = VisualTreeHelper.GetDpi(dv).PixelsPerDip;
                 var color = new SolidColorBrush(Color.FromRgb(0x28, 0xD1, 0xA7));
 
@@ -85,7 +85,7 @@ namespace BinanceUsdtTicker
             {
                 ctx.DrawRectangle(Brushes.Black, null, new Rect(0, 0, size, size));
 
-                var typeface = new Typeface("Segoe UI", FontStyles.Normal, FontWeights.Bold, FontStretches.Normal);
+                var typeface = new Typeface(new FontFamily("Segoe UI"), FontStyles.Normal, FontWeights.Bold, FontStretches.Normal);
                 var dpi = VisualTreeHelper.GetDpi(dv).PixelsPerDip;
 
                 var ft = new FormattedText("OKX", CultureInfo.InvariantCulture, FlowDirection.LeftToRight, typeface, 24, Brushes.White, dpi);


### PR DESCRIPTION
## Summary
- construct Typeface using FontFamily instead of raw strings to resolve compile errors

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd71c63d988333aa8428d4bbdae9f6