### PR TITLE
Quantize Binance order params based on symbol rules

### DIFF
--- a/Services/BinanceRestClientBase.cs
+++ b/Services/BinanceRestClientBase.cs
@@ -48,7 +48,7 @@ namespace BinanceUsdtTicker
             if (!parameters.ContainsKey("timestamp"))
                 parameters["timestamp"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture);
 
-            var queryString = string.Join("&", parameters.Select(kv => $"{kv.Key}={kv.Value}"));
+            var queryString = BuildQuery(parameters);
             var signature = Sign(queryString);
             var url = endpoint + "?" + queryString + "&signature=" + signature;
 
@@ -89,6 +89,12 @@ namespace BinanceUsdtTicker
             var data = Encoding.UTF8.GetBytes(queryString);
             var hash = HMACSHA256.HashData(_secretKeyBytes, data);
             return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
+        }
+
+        private static string BuildQuery(IDictionary<string, string> p)
+        {
+            // Değerler zaten Invariant string'e çevrildi (BinanceApiService tarafı).
+            return string.Join("&", p.Select(kv => $"{kv.Key}={Uri.EscapeDataString(kv.Value)}"));
         }
     }
 }


### PR DESCRIPTION
## Summary
- cache per-symbol filters and fetch from exchangeInfo with TTL
- quantize order quantity, price, and stop price before sending
- build query strings with invariant-culture values

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c53c68591883338aa064b7610a35cc