### PR TITLE
Expand news cards to full width

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -725,6 +725,7 @@
                                   <ListView x:Name="NewsList" Background="{DynamicResource SurfaceAlt}"
                                             Foreground="{DynamicResource OnSurface}" BorderThickness="0"
                                             ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                            ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                             VerticalAlignment="Stretch"
                                             VerticalContentAlignment="Stretch"
                                             HorizontalAlignment="Stretch"


### PR DESCRIPTION
## Summary
- Ensure news cards occupy the full available width by disabling horizontal scrolling in the news list.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd95d84b548333944a7847bfd5a470