### PR TITLE
Lower priority for news updates

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -199,7 +199,7 @@ namespace BinanceUsdtTicker
 
                 if (_newsItems.Count > 100)
                     _newsItems.RemoveAt(_newsItems.Count - 1);
-            });
+            }, DispatcherPriority.Background);
         }
 
         private async Task LoadNewsFromDatabaseAsync()
@@ -234,7 +234,7 @@ namespace BinanceUsdtTicker
                     _newsItems.Clear();
                     foreach (var item in items)
                         _newsItems.Add(item);
-                });
+                }, DispatcherPriority.Background);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- Prevent news updates from slowing the UI by dispatching them at background priority.
- Apply background dispatcher priority when loading news from the database.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be163315dc83339d835c8445c26c34