### PR TITLE
Handle Binance order precision and notional checks

### DIFF
--- a/Helpers/PrecisionHelper.cs
+++ b/Helpers/PrecisionHelper.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Globalization;
+
+namespace BinanceUsdtTicker.Helpers
+{
+    public static class PrecisionHelper
+    {
+        public static decimal AdjustToStep(decimal value, decimal step)
+        {
+            if (step <= 0m) return value;
+            var precision = GetPrecision(step);
+            var n = Math.Floor(value / step) * step;
+            return Math.Round(n, precision, MidpointRounding.ToZero);
+        }
+
+        public static string FormatForApi(decimal value, decimal step)
+        {
+            var precision = GetPrecision(step);
+            string formatted = precision > 0
+                ? value.ToString($"F{precision}", CultureInfo.InvariantCulture)
+                : value.ToString(CultureInfo.InvariantCulture);
+            var trimmed = formatted.TrimEnd('0').TrimEnd('.');
+            return string.IsNullOrEmpty(trimmed) ? "0" : trimmed;
+        }
+
+        public static int GetPrecision(decimal step)
+        {
+            var s = step.ToString(CultureInfo.InvariantCulture).TrimEnd('0');
+            var idx = s.IndexOf('.');
+            return idx >= 0 ? s.Length - idx - 1 : 0;
+        }
+    }
+}

--- a/Tests/BinanceUsdtTicker.Tests.csproj
+++ b/Tests/BinanceUsdtTicker.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BinanceUsdtTicker.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+</Project>

--- a/Tests/PrecisionHelperTests.cs
+++ b/Tests/PrecisionHelperTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Net.Http;
+using BinanceUsdtTicker;
+using BinanceUsdtTicker.Helpers;
+using Xunit;
+
+public class PrecisionHelperTests
+{
+    [Fact]
+    public async Task QuantizePrice_RoundsDown()
+    {
+        var api = CreateApi();
+        var (_, _, _, price, _) = await api.ApplyOrderPrecisionAsync("BTCUSDT", 57432.1234m, 1m);
+        Assert.Equal(57432.1m, price);
+    }
+
+    [Fact]
+    public async Task QuantityTooSmall_Throws()
+    {
+        var api = CreateApi();
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+        {
+            await api.ApplyOrderPrecisionAsync("BTCUSDT", null, 0.0009m);
+        });
+    }
+
+    private static BinanceApiService CreateApi()
+    {
+        var api = new BinanceApiService(new HttpClient());
+        var field = typeof(BinanceApiService).GetField("_symbolFilters", BindingFlags.NonPublic | BindingFlags.Instance);
+        var dict = (Dictionary<string, (decimal, decimal, decimal)>)field!.GetValue(api)!;
+        dict["BTCUSDT"] = (0.1m, 0.001m, 5m);
+        return api;
+    }
+}


### PR DESCRIPTION
## Summary
- cache futures symbol filters via `/fapi/v1/exchangeInfo?symbol=`
- quantize order fields using new `PrecisionHelper`
- enforce min notional and zero-quantity checks with optional stop/activation prices
- add unit tests covering price and quantity rounding edge cases

## Testing
- `dotnet test Tests/BinanceUsdtTicker.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c53863ef2c8333b2183b3871cc6800