### PR TITLE
fix: add missing namespace for service

### DIFF
--- a/ListingWatcherService/Program.cs
+++ b/ListingWatcherService/Program.cs
@@ -2,6 +2,7 @@ using BinanceUsdtTicker;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using ListingWatcher;
 
 var builder = Host.CreateDefaultBuilder(args)
     .ConfigureServices(services =>


### PR DESCRIPTION
## Summary
- add ListingWatcher namespace import to worker Program

## Testing
- `dotnet build ListingWatcherService/ListingWatcherService.csproj` *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb071f49c833399962167bd721707