### PR TITLE
Remove leftover merge marker causing XAML parse error

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -757,7 +757,6 @@
                                                         <Button Content="%75" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
                                                         <Button Content="%100" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
                                                     </UniformGrid>
->>>>>>> parent of 0a07e7e (Replace news table with card layout)
                                                 </StackPanel>
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>


### PR DESCRIPTION
## Summary
- remove stray merge conflict marker from MainWindow news section template

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7398db4883339e342f53b79b6e8e