### PR TITLE
Use DataGrid for wallet and alert history sections

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1320,79 +1320,84 @@
                                                 </DockPanel>
                                         </Expander.Header>
 
-                                        <ListView x:Name="AlertList" Margin="0,6,0,0"
-                          Loaded="AlertList_Loaded"
-                          SizeChanged="AlertList_SizeChanged">
-                                                <ListView.View>
-                                                        <GridView>
-                                                                <GridViewColumn Header="Zaman"  Width="80"  DisplayMemberBinding="{Binding LocalTime}"/>
-                                                                <GridViewColumn Header="Sembol" Width="110">
-                                                                        <GridViewColumn.CellTemplate>
-                                                                                <DataTemplate>
-                                                                                        <TextBlock>
-                                                                                                <Run Text="{Binding BaseSymbol, Mode=OneWay}"/>
-                                                                                                <Run Text="/USDT" Foreground="Gray"/>
-                                                                                        </TextBlock>
-                                                                                </DataTemplate>
-                                                                        </GridViewColumn.CellTemplate>
-                                                                </GridViewColumn>
-                                                                <GridViewColumn Header="Koşul"  Width="160" DisplayMemberBinding="{Binding TypeText}"/>
-                                                                <GridViewColumn x:Name="MsgColumn" Header="Mesaj" Width="260">
-                                                                        <GridViewColumn.CellTemplate>
-                                                                                <DataTemplate>
-                                                                                        <TextBlock Text="{Binding Message}"
-                                                   TextTrimming="CharacterEllipsis"
-                                                   ToolTip="{Binding Message}"/>
-                                                                                </DataTemplate>
-                                                                        </GridViewColumn.CellTemplate>
-                                                                </GridViewColumn>
-                                                        </GridView>
-                                                </ListView.View>
-                                        </ListView>
+                                        <DataGrid x:Name="AlertList" Margin="0,6,0,0"
+          Style="{DynamicResource MaterialDesignDataGrid}"
+          AutoGenerateColumns="False"
+          IsReadOnly="True"
+          CanUserSortColumns="True"
+          CanUserReorderColumns="True"
+          HeadersVisibility="Column"
+          GridLinesVisibility="None"
+          RowBackground="{DynamicResource RowBg}"
+          AlternatingRowBackground="{DynamicResource RowAltBg}"
+          ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+    <DataGrid.Columns>
+        <DataGridTextColumn Header="Zaman" Width="80" Binding="{Binding LocalTime}">
+            <DataGridTextColumn.ElementStyle>
+                <Style TargetType="TextBlock">
+                    <Setter Property="HorizontalAlignment" Value="Center"/>
+                </Style>
+            </DataGridTextColumn.ElementStyle>
+        </DataGridTextColumn>
+        <DataGridTemplateColumn Header="Sembol" Width="110">
+            <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate>
+                    <TextBlock>
+                        <Run Text="{Binding BaseSymbol, Mode=OneWay}"/>
+                        <Run Text="/USDT" Foreground="Gray"/>
+                    </TextBlock>
+                </DataTemplate>
+            </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+        <DataGridTextColumn Header="Koşul" Width="160" Binding="{Binding TypeText}"/>
+        <DataGridTemplateColumn Header="Mesaj" Width="*">
+            <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Message}" TextTrimming="CharacterEllipsis" ToolTip="{Binding Message}"/>
+                </DataTemplate>
+            </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+    </DataGrid.Columns>
+</DataGrid>
+
                                 </Expander>
 
                                 <!-- CÜZDAN BİLGİLERİ -->
                                 <Expander Grid.Column="1" Header="Cüzdan" IsExpanded="True" Padding="6,4">
