### PR TITLE
Fix read-only Title binding

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -752,7 +752,7 @@
                                                         <TextBlock TextWrapping="Wrap">
                                                             <Run Text="{Binding Timestamp, Mode=OneWay, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}"/>
                                                             <Run Text=" "/>
-                                                            <Run Text="{Binding Title}"/>
+                                                            <Run Text="{Binding Title, Mode=OneWay}"/>
                                                         </TextBlock>
 
                                                         <!-- Symbols with action buttons -->


### PR DESCRIPTION
## Summary
- Explicitly set OneWay binding for `NewsItem` titles so read-only properties don't cause binding errors

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd81e0d9c4833393ab0647b44fed0f