### PR TITLE
Expand news list to display all items

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -131,8 +131,8 @@ namespace BinanceUsdtTicker
             SetupList("PositionsList", _positions);
             SetupList("OrderHistoryList", _orderHistory);
             SetupList("TradeHistoryList", _tradeHistory);
-            // Fill the screen vertically for the News section
-            SetupList("NewsList", _newsItems);
+            // Let the News section use the available height so all items are visible
+            SetupList("NewsList", _newsItems, useScreenHeight: false);
 
             // show most recent orders/trades first
             var orderView = CollectionViewSource.GetDefaultView(_orderHistory);


### PR DESCRIPTION
## Summary
- allow NewsList to use available height instead of screenHeight/8 so multiple news entries are visible

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd980133cc8333b5948c6f7b8fffa5