### PR TITLE
Sayı parametrelerini invariant kültürde normalize et

### DIFF
--- a/Services/BinanceRestClientBase.cs
+++ b/Services/BinanceRestClientBase.cs
@@ -93,8 +93,15 @@ namespace BinanceUsdtTicker
 
         private static string BuildQuery(IDictionary<string, string> p)
         {
-            // Değerler zaten Invariant string'e çevrildi (BinanceApiService tarafı).
-            return string.Join("&", p.Select(kv => $"{kv.Key}={Uri.EscapeDataString(kv.Value)}"));
+            return string.Join("&", p.Select(kv => $"{kv.Key}={Uri.EscapeDataString(Normalize(kv.Value))}"));
+        }
+
+        private static string Normalize(string value)
+        {
+            if (decimal.TryParse(value, NumberStyles.Number, CultureInfo.CurrentCulture, out var dec))
+                return dec.ToString("0.####################", CultureInfo.InvariantCulture)
+                        .TrimEnd('0').TrimEnd('.');
+            return value;
         }
     }
 }


### PR DESCRIPTION
## Özet
- Binance REST istemcisinde gönderilen tüm parametreleri InvariantCulture'a göre normalize eden `Normalize` yardımcı metodunu eklendi.
- Fiyat ve benzeri sayısal değerlerin binlik ayraçlarla yanlış parse edilmesi engellendi.

## Testler
- `dotnet test` (Dotnet kurulmadığından çalıştırılamadı)


------
https://chatgpt.com/codex/tasks/task_e_68c55e05223483338aa08af308b010a4