### PR TITLE
Fix invalid ScrollViewer property causing build failure

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -725,7 +725,7 @@
                                 <ListView x:Name="NewsList" Background="{DynamicResource SurfaceAlt}"
                                           Foreground="{DynamicResource OnSurface}" BorderThickness="0"
                                           ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                          ScrollViewer.VerticalContentAlignment="Top"
+                                          VerticalContentAlignment="Top"
                                           HorizontalContentAlignment="Stretch">
                                     <ListView.ItemTemplate>
                                             <DataTemplate>


### PR DESCRIPTION
## Summary
- replace nonexistent `ScrollViewer.VerticalContentAlignment` with `VerticalContentAlignment` in `NewsList` view

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8e07f64c8333bf47372826bad46f