-                                        <ListView x:Name="WalletList" Margin="0,6,0,0">
-                                                <ListView.View>
-                                                        <GridView>
-                                                                <GridViewColumn Header="Varlık" Width="70">
-                                                                        <GridViewColumn.CellTemplate>
-                                                                                <DataTemplate>
-                                                                                        <Border BorderBrush="{DynamicResource Divider}"
-                                                                                                BorderThickness="0,0,1,1" Padding="2">
-                                                                                                <TextBlock Text="{Binding Asset}"/>
-                                                                                        </Border>
-                                                                                </DataTemplate>
-                                                                        </GridViewColumn.CellTemplate>
-                                                                </GridViewColumn>
-                                                                <GridViewColumn Header="Bakiye" Width="90">
-                                                                        <GridViewColumn.CellTemplate>
-                                                                                <DataTemplate>
-                                                                                        <Border BorderBrush="{DynamicResource Divider}"
-                                                                                                BorderThickness="0,0,1,1" Padding="2">
-                                                                                                <TextBlock Text="{Binding Balance, StringFormat={}{0:#,0.00}}"
-                                                                                                           HorizontalAlignment="Right"
-                                                                                                           TextAlignment="Right"/>
-                                                                                        </Border>
-                                                                                </DataTemplate>
-                                                                        </GridViewColumn.CellTemplate>
-                                                                </GridViewColumn>
-                                                                <GridViewColumn Header="Kullanılabilir" Width="90">
-                                                                        <GridViewColumn.CellTemplate>
-                                                                                <DataTemplate>
-                                                                                        <Border BorderBrush="{DynamicResource Divider}"
-                                                                                                BorderThickness="0,0,0,1" Padding="2">
-                                                                                                <TextBlock Text="{Binding Available, StringFormat={}{0:#,0.00}}"
-                                                                                                           HorizontalAlignment="Right"
-                                                                                                           TextAlignment="Right"/>
-                                                                                        </Border>
-                                                                                </DataTemplate>
-                                                                        </GridViewColumn.CellTemplate>
-                                                                </GridViewColumn>
-                                                        </GridView>
-                                                </ListView.View>
-                                        </ListView>
+                                        <DataGrid x:Name="WalletList" Margin="0,6,0,0"
+          Style="{DynamicResource MaterialDesignDataGrid}"
+          AutoGenerateColumns="False"
+          IsReadOnly="True"
+          HeadersVisibility="Column"
+          GridLinesVisibility="None"
+          RowBackground="{DynamicResource RowBg}"
+          AlternatingRowBackground="{DynamicResource RowAltBg}"
+          ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+    <DataGrid.Columns>
+        <DataGridTextColumn Header="Varlık" Width="70" Binding="{Binding Asset}">
+            <DataGridTextColumn.ElementStyle>
+                <Style TargetType="TextBlock">
+                    <Setter Property="HorizontalAlignment" Value="Center"/>
+                </Style>
+            </DataGridTextColumn.ElementStyle>
+        </DataGridTextColumn>
+        <DataGridTextColumn Header="Bakiye" Width="90" Binding="{Binding Balance, StringFormat={}{0:#,0.00}}">
+            <DataGridTextColumn.ElementStyle>
+                <Style TargetType="TextBlock">
+                    <Setter Property="TextAlignment" Value="Right"/>
+                </Style>
+            </DataGridTextColumn.ElementStyle>
+        </DataGridTextColumn>
+        <DataGridTextColumn Header="Kullanılabilir" Width="90" Binding="{Binding Available, StringFormat={}{0:#,0.00}}">
+            <DataGridTextColumn.ElementStyle>
+                <Style TargetType="TextBlock">
+                    <Setter Property="TextAlignment" Value="Right"/>
+                </Style>
+            </DataGridTextColumn.ElementStyle>
+        </DataGridTextColumn>
+    </DataGrid.Columns>
+</DataGrid>
+
                                 </Expander>
                         </Grid>
                 </Grid>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -89,7 +89,7 @@ namespace BinanceUsdtTicker
             var screenHeight = SystemParameters.PrimaryScreenHeight / 8;
 
             // alarm geçmişi bağla
-            var alertList = FindName("AlertList") as ListView;
+            var alertList = FindName("AlertList") as DataGrid;
             if (alertList != null)
             {
                 alertList.ItemsSource = _alertLog;
@@ -100,7 +100,7 @@ namespace BinanceUsdtTicker
             }
 
             // cüzdan listesi bağla
-            var walletList = FindName("WalletList") as ListView;
+            var walletList = FindName("WalletList") as DataGrid;
             if (walletList != null)
             {
                 walletList.ItemsSource = _walletAssets;
@@ -936,7 +936,6 @@ namespace BinanceUsdtTicker
             if (_alertLog.Count > MaxAlertLog)
                 _alertLog.RemoveAt(_alertLog.Count - 1);
 
-            AdjustAlertMsgColumnWidth();
         }
 
         private void ShowWindowsNotification(string msg)
@@ -962,7 +961,6 @@ namespace BinanceUsdtTicker
         private void ClearAlertLog_Click(object sender, RoutedEventArgs e)
         {
             _alertLog.Clear();
-            AdjustAlertMsgColumnWidth();
         }
 
         private void ExportAlertLog_Click(object sender, RoutedEventArgs e)
@@ -1226,40 +1224,6 @@ namespace BinanceUsdtTicker
                         col.Width = new DataGridLength(st.Width, DataGridLengthUnitType.Pixel);
                 }
             }
-        }
-
-        private void AlertList_Loaded(object sender, RoutedEventArgs e) => AdjustAlertMsgColumnWidth();
-        private void AlertList_SizeChanged(object sender, SizeChangedEventArgs e) => AdjustAlertMsgColumnWidth();
-
-        private void AdjustAlertMsgColumnWidth()
-        {
-            var alertList = Q<ListView>("AlertList");
-            if (alertList?.View is not GridView gv) return;
-
-            // "Mesaj" başlıklı sütunu bul
-            GridViewColumn? msgCol = gv.Columns.FirstOrDefault(c =>
-                string.Equals(c.Header?.ToString(), "Mesaj", StringComparison.OrdinalIgnoreCase));
-            if (msgCol == null) return;
-
-            double fixedSum = 0;
-            foreach (var col in gv.Columns)
-            {
-                if (ReferenceEquals(col, msgCol)) continue;
-                var w = col.Width;
-                if (double.IsNaN(w) || w <= 0) w = 100;
-                fixedSum += w;
-            }
-
-            double total = alertList.ActualWidth;
-            double padding = 35;
-
-            double scroll = 0;
-            var sv = FindDescendant<ScrollViewer>(alertList);
-            if (sv != null && sv.ComputedVerticalScrollBarVisibility == Visibility.Visible)
-                scroll = SystemParameters.VerticalScrollBarWidth;
-
-            double newWidth = Math.Max(120, total - fixedSum - padding - scroll);
-            msgCol.Width = newWidth;
         }
 
         private static T? FindDescendant<T>(DependencyObject root) where T : DependencyObject


### PR DESCRIPTION
## Summary
- Replace wallet and alert history ListViews with styled DataGrids for consistent appearance
- Bind new DataGrids in code-behind and remove obsolete alert log column sizing logic

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c546cfbac48333ba5af0df4ae90c5b