### PR TITLE
Align Top Movers hover behavior with Coin grid

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -881,11 +881,7 @@
                                                                                <Setter Property="Background" Value="{DynamicResource Up1Bg}"/>
                                                                                <Setter Property="Foreground" Value="{DynamicResource Up1Fg}"/>
                                                                        </DataTrigger>
-                                                                       <!-- Hover: highlight row -->
-                                                                       <Trigger Property="IsMouseOver" Value="True">
-                                                                               <Setter Property="Background" Value="{DynamicResource RowHoverBg}"/>
-                                                                               <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
-                                                                       </Trigger>
+                                                                       <!-- No hover styling to match Coin grid -->
                                                                </Style.Triggers>
                                                        </Style>
                                                </DataGrid.RowStyle>
@@ -898,9 +894,6 @@
                                                                        <DataTrigger Binding="{Binding IsMove1Plus}" Value="True">
                                                                                <Setter Property="Foreground" Value="{DynamicResource Up1Fg}"/>
                                                                        </DataTrigger>
-                                                                       <Trigger Property="IsMouseOver" Value="True">
-                                                                               <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
-                                                                       </Trigger>
                                                                </Style.Triggers>
                                                        </Style>
                                                </DataGrid.CellStyle>
@@ -945,11 +938,7 @@
                                                                                <Setter Property="Background" Value="{DynamicResource Down1Bg}"/>
                                                                                <Setter Property="Foreground" Value="{DynamicResource Down1Fg}"/>
                                                                        </DataTrigger>
-                                                                       <!-- Hover: highlight row -->
-                                                                       <Trigger Property="IsMouseOver" Value="True">
-                                                                               <Setter Property="Background" Value="{DynamicResource RowHoverBg}"/>
-                                                                               <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
-                                                                       </Trigger>
+                                                                       <!-- No hover styling to match Coin grid -->
                                                                </Style.Triggers>
                                                        </Style>
                                                </DataGrid.RowStyle>
@@ -962,9 +951,6 @@
                                                                        <DataTrigger Binding="{Binding IsMoveMinus1}" Value="True">
                                                                                <Setter Property="Foreground" Value="{DynamicResource Down1Fg}"/>
                                                                        </DataTrigger>
-                                                                       <Trigger Property="IsMouseOver" Value="True">
-                                                                               <Setter Property="Foreground" Value="{DynamicResource OnSurface}"/>
-                                                                       </Trigger>
                                                                </Style.Triggers>
                                                        </Style>
                                                </DataGrid.CellStyle>


### PR DESCRIPTION
## Summary
- Remove custom hover triggers from Top Movers DataGrids

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c549dfd3ac83338a1ebe91ffc72366