### PR TITLE
feat: move azure translate key to settings

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -20,8 +20,7 @@ public partial class App : Application
     private readonly HashSet<string> _usdtSymbols = new(StringComparer.OrdinalIgnoreCase);
     private WebApplication? _listingApp;
     private readonly string _connectionString =
-        Environment.GetEnvironmentVariable("BINANCE_DB_CONNECTION") ??
-        "Server=KARAKAYA-MSI\\KARAKAYADB;Database=BinanceUsdtTicker;User Id=sa;Password=Lhya!812;TrustServerCertificate=True;";
+        Environment.GetEnvironmentVariable("BINANCE_DB_CONNECTION") ?? string.Empty;
     private static readonly string SymbolsFile = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
         "BinanceUsdtTicker", "usdt_symbols.txt");
@@ -37,9 +36,12 @@ public partial class App : Application
     {
         await UpdateUsdtSymbolsFileAsync();
 
-        _newsHub = new NewsDbService(_connectionString, TimeSpan.FromSeconds(5));
-        _newsHub.NewsReceived += OnNewsReceived;
-        await _newsHub.StartAsync();
+        if (!string.IsNullOrEmpty(_connectionString))
+        {
+            _newsHub = new NewsDbService(_connectionString, TimeSpan.FromSeconds(5));
+            _newsHub.NewsReceived += OnNewsReceived;
+            await _newsHub.StartAsync();
+        }
     }
 
     private async Task StartListingListenerAsync()

--- a/ListingWatcherService/ListingWatcherService.cs
+++ b/ListingWatcherService/ListingWatcherService.cs
@@ -42,8 +42,7 @@ public sealed class ListingWatcherService : BackgroundService
         };
         _http.DefaultRequestHeaders.UserAgent.ParseAdd("ListingWatcher/1.0");
         _connectionString =
-            Environment.GetEnvironmentVariable("BINANCE_DB_CONNECTION") ??
-            "Server=KARAKAYA-MSI\\KARAKAYADB;Database=BinanceUsdtTicker;User Id=sa;Password=Lhya!812;TrustServerCertificate=True;";
+            Environment.GetEnvironmentVariable("BINANCE_DB_CONNECTION") ?? string.Empty;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -314,6 +313,8 @@ public sealed class ListingWatcherService : BackgroundService
 
     private async Task EnsureDatabaseAsync(CancellationToken ct)
     {
+        if (string.IsNullOrEmpty(_connectionString))
+            return;
         try
         {
             var builder = new SqlConnectionStringBuilder(_connectionString);
@@ -353,6 +354,8 @@ END";
 
     private async Task SaveListingAsync(string source, string id, string title, string? url, string symbol, DateTimeOffset createdAt)
     {
+        if (string.IsNullOrEmpty(_connectionString))
+            return;
         try
         {
             await using var conn = new SqlConnection(_connectionString);

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -205,8 +205,9 @@ namespace BinanceUsdtTicker
         private async Task LoadNewsFromDatabaseAsync()
         {
             var connectionString =
-                Environment.GetEnvironmentVariable("BINANCE_DB_CONNECTION") ??
-                "Server=KARAKAYA-MSI\\KARAKAYADB;Database=BinanceUsdtTicker;User Id=sa;Password=Lhya!812;TrustServerCertificate=True;";
+                Environment.GetEnvironmentVariable("BINANCE_DB_CONNECTION") ?? string.Empty;
+            if (string.IsNullOrEmpty(connectionString))
+                return;
             try
             {
                 await using var conn = new SqlConnection(connectionString);

--- a/Models/UiSettings.cs
+++ b/Models/UiSettings.cs
@@ -115,5 +115,12 @@ namespace BinanceUsdtTicker.Models
             get => _binanceApiSecret;
             set { if (_binanceApiSecret != value) { _binanceApiSecret = value; OnPropertyChanged(); } }
         }
+
+        private string _azureTranslateKey = string.Empty;
+        public string AzureTranslateKey
+        {
+            get => _azureTranslateKey;
+            set { if (_azureTranslateKey != value) { _azureTranslateKey = value; OnPropertyChanged(); } }
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -36,13 +36,16 @@ to the base address of the running script. The desktop app now defaults to
 `http://localhost:5005`, matching the feed script's default port. Adjust this
 value from the settings window if your service runs elsewhere.
 
+## Azure Translation
+
+Azure Translator API support requires a subscription key. Enter this key in the
+application's settings window; it is not stored in the repository.
+
 ## Listing Watcher Windows Service
 
 The `ListingWatcherService` project polls several exchange announcement APIs
 and writes new listings directly to a SQL database. Configure the database
-connection string with the `BINANCE_DB_CONNECTION` environment variable;
-otherwise it connects to `KARAKAYA-MSI\\KARAKAYADB` using the SQL login
-`sa` with password `Lhya!812`.
+connection string with the `BINANCE_DB_CONNECTION` environment variable.
 
 You can run the service as a console app for testing:
 

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -130,6 +130,10 @@
                         <TextBlock Text="Binance Secret Key:" Width="120" VerticalAlignment="Center"/>
                         <TextBox Text="{Binding BinanceApiSecret}" Width="300" MaxLength="64"/>
                     </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                        <TextBlock Text="Azure Translate Key:" Width="120" VerticalAlignment="Center"/>
+                        <TextBox Text="{Binding AzureTranslateKey}" Width="300" MaxLength="64"/>
+                    </StackPanel>
                 </StackPanel>
             </TabItem>
             <TabItem Header="Bildirimler">

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -30,7 +30,8 @@ namespace BinanceUsdtTicker
                 WindowsNotification = settings.WindowsNotification,
                 BaseUrl = settings.BaseUrl,
                 BinanceApiKey = settings.BinanceApiKey,
-                BinanceApiSecret = settings.BinanceApiSecret
+                BinanceApiSecret = settings.BinanceApiSecret,
+                AzureTranslateKey = settings.AzureTranslateKey
             };
             DataContext = _work;
         }
@@ -135,6 +136,7 @@ namespace BinanceUsdtTicker
             _settings.BaseUrl = _work.BaseUrl;
             _settings.BinanceApiKey = _work.BinanceApiKey;
             _settings.BinanceApiSecret = _work.BinanceApiSecret;
+            _settings.AzureTranslateKey = _work.AzureTranslateKey;
             DialogResult = true;
         }
     }


### PR DESCRIPTION
## Summary
- add Azure Translate key field to UI settings and settings dialog
- drop hard-coded database connection strings

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc5035ec48333a49a8bccc1e2ed63