### PR TITLE
Use SqlDependency for push-based news updates

### DIFF
--- a/Services/NewsDbService.cs
+++ b/Services/NewsDbService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 
@@ -10,98 +9,82 @@ namespace BinanceUsdtTicker
     public class NewsDbService : IAsyncDisposable
     {
         private readonly string _connectionString;
-        private readonly TimeSpan _pollInterval;
-        private CancellationTokenSource? _cts;
-        private Task? _loop;
+        private SqlDependency? _dependency;
         private DateTimeOffset _lastTimestamp = DateTimeOffset.MinValue;
 
         public event EventHandler<NewsItem>? NewsReceived;
 
-        public NewsDbService(string connectionString, TimeSpan pollInterval)
+        public NewsDbService(string connectionString, TimeSpan _)
         {
             _connectionString = connectionString;
-            _pollInterval = pollInterval;
         }
 
-        public Task StartAsync()
+        public async Task StartAsync()
         {
-            _cts = new CancellationTokenSource();
-            _loop = Task.Run(() => PollAsync(_cts.Token));
-            return Task.CompletedTask;
+            SqlDependency.Start(_connectionString);
+            await FetchAndSubscribeAsync();
         }
 
-        private async Task PollAsync(CancellationToken ct)
+        private async Task FetchAndSubscribeAsync()
         {
-            while (!ct.IsCancellationRequested)
+            _dependency?.OnChange -= OnDependencyChange;
+            await using var conn = new SqlConnection(_connectionString);
+            await conn.OpenAsync();
+            var cmd = conn.CreateCommand();
+            if (_lastTimestamp == DateTimeOffset.MinValue)
             {
-                try
-                {
-                    await using var conn = new SqlConnection(_connectionString);
-                    await conn.OpenAsync(ct);
-                    var cmd = conn.CreateCommand();
-                    if (_lastTimestamp == DateTimeOffset.MinValue)
-                    {
-                        cmd.CommandText = @"SELECT TOP 10 Id, Source, Title, TitleTranslate, Url, Symbols, CreatedAt FROM dbo.News ORDER BY CreatedAt DESC";
-                    }
-                    else
-                    {
-                        cmd.CommandText = @"SELECT Id, Source, Title, TitleTranslate, Url, Symbols, CreatedAt FROM dbo.News WHERE CreatedAt > @last ORDER BY CreatedAt";
-                        cmd.Parameters.AddWithValue("@last", _lastTimestamp);
-                    }
+                cmd.CommandText = @"SELECT TOP 10 Id, Source, Title, TitleTranslate, Url, Symbols, CreatedAt FROM dbo.News ORDER BY CreatedAt DESC";
+            }
+            else
+            {
+                cmd.CommandText = @"SELECT Id, Source, Title, TitleTranslate, Url, Symbols, CreatedAt FROM dbo.News WHERE CreatedAt > @last ORDER BY CreatedAt";
+                cmd.Parameters.AddWithValue("@last", _lastTimestamp);
+            }
 
-                    await using var reader = await cmd.ExecuteReaderAsync(ct);
-                    var items = new List<(NewsItem Item, DateTimeOffset Created)>();
-                    while (await reader.ReadAsync(ct))
-                    {
-                        var id = reader.GetString(0);
-                        var source = reader.GetString(1);
-                        var title = reader.GetString(2);
-                        var titleTranslate = reader.IsDBNull(3) ? null : reader.GetString(3);
-                        var url = reader.IsDBNull(4) ? string.Empty : reader.GetString(4);
-                        var symbolsStr = reader.IsDBNull(5) ? string.Empty : reader.GetString(5);
-                        var created = reader.GetDateTimeOffset(6);
-                        IReadOnlyList<string> symbols = symbolsStr.Split(',', StringSplitOptions.RemoveEmptyEntries).ToList();
-                        var item = new NewsItem(id: id, source: source, timestamp: created.UtcDateTime, title: title, titleTranslate: titleTranslate, body: null, link: url, type: NewsType.Listing, symbols: symbols);
-                        items.Add((item, created));
-                    }
+            _dependency = new SqlDependency(cmd);
+            _dependency.OnChange += OnDependencyChange;
 
-                    if (_lastTimestamp == DateTimeOffset.MinValue)
-                        items.Reverse();
+            await using var reader = await cmd.ExecuteReaderAsync();
+            var items = new List<(NewsItem Item, DateTimeOffset Created)>();
+            while (await reader.ReadAsync())
+            {
+                var id = reader.GetString(0);
+                var source = reader.GetString(1);
+                var title = reader.GetString(2);
+                var titleTranslate = reader.IsDBNull(3) ? null : reader.GetString(3);
+                var url = reader.IsDBNull(4) ? string.Empty : reader.GetString(4);
+                var symbolsStr = reader.IsDBNull(5) ? string.Empty : reader.GetString(5);
+                var created = reader.GetDateTimeOffset(6);
+                IReadOnlyList<string> symbols = symbolsStr.Split(',', StringSplitOptions.RemoveEmptyEntries).ToList();
+                var item = new NewsItem(id: id, source: source, timestamp: created.UtcDateTime, title: title, titleTranslate: titleTranslate, body: null, link: url, type: NewsType.Listing, symbols: symbols);
+                items.Add((item, created));
+            }
 
-                    foreach (var (item, created) in items)
-                    {
-                        NewsReceived?.Invoke(this, item);
-                        if (created > _lastTimestamp)
-                            _lastTimestamp = created;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Console.Error.WriteLine($"DB news poll error: {ex}");
-                }
+            if (_lastTimestamp == DateTimeOffset.MinValue)
+                items.Reverse();
 
-                try
-                {
-                    await Task.Delay(_pollInterval, ct);
-                }
-                catch (TaskCanceledException)
-                {
-                    break;
-                }
+            foreach (var (item, created) in items)
+            {
+                NewsReceived?.Invoke(this, item);
+                if (created > _lastTimestamp)
+                    _lastTimestamp = created;
             }
         }
 
-        public async ValueTask DisposeAsync()
+        private async void OnDependencyChange(object? sender, SqlNotificationEventArgs e)
         {
-            if (_cts != null)
+            await FetchAndSubscribeAsync();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (_dependency != null)
             {
-                _cts.Cancel();
-                if (_loop != null)
-                {
-                    try { await _loop; } catch { }
-                }
-                _cts.Dispose();
+                _dependency.OnChange -= OnDependencyChange;
+                _dependency = null;
             }
+            SqlDependency.Stop(_connectionString);
+            return ValueTask.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
## Summary
- switch `NewsDbService` from polling to SQL Server query notifications via `SqlDependency`
- automatically re-subscribe and propagate new rows to the UI

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be192d225c8333ac656e47559172bf