### PR TITLE
Fix integer price formatting for Binance orders

### DIFF
--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -475,8 +475,7 @@ namespace BinanceUsdtTicker
         }
 
         private static string ToInvariantString(decimal v)
-            => v.ToString("0.####################", CultureInfo.InvariantCulture)
-                 .TrimEnd('0').TrimEnd('.');
+            => v.ToString("0.####################", CultureInfo.InvariantCulture);
 
         private async Task<(string qStr, string? pStr, string? spStr)> PrepareOrderNumbersAsync(
             string symbol, decimal quantity, decimal? price, decimal? stopPrice, bool reduceOnly, CancellationToken ct)

--- a/Tests/PrecisionHelperTests.cs
+++ b/Tests/PrecisionHelperTests.cs
@@ -27,6 +27,14 @@ public class PrecisionHelperTests
         });
     }
 
+    [Fact]
+    public void ToInvariantString_LeavesIntegerUnchanged()
+    {
+        var method = typeof(BinanceApiService).GetMethod("ToInvariantString", BindingFlags.NonPublic | BindingFlags.Static);
+        var result = (string)method!.Invoke(null, new object[] { 116500m })!;
+        Assert.Equal("116500", result);
+    }
+
     private static BinanceApiService CreateApi()
     {
         var api = new BinanceApiService(new HttpClient());


### PR DESCRIPTION
## Summary
- prevent order price strings from trimming trailing zeros
- add unit test ensuring integer prices remain unchanged

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c56ab9f17c8333b3eb42f488e47ee3