### PR TITLE
Fix decimal input for close position limit

### DIFF
--- a/Converters/UserDecimalConverter.cs
+++ b/Converters/UserDecimalConverter.cs
@@ -23,9 +23,19 @@ namespace BinanceUsdtTicker
             var s = value?.ToString();
             if (string.IsNullOrWhiteSpace(s))
                 return null;
+
+            s = s.Trim();
+
+            // Allow the user to temporarily enter a trailing decimal separator
+            // without losing it immediately due to binding updates.
+            char last = s[s.Length - 1];
+            if (last == '.' || last == ',')
+                return Binding.DoNothing;
+
             if (InputParser.TryParseUserDecimal(s, out var v))
                 return v;
-            throw new FormatException($"Invalid decimal: {s}");
+
+            return Binding.DoNothing;
         }
     }
 }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1101,7 +1101,9 @@
                                                                                 <DataGridTemplateColumn.CellTemplate>
                                                                                         <DataTemplate>
                                                                                                 <StackPanel Orientation="Horizontal">
-                                                                                                        <TextBox Width="60" Margin="0,0,4,0" Text="{Binding CloseLimitPrice, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource UserDecimalConverter}}"/>
+                                                                                                        <TextBox Width="60" Margin="0,0,4,0"
+                                                                                                                 PreviewTextInput="LimitPrice_PreviewTextInput"
+                                                                                                                 Text="{Binding CloseLimitPrice, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource UserDecimalConverter}}"/>
                                                                                                         <Button Content="Limit" Margin="0,0,4,0" Tag="{Binding}" Click="ClosePositionLimit_Click"/>
                                                                                                         <Button Content="Market" Tag="{Binding}" Click="ClosePositionMarket_Click"/>
                                                                                                 </StackPanel>


### PR DESCRIPTION
## Summary
- Allow decimal separators in close limit price field
- Improve decimal converter to preserve trailing separator during editing

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c57474ef808333b5ff3f50f463283c