### PR TITLE
Read connection string from configuration for ListingWatcherService

### DIFF
--- a/ListingWatcherService/ListingWatcherService.cs
+++ b/ListingWatcherService/ListingWatcherService.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Threading.Channels;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
 using System.Data;
 using System.Data.SqlClient;
 using System.Net.Http.Headers;
@@ -33,7 +34,10 @@ public sealed class ListingWatcherService : BackgroundService
     private readonly string? _translatorKey;
     private readonly string? _translatorRegion;
 
-    public ListingWatcherService(ILogger<ListingWatcherService> logger, ISymbolExtractor symbolExtractor)
+    public ListingWatcherService(
+        ILogger<ListingWatcherService> logger,
+        ISymbolExtractor symbolExtractor,
+        IConfiguration configuration)
     {
         _logger = logger;
         _symbolExtractor = symbolExtractor;
@@ -46,7 +50,8 @@ public sealed class ListingWatcherService : BackgroundService
             Timeout = TimeSpan.FromSeconds(10)
         };
         _http.DefaultRequestHeaders.UserAgent.ParseAdd("ListingWatcher/1.0");
-        _connectionString =
+
+        _connectionString = configuration.GetConnectionString("Listings") ??
             Environment.GetEnvironmentVariable("BINANCE_DB_CONNECTION") ?? string.Empty;
 
         _translatorKey = Environment.GetEnvironmentVariable("AZURE_TRANSLATOR_KEY");

--- a/ListingWatcherService/ListingWatcherService.csproj
+++ b/ListingWatcherService/ListingWatcherService.csproj
@@ -17,4 +17,9 @@
   <ItemGroup>
     <Compile Include="..\Services\SymbolExtractor.cs" Link="SymbolExtractor.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/ListingWatcherService/appsettings.json
+++ b/ListingWatcherService/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "Listings": "Server=(localdb)\\MSSQLLocalDB;Database=Listings;Trusted_Connection=True;TrustServerCertificate=True"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ application's settings window; it is not stored in the repository.
 
 The `ListingWatcherService` project polls several exchange announcement APIs
 and writes new listings directly to a SQL database. Configure the database
-connection string with the `BINANCE_DB_CONNECTION` environment variable.
+connection string via the `ConnectionStrings:Listings` setting in
+`ListingWatcherService/appsettings.json` or by setting the
+`BINANCE_DB_CONNECTION` environment variable.
 
 You can run the service as a console app for testing:
 


### PR DESCRIPTION
## Summary
- load ListingWatcherService connection string from appsettings or BINANCE_DB_CONNECTION env var
- add appsettings.json to ListingWatcherService and copy during build
- document new configuration option for the service

## Testing
- ⚠️ `dotnet build ListingWatcherService/ListingWatcherService.csproj` (dotnet not installed)
- ⚠️ `apt-get update` (403: repository not signed)


------
https://chatgpt.com/codex/tasks/task_e_68bdfa99024083338f0d269d8a126411