### PR TITLE
Adjust Top Movers font size

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -868,7 +868,7 @@
                              AutoGenerateColumns="False" IsReadOnly="True"
                              HeadersVisibility="Column" GridLinesVisibility="None"
                              Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
-                             RowHeight="25">
+                             RowHeight="25" FontSize="12">
                                                <DataGrid.RowStyle>
                                                        <Style TargetType="DataGridRow" BasedOn="{StaticResource MaterialDesignDataGridRow}">
                                                                <Style.Triggers>
@@ -927,7 +927,7 @@
                              AutoGenerateColumns="False" IsReadOnly="True"
                              HeadersVisibility="Column" GridLinesVisibility="None"
                              Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
-                             RowHeight="25">
+                             RowHeight="25" FontSize="12">
                                                <DataGrid.RowStyle>
                                                        <Style TargetType="DataGridRow" BasedOn="{StaticResource MaterialDesignDataGridRow}">
                                                                <Style.Triggers>


### PR DESCRIPTION
## Summary
- reduce font size for Top Movers gainers and losers lists

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c54d68dc4c83339434668345f59c86