### PR TITLE
Fix quantity formatting when step size is zero

### DIFF
--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -411,8 +411,14 @@ namespace BinanceUsdtTicker
         private static string FormatForApi(decimal value, decimal step)
         {
             var precision = GetPrecision(step);
-            var formatted = value.ToString($"F{precision}", CultureInfo.InvariantCulture);
-            return formatted.TrimEnd('0').TrimEnd('.');
+            string formatted;
+            if (precision > 0)
+                formatted = value.ToString($"F{precision}", CultureInfo.InvariantCulture);
+            else
+                formatted = value.ToString(CultureInfo.InvariantCulture);
+
+            var trimmed = formatted.TrimEnd('0').TrimEnd('.');
+            return string.IsNullOrEmpty(trimmed) ? "0" : trimmed;
         }
 
         private static decimal AdjustToStep(decimal value, decimal step)


### PR DESCRIPTION
## Summary
- ensure FormatForApi handles zero step sizes by using invariant formatting and fallback

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c286eb5b948333a28658706d281f93