### PR TITLE
Refactor news section into card layout

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -722,51 +722,90 @@
                                   Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
                                   BorderBrush="{DynamicResource Divider}" VerticalAlignment="Stretch"
                                   VerticalContentAlignment="Top" HorizontalContentAlignment="Stretch">
-                                <DataGrid x:Name="NewsList" Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
-                                          AutoGenerateColumns="False" HeadersVisibility="Column" IsReadOnly="True"
-                                          ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                          Loaded="NewsList_Loaded" SizeChanged="NewsList_SizeChanged"
-                                          VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
-                                    <DataGrid.Columns>
-                                        <DataGridTextColumn Header="Kaynak" Width="80" Binding="{Binding Source}"/>
-                                        <DataGridTextColumn Header="Sembol" Width="80" Binding="{Binding SymbolsDisplay}"/>
-                                        <DataGridTextColumn Header="Zaman" Width="170" Binding="{Binding Timestamp, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}"/>
-                    <DataGridTemplateColumn Header="Başlık" Width="*">
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate>
-                                <StackPanel>
-                                    <!-- News headline -->
-                                    <TextBlock Text="{Binding Title}" TextWrapping="Wrap"/>
-
-                                    <!-- Buttons for each symbol -->
-                                    <ItemsControl ItemsSource="{Binding Symbols}">
-                                        <ItemsControl.ItemTemplate>
+                                <ListView x:Name="NewsList" Background="{DynamicResource SurfaceAlt}"
+                                          Foreground="{DynamicResource OnSurface}" BorderThickness="0"
+                                          ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                    <ListView.ItemTemplate>
                                             <DataTemplate>
-                                                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                                                    <!-- Symbol label -->
-                                                    <TextBlock Text="{Binding}" Margin="0,0,6,0"/>
-                                                    <UniformGrid Rows="2" Columns="4">
-                                                        <!-- 4 green buy buttons -->
-                                                        <Button Content="%25" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
-                                                        <Button Content="%50" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
-                                                        <Button Content="%75" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
-                                                        <Button Content="%100" Background="{DynamicResource Up1Bg}" Foreground="{DynamicResource Up1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
-                                                        <!-- 4 red sell buttons -->
-                                                        <Button Content="%25" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
-                                                        <Button Content="%50" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
-                                                        <Button Content="%75" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
-                                                        <Button Content="%100" Background="{DynamicResource Down1Bg}" Foreground="{DynamicResource Down1Fg}" Margin="2" Width="72" Height="40" FontSize="16" FontWeight="Bold"/>
-                                                    </UniformGrid>
-                                                </StackPanel>
+                                                <Border Margin="4" Padding="6" BorderBrush="{DynamicResource Divider}"
+                                                        BorderThickness="1">
+                                                    <StackPanel>
+                                                        <!-- Source information with logo -->
+                                                        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                                                            <Image Source="{Binding Source, Converter={StaticResource SourceToLogo}}"
+                                                                   Width="24" Height="24" Margin="0,0,6,0"/>
+                                                            <TextBlock Text="{Binding Source}" FontWeight="Bold">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding Source, Converter={StaticResource SourceToLogo}}" Value="{x:Null}">
+                                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
+                                                        </StackPanel>
+
+                                                        <!-- Time and title on first line -->
+                                                        <TextBlock TextWrapping="Wrap">
+                                                            <Run Text="{Binding Timestamp, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}"/>
+                                                            <Run Text=" "/>
+                                                            <Run Text="{Binding Title}"/>
+                                                        </TextBlock>
+
+                                                        <!-- Symbols with action buttons -->
+                                                        <ItemsControl ItemsSource="{Binding Symbols}" Margin="0,4,0,0">
+                                                            <ItemsControl.ItemTemplate>
+                                                                <DataTemplate>
+                                                                    <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                                                                        <TextBlock Text="{Binding}" Margin="0,0,6,0"/>
+                                                                        <UniformGrid Rows="2" Columns="4">
+                                                                            <!-- 4 green buy buttons -->
+                                                                            <Button Content="%25" Background="{DynamicResource Up1Bg}"
+                                                                                    Foreground="{DynamicResource Up1Fg}"
+                                                                                    Margin="2" Width="72" Height="40"
+                                                                                    FontSize="16" FontWeight="Bold"/>
+                                                                            <Button Content="%50" Background="{DynamicResource Up1Bg}"
+                                                                                    Foreground="{DynamicResource Up1Fg}"
+                                                                                    Margin="2" Width="72" Height="40"
+                                                                                    FontSize="16" FontWeight="Bold"/>
+                                                                            <Button Content="%75" Background="{DynamicResource Up1Bg}"
+                                                                                    Foreground="{DynamicResource Up1Fg}"
+                                                                                    Margin="2" Width="72" Height="40"
+                                                                                    FontSize="16" FontWeight="Bold"/>
+                                                                            <Button Content="%100" Background="{DynamicResource Up1Bg}"
+                                                                                    Foreground="{DynamicResource Up1Fg}"
+                                                                                    Margin="2" Width="72" Height="40"
+                                                                                    FontSize="16" FontWeight="Bold"/>
+                                                                            <!-- 4 red sell buttons -->
+                                                                            <Button Content="%25" Background="{DynamicResource Down1Bg}"
+                                                                                    Foreground="{DynamicResource Down1Fg}"
+                                                                                    Margin="2" Width="72" Height="40"
+                                                                                    FontSize="16" FontWeight="Bold"/>
+                                                                            <Button Content="%50" Background="{DynamicResource Down1Bg}"
+                                                                                    Foreground="{DynamicResource Down1Fg}"
+                                                                                    Margin="2" Width="72" Height="40"
+                                                                                    FontSize="16" FontWeight="Bold"/>
+                                                                            <Button Content="%75" Background="{DynamicResource Down1Bg}"
+                                                                                    Foreground="{DynamicResource Down1Fg}"
+                                                                                    Margin="2" Width="72" Height="40"
+                                                                                    FontSize="16" FontWeight="Bold"/>
+                                                                            <Button Content="%100" Background="{DynamicResource Down1Bg}"
+                                                                                    Foreground="{DynamicResource Down1Fg}"
+                                                                                    Margin="2" Width="72" Height="40"
+                                                                                    FontSize="16" FontWeight="Bold"/>
+                                                                        </UniformGrid>
+                                                                    </StackPanel>
+                                                                </DataTemplate>
+                                                            </ItemsControl.ItemTemplate>
+                                                        </ItemsControl>
+                                                    </StackPanel>
+                                                </Border>
                                             </DataTemplate>
