### PR TITLE
Fix two-way binding error on read-only NewsItem properties

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -775,13 +775,13 @@
                                                         <!-- Translated title -->
                                                         <TextBlock Grid.Row="1" TextWrapping="Wrap">
                                                             <Run FontWeight="Bold" Text="TR: "/>
-                                                            <Run Text="{Binding TitleTranslate}"/>
+                                                            <Run Text="{Binding TitleTranslate, Mode=OneWay}"/>
                                                         </TextBlock>
 
                                                         <!-- Original title -->
                                                         <TextBlock Grid.Row="2" TextWrapping="Wrap">
                                                             <Run FontWeight="Bold" Text="EN: "/>
-                                                            <Run Text="{Binding Title}"/>
+                                                            <Run Text="{Binding Title, Mode=OneWay}"/>
                                                         </TextBlock>
 
                                                         <!-- Symbols with action buttons -->


### PR DESCRIPTION
## Summary
- use explicit OneWay binding for `TitleTranslate` and `Title` in `MainWindow` item template

## Testing
- `dotnet build` *(fails: dotnet: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f5c4d328833394c8d9668a2e3dba