### PR TITLE
Fix orderId variable shadowing in BinanceApiService

### DIFF
--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -331,14 +331,14 @@ namespace BinanceUsdtTicker
             {
                 using var doc = JsonDocument.Parse(json);
                 var el = doc.RootElement;
-                long orderId = el.GetProperty("orderId").GetInt64();
+                long parsedOrderId = el.GetProperty("orderId").GetInt64();
                 decimal.TryParse(el.GetProperty("origQty").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var qty);
                 decimal.TryParse(el.GetProperty("price").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var price);
                 decimal.TryParse(el.GetProperty("executedQty").GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var filled);
                 long time = el.GetProperty("time").GetInt64();
                 return new FuturesOrder
                 {
-                    OrderId = orderId,
+                    OrderId = parsedOrderId,
                     Symbol = el.GetProperty("symbol").GetString() ?? symbol,
                     Side = el.GetProperty("side").GetString() ?? string.Empty,
                     Quantity = qty,


### PR DESCRIPTION
## Summary
- avoid parameter shadowing by renaming local `orderId` variable when parsing open order response

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c577b032b88333b6adc844c4e34830