### PR TITLE
Reduce listing logos height

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -744,7 +744,8 @@
                                                         <!-- Source information with logo -->
                                                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,4">
                                                             <Image Source="{Binding Source, Converter={StaticResource SourceToLogo}}"
-                                                                   Margin="0,0,6,0"/>
+                                                                   Margin="0,0,6,0"
+                                                                   Height="20"/>
                                                             <TextBlock Text="{Binding Source}" FontWeight="Bold">
                                                                 <TextBlock.Style>
                                                                     <Style TargetType="TextBlock">


### PR DESCRIPTION
## Summary
- shrink logo image height in the listing view for a more compact look

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9c76706483338366a24470ae4f01