### PR TITLE
Align news list items to top

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -725,6 +725,7 @@
                                 <ListView x:Name="NewsList" Background="{DynamicResource SurfaceAlt}"
                                           Foreground="{DynamicResource OnSurface}" BorderThickness="0"
                                           ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                          ScrollViewer.VerticalContentAlignment="Top"
                                           HorizontalContentAlignment="Stretch">
                                     <ListView.ItemTemplate>
                                             <DataTemplate>


### PR DESCRIPTION
## Summary
- align news section items to the top by setting ScrollViewer.VerticalContentAlignment

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd88449af8833393f4584cfacafeb9