### PR TITLE
Remove unused Azure Translate Key setting

### DIFF
--- a/Models/UiSettings.cs
+++ b/Models/UiSettings.cs
@@ -116,13 +116,6 @@ namespace BinanceUsdtTicker.Models
             set { if (_binanceApiSecret != value) { _binanceApiSecret = value; OnPropertyChanged(); } }
         }
 
-        private string _azureTranslateKey = string.Empty;
-        public string AzureTranslateKey
-        {
-            get => _azureTranslateKey;
-            set { if (_azureTranslateKey != value) { _azureTranslateKey = value; OnPropertyChanged(); } }
-        }
-
         private string _translateKey = string.Empty;
         public string TranslateKey
         {

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -138,10 +138,6 @@
                         <TextBlock Text="Binance Secret Key:" Width="120" VerticalAlignment="Center"/>
                         <TextBox Text="{Binding BinanceApiSecret}" Width="300" MaxLength="64"/>
                     </StackPanel>
-                    <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                        <TextBlock Text="Azure Translate Key:" Width="120" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding AzureTranslateKey}" Width="300" MaxLength="64"/>
-                    </StackPanel>
                 </StackPanel>
             </TabItem>
             <TabItem Header="Bildirimler">

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -31,7 +31,6 @@ namespace BinanceUsdtTicker
                 BaseUrl = settings.BaseUrl,
                 BinanceApiKey = settings.BinanceApiKey,
                 BinanceApiSecret = settings.BinanceApiSecret,
-                AzureTranslateKey = settings.AzureTranslateKey,
                 TranslateKey = settings.TranslateKey,
                 TranslateRegion = settings.TranslateRegion
             };
@@ -99,7 +98,6 @@ namespace BinanceUsdtTicker
             _work.ControlColor = def.ControlColor;
             _work.WindowsNotification = def.WindowsNotification;
             _work.BaseUrl = def.BaseUrl;
-            _work.AzureTranslateKey = def.AzureTranslateKey;
             _work.TranslateKey = def.TranslateKey;
             _work.TranslateRegion = def.TranslateRegion;
         }
@@ -141,7 +139,6 @@ namespace BinanceUsdtTicker
             _settings.BaseUrl = _work.BaseUrl;
             _settings.BinanceApiKey = _work.BinanceApiKey;
             _settings.BinanceApiSecret = _work.BinanceApiSecret;
-            _settings.AzureTranslateKey = _work.AzureTranslateKey;
             _settings.TranslateKey = _work.TranslateKey;
             _settings.TranslateRegion = _work.TranslateRegion;
             DialogResult = true;


### PR DESCRIPTION
## Summary
- remove unused Azure Translate Key property from settings model
- drop Azure Translate Key input from settings window

## Testing
- `dotnet build` *(fails: dotnet: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: unable to locate package dotnet-sdk-8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68be087593d48333b9656a3820a07998