### PR TITLE
Increase news card logo size

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -744,7 +744,7 @@
                                                         <!-- Source information with logo -->
                                                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,4">
                                                             <Image Source="{Binding Source, Converter={StaticResource SourceToLogo}}"
-                                                                   Width="24" Height="24" Margin="0,0,6,0"/>
+                                                                   Width="32" Height="32" Margin="0,0,6,0"/>
                                                             <TextBlock Text="{Binding Source}" FontWeight="Bold">
                                                                 <TextBlock.Style>
                                                                     <Style TargetType="TextBlock">


### PR DESCRIPTION
## Summary
- enlarge news item logos for better visibility

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd992132bc833382ba668115f13489