-                                        </ItemsControl.ItemTemplate>
-                                    </ItemsControl>
-                                </StackPanel>
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>
-                                    </DataGrid.Columns>
-                                </DataGrid>
+                                        </ListView.ItemTemplate>
+                                    </ListView>
                         </GroupBox>
 
                         <!-- TOP MOVERS -->

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -133,6 +133,15 @@ namespace BinanceUsdtTicker
             SetupList("TradeHistoryList", _tradeHistory);
             SetupList("NewsList", _newsItems, useScreenHeight: false);
 
+            // Ensure the News section shows multiple items
+            if (FindName("NewsList") is ListView newsList)
+            {
+                double newsHeight = SystemParameters.PrimaryScreenHeight / 3;
+                newsList.Height = newsHeight;
+                newsList.MinHeight = newsHeight;
+                newsList.MaxHeight = newsHeight;
+            }
+
             // show most recent orders/trades first
             var orderView = CollectionViewSource.GetDefaultView(_orderHistory);
             orderView.SortDescriptions.Clear();
@@ -1225,9 +1234,6 @@ namespace BinanceUsdtTicker
         private void AlertList_Loaded(object sender, RoutedEventArgs e) => AdjustAlertMsgColumnWidth();
         private void AlertList_SizeChanged(object sender, SizeChangedEventArgs e) => AdjustAlertMsgColumnWidth();
 
-        private void NewsList_Loaded(object sender, RoutedEventArgs e) => AdjustNewsTitleColumnWidth();
-        private void NewsList_SizeChanged(object sender, SizeChangedEventArgs e) => AdjustNewsTitleColumnWidth();
-
         private void AdjustAlertMsgColumnWidth()
         {
             var alertList = Q<ListView>("AlertList");
@@ -1257,42 +1263,6 @@ namespace BinanceUsdtTicker
 
             double newWidth = Math.Max(120, total - fixedSum - padding - scroll);
             msgCol.Width = newWidth;
-        }
-
-        private void AdjustNewsTitleColumnWidth()
-        {
-            var newsList = Q<DataGrid>("NewsList");
-            if (newsList == null) return;
-
-            // Increase the News section height so more items are visible
-            double screenHeight = SystemParameters.PrimaryScreenHeight / 3;
-            newsList.Height = screenHeight;
-            newsList.MinHeight = screenHeight;
-            newsList.MaxHeight = screenHeight;
-
-            DataGridColumn? titleCol = newsList.Columns.FirstOrDefault(c =>
-                string.Equals(c.Header?.ToString(), "Başlık", StringComparison.OrdinalIgnoreCase));
-            if (titleCol == null) return;
-
-            double fixedSum = 0;
-            foreach (var col in newsList.Columns)
-            {
-                if (ReferenceEquals(col, titleCol)) continue;
-                var w = col.ActualWidth;
-                if (double.IsNaN(w) || w <= 0) w = 100;
-                fixedSum += w;
-            }
-
-            double total = newsList.ActualWidth;
-            double padding = 35;
-
-            double scroll = 0;
-            var sv = FindDescendant<ScrollViewer>(newsList);
-            if (sv != null && sv.ComputedVerticalScrollBarVisibility == Visibility.Visible)
-                scroll = SystemParameters.VerticalScrollBarWidth;
-
-            double newWidth = Math.Max(100, total - fixedSum - padding - scroll);
-            titleCol.Width = new DataGridLength(newWidth, DataGridLengthUnitType.Pixel);
         }
 
         private static T? FindDescendant<T>(DependencyObject root) where T : DependencyObject


### PR DESCRIPTION
## Summary
- Replace News DataGrid with ListView cards showing source logos, timestamp and title on one line, and symbol buttons
- Ensure the news list has sufficient height so multiple items display at once
- Hide source text when a logo is available

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7711c18c83339ce5a788f9e4d9c7