### PR TITLE
Center open positions grid rows

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1016,6 +1016,19 @@
                                                                                 </Setter>
                                                                         </Style>
                                                                 </DataGrid.ColumnHeaderStyle>
+                                                                <DataGrid.RowStyle>
+                                                                        <Style TargetType="DataGridRow">
+                                                                                <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                                                                                <Setter Property="VerticalContentAlignment" Value="Center"/>
+                                                                        </Style>
+                                                                </DataGrid.RowStyle>
+                                                                <DataGrid.CellStyle>
+                                                                        <Style TargetType="DataGridCell">
+                                                                                <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                                                                                <Setter Property="VerticalContentAlignment" Value="Center"/>
+                                                                                <Setter Property="TextBlock.TextAlignment" Value="Center"/>
+                                                                        </Style>
+                                                                </DataGrid.CellStyle>
                                                                 <DataGrid.Columns>
                                                                         <DataGridTemplateColumn Header="Sembol" Width="110">
                                                                                 <DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
## Summary
- Center align rows in the Open Positions DataGrid for both horizontal and vertical content alignment

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c551afd00083338bffb340e80dfeeb