### PR TITLE
Fix price normalization removing trailing zeros

### DIFF
--- a/Services/BinanceRestClientBase.cs
+++ b/Services/BinanceRestClientBase.cs
@@ -109,8 +109,7 @@ namespace BinanceUsdtTicker
         {
             if (decimal.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var dec) ||
                 decimal.TryParse(value, NumberStyles.Number, new CultureInfo("tr-TR"), out dec))
-                return dec.ToString("0.####################", CultureInfo.InvariantCulture)
-                        .TrimEnd('0').TrimEnd('.');
+                return dec.ToString("0.####################", CultureInfo.InvariantCulture);
             return value;
         }
     }

--- a/Tests/PrecisionHelperTests.cs
+++ b/Tests/PrecisionHelperTests.cs
@@ -35,6 +35,15 @@ public class PrecisionHelperTests
         Assert.Equal("116500", result);
     }
 
+    [Fact]
+    public void BuildQuery_LeavesIntegerUnchanged()
+    {
+        var method = typeof(BinanceRestClientBase).GetMethod("BuildQuery", BindingFlags.NonPublic | BindingFlags.Static);
+        var dict = new Dictionary<string, string> { ["price"] = "116500" };
+        var result = (string)method!.Invoke(null, new object[] { dict })!;
+        Assert.Equal("price=116500", result);
+    }
+
     private static BinanceApiService CreateApi()
     {
         var api = new BinanceApiService(new HttpClient());


### PR DESCRIPTION
## Summary
- ensure integer prices remain unchanged when signing REST requests
- add unit test for query normalization with integer price

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5712f932483339449ad09cd8df578