### PR TITLE
Format limit price input automatically

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -679,7 +679,9 @@
                                                 <TabItem Header="Limit">
                                                         <StackPanel Margin="4">
                                                                 <TextBlock Text="Price" Margin="0,0,0,4"/>
-                                                                <TextBox x:Name="LimitPriceTextBox" Margin="0,0,0,8" Height="40" FontSize="18" FontWeight="Bold"/>
+                                                                <TextBox x:Name="LimitPriceTextBox" Margin="0,0,0,8" Height="40" FontSize="18" FontWeight="Bold"
+                                                                         PreviewTextInput="LimitPrice_PreviewTextInput"
+                                                                         LostFocus="LimitPriceTextBox_LostFocus"/>
                                                                 <TextBlock Text="Size" Margin="0,0,0,4"/>
                                                                 <Slider x:Name="LimitSizeSlider" Minimum="0" Maximum="100" TickPlacement="BottomRight" Ticks="0,25,50,75,100" IsSnapToTickEnabled="False" ValueChanged="SizeSlider_ValueChanged"/>
                                                                 <TextBlock x:Name="LimitSizeValueText" Margin="0,4,0,0"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1455,6 +1455,42 @@ namespace BinanceUsdtTicker
                 priceBox.Text = _selectedTicker.Price.ToString("0.########", CultureInfo.CurrentCulture);
         }
 
+        private void LimitPrice_PreviewTextInput(object sender, TextCompositionEventArgs e)
+        {
+            if (e.Text == ",")
+            {
+                if (sender is TextBox tb)
+                {
+                    int caret = tb.CaretIndex;
+                    tb.Text = tb.Text.Insert(caret, ".");
+                    tb.CaretIndex = caret + 1;
+                }
+                e.Handled = true;
+            }
+        }
+
+        private void LimitPriceTextBox_LostFocus(object sender, RoutedEventArgs e)
+        {
+            if (sender is not TextBox tb)
+                return;
+
+            var digitsOnly = new string(tb.Text.Where(c => char.IsDigit(c) || c == '.').ToArray());
+            if (string.IsNullOrWhiteSpace(digitsOnly))
+            {
+                tb.Text = string.Empty;
+                return;
+            }
+
+            if (decimal.TryParse(digitsOnly, NumberStyles.Float, CultureInfo.InvariantCulture, out var price))
+            {
+                tb.Text = price.ToString("0.00", CultureInfo.InvariantCulture);
+            }
+            else
+            {
+                tb.Text = string.Empty;
+            }
+        }
+
         private void UpdatePriceAndSize()
         {
             var tab = Q<TabControl>("OrderTypeTab");


### PR DESCRIPTION
## Summary
- Format limit order price text after input loses focus
- Allow typing comma which is converted to dot for price entry

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c56739388883339ff894bf2392e0ea