### PR TITLE
Add cancel support and improve order/trade history display

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1183,6 +1183,13 @@
                                                                                 </DataGridTemplateColumn.CellTemplate>
                                                                         </DataGridTemplateColumn>
                                                                         <DataGridTextColumn Header="Durum" Width="80" Binding="{Binding Status}"/>
+                                                                        <DataGridTemplateColumn Header="İptal" Width="60">
+                                                                                <DataGridTemplateColumn.CellTemplate>
+                                                                                        <DataTemplate>
+                                                                                                <Button Content="İptal" Tag="{Binding}" Click="CancelOrder_Click"/>
+                                                                                        </DataTemplate>
+                                                                                </DataGridTemplateColumn.CellTemplate>
+                                                                        </DataGridTemplateColumn>
                                                                 </DataGrid.Columns>
                                                         </DataGrid>
                                                 </TabItem>
@@ -1235,20 +1242,54 @@
                                                                                 </DataGridTemplateColumn.CellTemplate>
                                                                         </DataGridTemplateColumn>
                                                                         <DataGridTemplateColumn Header="Fiyat" Width="80">
-                                                                                <DataGridTemplateColumn.CellTemplate>
-                                                                                        <DataTemplate>
-                                                                                                <TextBlock Text="{Binding Price, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
-                                                                                        </DataTemplate>
-                                                                                </DataGridTemplateColumn.CellTemplate>
-                                                                        </DataGridTemplateColumn>
-                                                                        <DataGridTextColumn Header="Durum" Width="80" Binding="{Binding Status}"/>
-                                                                        <DataGridTemplateColumn Header="Zaman" Width="120">
-                                                                                <DataGridTemplateColumn.CellTemplate>
-                                                                                        <DataTemplate>
-                                                                                                <TextBlock Text="{Binding Time, StringFormat={}{0:HH:mm:ss}}" TextAlignment="Center"/>
-                                                                                        </DataTemplate>
-                                                                                </DataGridTemplateColumn.CellTemplate>
-                                                                        </DataGridTemplateColumn>
+        <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate>
+                        <TextBlock Text="{Binding Price,
+ StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                </DataTemplate>
+        </DataGridTemplateColumn.CellTemplate>
+</DataGridTemplateColumn>
+<DataGridTemplateColumn Header="Executed" Width="80">
+        <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate>
+                        <TextBlock Text="{Binding Filled,
+ StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                </DataTemplate>
+        </DataGridTemplateColumn.CellTemplate>
+</DataGridTemplateColumn>
+<DataGridTemplateColumn Header="Amount" Width="90">
+        <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate>
+                        <TextBlock Text="{Binding Amount,
+ StringFormat={}{0:#,0.##}}" TextAlignment="Right"/>
+                </DataTemplate>
+        </DataGridTemplateColumn.CellTemplate>
+</DataGridTemplateColumn>
+<DataGridTemplateColumn Header="Durum" Width="80">
+        <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate>
+                        <TextBlock Text="{Binding Status}">
+                                <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                                <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Status}" Value="FILLED">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                        </DataTrigger>
+                                                </Style.Triggers>
+                                        </Style>
+                                </TextBlock.Style>
+                        </TextBlock>
+                </DataTemplate>
+        </DataGridTemplateColumn.CellTemplate>
+</DataGridTemplateColumn>
+<DataGridTemplateColumn Header="Zaman" Width="150">
+        <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate>
+                        <TextBlock Text="{Binding Time,
+StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}" TextAlignment="Center"/>
+                </DataTemplate>
+        </DataGridTemplateColumn.CellTemplate>
+</DataGridTemplateColumn>
                                                                 </DataGrid.Columns>
                                                         </DataGrid>
                                                 </TabItem>
@@ -1293,7 +1334,7 @@
                                                                                         </DataTemplate>
                                                                                 </DataGridTemplateColumn.CellTemplate>
                                                                         </DataGridTemplateColumn>
-                                                                        <DataGridTemplateColumn Header="Adet" Width="80">
+                                                                        <DataGridTemplateColumn Header="Pozisyon Boyutu" Width="80">
                                                                                 <DataGridTemplateColumn.CellTemplate>
                                                                                         <DataTemplate>
                                                                                                 <TextBlock Text="{Binding Quantity, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
@@ -1301,11 +1342,11 @@
                                                                                 </DataGridTemplateColumn.CellTemplate>
                                                                         </DataGridTemplateColumn>
                                                                         <DataGridTemplateColumn Header="Fiyat" Width="80">
