### PR TITLE
Default timeInForce to GTC for limit orders

### DIFF
--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -509,7 +509,11 @@ namespace BinanceUsdtTicker
             if (prep.pStr != null) parameters["price"] = prep.pStr;
             if (prep.spStr != null) parameters["stopPrice"] = prep.spStr;
 
-            if (!string.IsNullOrEmpty(timeInForce)) parameters["timeInForce"] = timeInForce;
+            if (string.IsNullOrEmpty(timeInForce) && type.Contains("LIMIT", StringComparison.OrdinalIgnoreCase))
+                parameters["timeInForce"] = "GTC";
+            else if (!string.IsNullOrEmpty(timeInForce))
+                parameters["timeInForce"] = timeInForce;
+
             if (reduceOnly) parameters["reduceOnly"] = "true";
             if (!string.IsNullOrEmpty(positionSide)) parameters["positionSide"] = positionSide;
 


### PR DESCRIPTION
## Summary
- Default to `GTC` time-in-force for limit orders when none is specified.

## Testing
- ⚠️ `dotnet test` *(command not found)*
- ⚠️ `apt-get update` *(403 repository errors while attempting to install .NET SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68c53e9788a88333b55a1625b352d167