### PR TITLE
fix build error in UserDecimalConverter

### DIFF
--- a/Converters/UserDecimalConverter.cs
+++ b/Converters/UserDecimalConverter.cs
@@ -15,8 +15,6 @@ namespace BinanceUsdtTicker
         {
             if (value is decimal d)
                 return d.ToString("0.####################", CultureInfo.CurrentCulture);
-            if (value is decimal? dn && dn.HasValue)
-                return dn.Value.ToString("0.####################", CultureInfo.CurrentCulture);
             return string.Empty;
         }
 


### PR DESCRIPTION
## Summary
- simplify UserDecimalConverter's Convert method to avoid invalid `decimal?` pattern that caused build errors

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c56687856883338294a83c04ac4f19