### PR TITLE
Handle market lot size precision

### DIFF
--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -366,8 +366,18 @@ namespace BinanceUsdtTicker
             {
                 var price = sym.Filters.OfType<PriceFilter>().FirstOrDefault();
                 var lot = sym.Filters.OfType<LotSizeFilter>().FirstOrDefault();
+                var marketLot = sym.Filters.OfType<MarketLotSizeFilter>().FirstOrDefault();
                 if (price != null) tick = price.TickSize;
-                if (lot != null) step = lot.StepSize;
+
+                // Some symbols have different step sizes for market and limit orders.
+                // Use the more restrictive (larger) step size to avoid sending a quantity
+                // with higher precision than allowed by the exchange.
+                if (lot != null && marketLot != null)
+                    step = Math.Max(lot.StepSize, marketLot.StepSize);
+                else if (lot != null)
+                    step = lot.StepSize;
+                else if (marketLot != null)
+                    step = marketLot.StepSize;
             }
 
             var res = (tick, step);


### PR DESCRIPTION
## Summary
- consider MARKET_LOT_SIZE filter when determining quantity step
- use larger step size from lot and market filters to match exchange precision

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c533fdaf688333a0e38ce57f09706b