### PR TITLE
Read Azure Translator config from settings

### DIFF
--- a/ListingWatcherService/ListingWatcherService.cs
+++ b/ListingWatcherService/ListingWatcherService.cs
@@ -54,8 +54,10 @@ public sealed class ListingWatcherService : BackgroundService
         _connectionString = configuration.GetConnectionString("Listings") ??
             Environment.GetEnvironmentVariable("BINANCE_DB_CONNECTION") ?? string.Empty;
 
-        _translatorKey = Environment.GetEnvironmentVariable("AZURE_TRANSLATOR_KEY");
-        _translatorRegion = Environment.GetEnvironmentVariable("AZURE_TRANSLATOR_REGION");
+        _translatorKey = configuration["AZURE_TRANSLATOR_KEY"] ??
+            Environment.GetEnvironmentVariable("AZURE_TRANSLATOR_KEY");
+        _translatorRegion = configuration["AZURE_TRANSLATOR_REGION"] ??
+            Environment.GetEnvironmentVariable("AZURE_TRANSLATOR_REGION");
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/ListingWatcherService/appsettings.json
+++ b/ListingWatcherService/appsettings.json
@@ -1,5 +1,7 @@
 {
   "ConnectionStrings": {
     "Listings": "Server=KARAKAYA-MSI\\KARAKAYADB;Database=BinanceUsdtTicker;User Id=sa;Password=Lhya!812;TrustServerCertificate=True"
-  }
+  },
+  "AZURE_TRANSLATOR_KEY": "",
+  "AZURE_TRANSLATOR_REGION": ""
 }


### PR DESCRIPTION
## Summary
- allow ListingWatcherService to obtain Azure Translator credentials from configuration
- provide appsettings placeholders for translator key and region

## Testing
- `dotnet build ListingWatcherService/ListingWatcherService.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be042560f883338a34c79bd1c8eb1c