### PR TITLE
Fix precision for Binance order placement

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1719,7 +1719,9 @@ namespace BinanceUsdtTicker
         private static decimal AdjustToStep(decimal value, decimal step)
         {
             if (step <= 0m) return value;
-            return Math.Floor(value / step) * step;
+            var precision = GetPrecision(step);
+            var n = Math.Floor(value / step) * step;
+            return Math.Round(n, precision, MidpointRounding.ToZero);
         }
 
         private async Task RefreshTradingDataAsync()

--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -411,7 +411,9 @@ namespace BinanceUsdtTicker
         private static decimal AdjustToStep(decimal value, decimal step)
         {
             if (step <= 0m) return value;
-            return Math.Floor(value / step) * step;
+            var precision = GetPrecision(step);
+            var n = Math.Floor(value / step) * step;
+            return Math.Round(n, precision, MidpointRounding.ToZero);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- ensure price and quantity are rounded to Binance's allowed precision when placing orders

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c2843c51bc8333bdf6c333de708e88