### PR TITLE
Specify one-way timestamp binding

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -750,7 +750,7 @@
 
                                                         <!-- Time and title on first line -->
                                                         <TextBlock TextWrapping="Wrap">
-                                                            <Run Text="{Binding Timestamp, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}"/>
+                                                            <Run Text="{Binding Timestamp, Mode=OneWay, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}"/>
                                                             <Run Text=" "/>
                                                             <Run Text="{Binding Title}"/>
                                                         </TextBlock>


### PR DESCRIPTION
## Summary
- Ensure news item timestamp binding uses Mode=OneWay to avoid WPF TwoWay binding error

## Testing
- ⚠️ `dotnet build` *(dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8143b6008333ad84476594b5ec0e