### PR TITLE
Expand News list to full height

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -721,11 +721,12 @@
                         <GroupBox Grid.Row="0" Grid.Column="2" Header="News" Margin="0,0,8,0"
                                   Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
                                   BorderBrush="{DynamicResource Divider}" VerticalAlignment="Stretch"
-                                  VerticalContentAlignment="Top" HorizontalContentAlignment="Stretch">
+                                  VerticalContentAlignment="Stretch" HorizontalContentAlignment="Stretch">
                                   <ListView x:Name="NewsList" Background="{DynamicResource SurfaceAlt}"
                                             Foreground="{DynamicResource OnSurface}" BorderThickness="0"
                                             ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                            VerticalContentAlignment="Top"
+                                            VerticalAlignment="Stretch"
+                                            VerticalContentAlignment="Stretch"
                                             HorizontalAlignment="Stretch"
                                             HorizontalContentAlignment="Stretch">
                                     <ListView.ItemTemplate>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -131,16 +131,8 @@ namespace BinanceUsdtTicker
             SetupList("PositionsList", _positions);
             SetupList("OrderHistoryList", _orderHistory);
             SetupList("TradeHistoryList", _tradeHistory);
-            SetupList("NewsList", _newsItems, useScreenHeight: false);
-
-            // Ensure the News section shows multiple items
-            if (FindName("NewsList") is ListView newsList)
-            {
-                double newsHeight = SystemParameters.PrimaryScreenHeight / 3;
-                newsList.Height = newsHeight;
-                newsList.MinHeight = newsHeight;
-                newsList.MaxHeight = newsHeight;
-            }
+            // Fill the screen vertically for the News section
+            SetupList("NewsList", _newsItems);
 
             // show most recent orders/trades first
             var orderView = CollectionViewSource.GetDefaultView(_orderHistory);


### PR DESCRIPTION
## Summary
- stretch News section to fill available vertical space
- remove fixed height limit from News list

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd94b35b788333975f178543eb752e