### PR TITLE
Replace preview-only null conditional assignment with explicit check

### DIFF
--- a/Services/NewsDbService.cs
+++ b/Services/NewsDbService.cs
@@ -27,7 +27,8 @@ namespace BinanceUsdtTicker
 
         private async Task FetchAndSubscribeAsync()
         {
-            _dependency?.OnChange -= OnDependencyChange;
+            if (_dependency != null)
+                _dependency.OnChange -= OnDependencyChange;
             await using var conn = new SqlConnection(_connectionString);
             await conn.OpenAsync();
             var cmd = conn.CreateCommand();


### PR DESCRIPTION
## Summary
- avoid using preview-only null-conditional event unsubscription in `NewsDbService`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be1ac47c308333a1059c357a0541af