-                                                                                <DataGridTemplateColumn.CellTemplate>
-                                                                                        <DataTemplate>
-                                                                                                <TextBlock Text="{Binding Price, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
-                                                                                        </DataTemplate>
-                                                                                </DataGridTemplateColumn.CellTemplate>
+                                                                        <DataGridTemplateColumn.CellTemplate>
+                                                                                <DataTemplate>
+                                                                                        <TextBlock Text="{Binding Price, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                </DataTemplate>
+                                                                        </DataGridTemplateColumn.CellTemplate>
                                                                         </DataGridTemplateColumn>
                                                                         <DataGridTemplateColumn Header="Ücret" Width="80">
                                                                                 <DataGridTemplateColumn.CellTemplate>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1692,6 +1692,22 @@ namespace BinanceUsdtTicker
                 await ClosePositionAsync(pos, null);
         }
 
+        private async void CancelOrder_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button btn && btn.Tag is FuturesOrder order)
+            {
+                try
+                {
+                    await _api.CancelOrderAsync(order.Symbol, order.OrderId);
+                    _ = RefreshTradingDataAsync();
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(this, ex.Message, "Hata", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            }
+        }
+
         private async void ClosePositionLimit_Click(object sender, RoutedEventArgs e)
         {
             if (sender is Button btn && btn.Tag is FuturesPosition pos)

--- a/Models/FuturesOrder.cs
+++ b/Models/FuturesOrder.cs
@@ -7,6 +7,7 @@ namespace BinanceUsdtTicker.Models
     /// </summary>
     public class FuturesOrder
     {
+        public long OrderId { get; set; }
         public string Symbol { get; set; } = string.Empty;
         public string Side { get; set; } = string.Empty;
         public decimal Quantity { get; set; }

--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -252,12 +252,14 @@ namespace BinanceUsdtTicker
                 using var doc = JsonDocument.Parse(json);
                 foreach (var el in doc.RootElement.EnumerateArray())
                 {
+                    long orderId = el.GetProperty("orderId").GetInt64();
                     decimal.TryParse(el.GetProperty("origQty").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var qty);
                     decimal.TryParse(el.GetProperty("price").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var price);
                     decimal.TryParse(el.GetProperty("executedQty").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var filled);
                     long time = el.GetProperty("time").GetInt64();
                     list.Add(new FuturesOrder
                     {
+                        OrderId = orderId,
                         Symbol = el.GetProperty("symbol").GetString() ?? symbol,
                         Side = el.GetProperty("side").GetString() ?? string.Empty,
                         Quantity = qty,
@@ -288,12 +290,14 @@ namespace BinanceUsdtTicker
                 using var doc = JsonDocument.Parse(json);
                 foreach (var el in doc.RootElement.EnumerateArray())
                 {
+                    long orderId = el.GetProperty("orderId").GetInt64();
                     decimal.TryParse(el.GetProperty("origQty").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var qty);
                     decimal.TryParse(el.GetProperty("price").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var price);
                     decimal.TryParse(el.GetProperty("executedQty").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var filled);
                     long time = el.GetProperty("time").GetInt64();
                     list.Add(new FuturesOrder
                     {
+                        OrderId = orderId,
                         Symbol = el.GetProperty("symbol").GetString() ?? string.Empty,
                         Side = el.GetProperty("side").GetString() ?? string.Empty,
                         Quantity = qty,
@@ -327,12 +331,14 @@ namespace BinanceUsdtTicker
             {
                 using var doc = JsonDocument.Parse(json);
                 var el = doc.RootElement;
+                long orderId = el.GetProperty("orderId").GetInt64();
                 decimal.TryParse(el.GetProperty("origQty").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var qty);
                 decimal.TryParse(el.GetProperty("price").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var price);
                 decimal.TryParse(el.GetProperty("executedQty").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var filled);
                 long time = el.GetProperty("time").GetInt64();
                 return new FuturesOrder
                 {
+                    OrderId = orderId,
                     Symbol = el.GetProperty("symbol").GetString() ?? symbol,
                     Side = el.GetProperty("side").GetString() ?? string.Empty,
                     Quantity = qty,
@@ -346,6 +352,16 @@ namespace BinanceUsdtTicker
             {
                 return null;
             }
+        }
+
+        public async Task CancelOrderAsync(string symbol, long orderId)
+        {
+            var query = new Dictionary<string, string>
+            {
+                ["symbol"] = symbol,
+                ["orderId"] = orderId.ToString(CultureInfo.InvariantCulture)
+            };
+            await SendSignedAsync(HttpMethod.Delete, "/fapi/v1/order", query);
         }
 
         public async Task SetLeverageAsync(string symbol, int leverage)


### PR DESCRIPTION
## Summary
- add cancel button for open orders with backend support
- show executed, amount, and colored status in order history, with full timestamps
- rename trade history quantity column to "Pozisyon Boyutu"

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c576068fa48333a9fd8392684a9326