### PR TITLE
Reduce Top Movers row height

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -868,7 +868,7 @@
                              AutoGenerateColumns="False" IsReadOnly="True"
                              HeadersVisibility="Column" GridLinesVisibility="None"
                              Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
-                             RowHeight="35">
+                             RowHeight="25">
                                                <DataGrid.RowStyle>
                                                        <Style TargetType="DataGridRow" BasedOn="{StaticResource MaterialDesignDataGridRow}">
                                                                <Style.Triggers>
@@ -927,7 +927,7 @@
                              AutoGenerateColumns="False" IsReadOnly="True"
                              HeadersVisibility="Column" GridLinesVisibility="None"
                              Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
-                             RowHeight="35">
+                             RowHeight="25">
                                                <DataGrid.RowStyle>
                                                        <Style TargetType="DataGridRow" BasedOn="{StaticResource MaterialDesignDataGridRow}">
                                                                <Style.Triggers>


### PR DESCRIPTION
## Summary
- use a compact row height for Top Movers lists

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c54c6818ac83338b81f9e5ff256527