### PR TITLE
Add translation key and region settings to UI configuration

### DIFF
--- a/Models/UiSettings.cs
+++ b/Models/UiSettings.cs
@@ -122,5 +122,19 @@ namespace BinanceUsdtTicker.Models
             get => _azureTranslateKey;
             set { if (_azureTranslateKey != value) { _azureTranslateKey = value; OnPropertyChanged(); } }
         }
+
+        private string _translateKey = string.Empty;
+        public string TranslateKey
+        {
+            get => _translateKey;
+            set { if (_translateKey != value) { _translateKey = value; OnPropertyChanged(); } }
+        }
+
+        private string _translateRegion = string.Empty;
+        public string TranslateRegion
+        {
+            get => _translateRegion;
+            set { if (_translateRegion != value) { _translateRegion = value; OnPropertyChanged(); } }
+        }
     }
 }

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -31,6 +31,7 @@ namespace BinanceUsdtTicker
                 BaseUrl = settings.BaseUrl,
                 BinanceApiKey = settings.BinanceApiKey,
                 BinanceApiSecret = settings.BinanceApiSecret,
+                AzureTranslateKey = settings.AzureTranslateKey,
                 TranslateKey = settings.TranslateKey,
                 TranslateRegion = settings.TranslateRegion
             };
@@ -98,6 +99,7 @@ namespace BinanceUsdtTicker
             _work.ControlColor = def.ControlColor;
             _work.WindowsNotification = def.WindowsNotification;
             _work.BaseUrl = def.BaseUrl;
+            _work.AzureTranslateKey = def.AzureTranslateKey;
             _work.TranslateKey = def.TranslateKey;
             _work.TranslateRegion = def.TranslateRegion;
         }
@@ -139,6 +141,7 @@ namespace BinanceUsdtTicker
             _settings.BaseUrl = _work.BaseUrl;
             _settings.BinanceApiKey = _work.BinanceApiKey;
             _settings.BinanceApiSecret = _work.BinanceApiSecret;
+            _settings.AzureTranslateKey = _work.AzureTranslateKey;
             _settings.TranslateKey = _work.TranslateKey;
             _settings.TranslateRegion = _work.TranslateRegion;
             DialogResult = true;


### PR DESCRIPTION
## Summary
- add TranslateKey and TranslateRegion properties to UiSettings
- copy Azure translate key and translation settings in Settings window

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdffcc91448333bcd5c0ea62f76409