### PR TITLE
Exclude tests from main project build

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -6,8 +6,8 @@
     <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
-    <!-- Exclude nested projects from being compiled into this project -->
-    <DefaultItemExcludes>ListingWatcherService\**;$(DefaultItemExcludes)</DefaultItemExcludes>
+    <!-- Exclude nested projects and test files from being compiled into this project -->
+    <DefaultItemExcludes>ListingWatcherService\**;Tests\**;$(DefaultItemExcludes)</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,8 +21,11 @@
   <!-- Prevent the worker service project from being compiled into the WPF application -->
   <ItemGroup>
     <Compile Remove="ListingWatcherService\**" />
+    <Compile Remove="Tests\**" />
     <None Remove="ListingWatcherService\**" />
+    <None Remove="Tests\**" />
     <EmbeddedResource Remove="ListingWatcherService\**" />
+    <EmbeddedResource Remove="Tests\**" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- prevent `Tests` folder from being included in WPF app build to fix xUnit compilation errors

## Testing
- `dotnet test` *(fails: command not found; dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c539dde7b083338c542eee84563601