### PR TITLE
fix: handle comma or dot decimal separators

### DIFF
--- a/Helpers/InputParser.cs
+++ b/Helpers/InputParser.cs
@@ -17,13 +17,32 @@ namespace BinanceUsdtTicker.Helpers
                 return false;
             }
 
-            var tr = new CultureInfo("tr-TR");
-            s = s.Replace(" ", string.Empty)
-                 .Replace(tr.NumberFormat.NumberGroupSeparator, string.Empty)
-                 .Replace(CultureInfo.InvariantCulture.NumberFormat.NumberGroupSeparator, string.Empty);
+            s = s.Replace(" ", string.Empty);
 
-            if (decimal.TryParse(s, NumberStyles.Number, tr, out value))
-                return true;
+            var commaIndex = s.LastIndexOf(',');
+            var dotIndex = s.LastIndexOf('.');
+
+            if (commaIndex >= 0 && dotIndex >= 0)
+            {
+                if (commaIndex > dotIndex)
+                {
+                    s = s.Replace(".", string.Empty);
+                    s = s.Replace(',', '.');
+                }
+                else
+                {
+                    s = s.Replace(",", string.Empty);
+                }
+            }
+            else if (commaIndex >= 0)
+            {
+                s = s.Replace(',', '.');
+            }
+            else
+            {
+                s = s.Replace(",", string.Empty);
+            }
+
             if (decimal.TryParse(s, NumberStyles.Number, CultureInfo.InvariantCulture, out value))
                 return true;
 

--- a/Tests/InputParserTests.cs
+++ b/Tests/InputParserTests.cs
@@ -1,0 +1,19 @@
+using BinanceUsdtTicker.Helpers;
+using Xunit;
+
+namespace BinanceUsdtTicker.Tests;
+
+public class InputParserTests
+{
+    [Theory]
+    [InlineData("116500,50")]
+    [InlineData("116500.50")]
+    [InlineData("116,500.50")]
+    [InlineData("116.500,50")]
+    public void ParsesDecimalWithCommaOrDot(string input)
+    {
+        var ok = InputParser.TryParseUserDecimal(input, out var value);
+        Assert.True(ok);
+        Assert.Equal(116500.50m, value);
+    }
+}


### PR DESCRIPTION
## Summary
- allow decimal inputs using comma or dot separators
- add tests for parsing user decimal values

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403, cannot install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c5737b9bb48333acdb4f1897467fdb