### PR TITLE
Expand open orders tab with amount and filled info

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1094,10 +1094,24 @@
                                                                                                 </DataTemplate>
                                                                                         </GridViewColumn.CellTemplate>
                                                                                 </GridViewColumn>
-                                                                                <GridViewColumn Header="Fiyat" Width="80">
+                                                                                <GridViewColumn Header="Giriş Fiyatı" Width="80">
                                                                                         <GridViewColumn.CellTemplate>
                                                                                                 <DataTemplate>
                                                                                                         <TextBlock Text="{Binding Price, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="Amount" Width="90">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding Amount, StringFormat={}{0:#,0.##}}" TextAlignment="Right"/>
+                                                                                                </DataTemplate>
+                                                                                        </GridViewColumn.CellTemplate>
+                                                                                </GridViewColumn>
+                                                                                <GridViewColumn Header="Filled" Width="80">
+                                                                                        <GridViewColumn.CellTemplate>
+                                                                                                <DataTemplate>
+                                                                                                        <TextBlock Text="{Binding Filled, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
                                                                                                 </DataTemplate>
                                                                                         </GridViewColumn.CellTemplate>
                                                                                 </GridViewColumn>

--- a/Models/FuturesOrder.cs
+++ b/Models/FuturesOrder.cs
@@ -11,6 +11,8 @@ namespace BinanceUsdtTicker.Models
         public string Side { get; set; } = string.Empty;
         public decimal Quantity { get; set; }
         public decimal Price { get; set; }
+        public decimal Filled { get; set; }
+        public decimal Amount => Price * Quantity;
         public string Status { get; set; } = string.Empty;
         public DateTime Time { get; set; }
 

--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -247,6 +247,7 @@ namespace BinanceUsdtTicker
                 {
                     decimal.TryParse(el.GetProperty("origQty").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var qty);
                     decimal.TryParse(el.GetProperty("price").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var price);
+                    decimal.TryParse(el.GetProperty("executedQty").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var filled);
                     long time = el.GetProperty("time").GetInt64();
                     list.Add(new FuturesOrder
                     {
@@ -254,6 +255,7 @@ namespace BinanceUsdtTicker
                         Side = el.GetProperty("side").GetString() ?? string.Empty,
                         Quantity = qty,
                         Price = price,
+                        Filled = filled,
                         Status = el.GetProperty("status").GetString() ?? string.Empty,
                         Time = DateTimeOffset.FromUnixTimeMilliseconds(time).LocalDateTime
                     });
@@ -281,6 +283,7 @@ namespace BinanceUsdtTicker
                 {
                     decimal.TryParse(el.GetProperty("origQty").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var qty);
                     decimal.TryParse(el.GetProperty("price").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var price);
+                    decimal.TryParse(el.GetProperty("executedQty").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var filled);
                     long time = el.GetProperty("time").GetInt64();
                     list.Add(new FuturesOrder
                     {
@@ -288,6 +291,7 @@ namespace BinanceUsdtTicker
                         Side = el.GetProperty("side").GetString() ?? string.Empty,
                         Quantity = qty,
                         Price = price,
+                        Filled = filled,
                         Status = el.GetProperty("status").GetString() ?? string.Empty,
                         Time = DateTimeOffset.FromUnixTimeMilliseconds(time).LocalDateTime
                     });
@@ -318,6 +322,7 @@ namespace BinanceUsdtTicker
                 var el = doc.RootElement;
                 decimal.TryParse(el.GetProperty("origQty").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var qty);
                 decimal.TryParse(el.GetProperty("price").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var price);
+                decimal.TryParse(el.GetProperty("executedQty").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var filled);
                 long time = el.GetProperty("time").GetInt64();
                 return new FuturesOrder
                 {
@@ -325,6 +330,7 @@ namespace BinanceUsdtTicker
                     Side = el.GetProperty("side").GetString() ?? string.Empty,
                     Quantity = qty,
                     Price = price,
+                    Filled = filled,
                     Status = el.GetProperty("status").GetString() ?? string.Empty,
                     Time = DateTimeOffset.FromUnixTimeMilliseconds(time).LocalDateTime
                 };


### PR DESCRIPTION
## Summary
- show entry price, USD amount, and filled quantity on open orders
- compute order amount and track filled quantity in data model
- parse executed quantities from Binance API responses

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c540deda348333b844a6f5efa19945