### PR TITLE
Fix missing ISymbolExtractor reference in ListingWatcherService

### DIFF
--- a/ListingWatcherService/ListingWatcherService.cs
+++ b/ListingWatcherService/ListingWatcherService.cs
@@ -9,6 +9,7 @@ using System.Threading.Channels;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
+using BinanceUsdtTicker;
 using System.Data;
 using System.Data.SqlClient;
 using System.Net.Http.Headers;


### PR DESCRIPTION
## Summary
- add BinanceUsdtTicker namespace import to ListingWatcherService to resolve missing `ISymbolExtractor`

## Testing
- `dotnet build ListingWatcherService/ListingWatcherService.csproj` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68be0d5ddd988333beea20b30d72b1a1