### PR TITLE
Show executed and trade position size in USDT

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1252,8 +1252,8 @@
 <DataGridTemplateColumn Header="Executed" Width="80">
         <DataGridTemplateColumn.CellTemplate>
                 <DataTemplate>
-                        <TextBlock Text="{Binding Filled,
- StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                        <TextBlock Text="{Binding FilledAmount,
+ StringFormat={}{0:#,0.##}}" TextAlignment="Right"/>
                 </DataTemplate>
         </DataGridTemplateColumn.CellTemplate>
 </DataGridTemplateColumn>
@@ -1337,7 +1337,7 @@ StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}" TextAlignment="Center"/>
                                                                         <DataGridTemplateColumn Header="Pozisyon Boyutu" Width="80">
                                                                                 <DataGridTemplateColumn.CellTemplate>
                                                                                         <DataTemplate>
-                                                                                                <TextBlock Text="{Binding Quantity, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                                <TextBlock Text="{Binding Amount, StringFormat={}{0:#,0.##}}" TextAlignment="Right"/>
                                                                                         </DataTemplate>
                                                                                 </DataGridTemplateColumn.CellTemplate>
                                                                         </DataGridTemplateColumn>

--- a/Models/FuturesOrder.cs
+++ b/Models/FuturesOrder.cs
@@ -13,6 +13,7 @@ namespace BinanceUsdtTicker.Models
         public decimal Quantity { get; set; }
         public decimal Price { get; set; }
         public decimal Filled { get; set; }
+        public decimal FilledAmount => Price * Filled;
         public decimal Amount => Price * Quantity;
         public string Status { get; set; } = string.Empty;
         public DateTime Time { get; set; }

--- a/Models/FuturesTrade.cs
+++ b/Models/FuturesTrade.cs
@@ -11,6 +11,7 @@ namespace BinanceUsdtTicker.Models
         public string Side { get; set; } = string.Empty;
         public decimal Quantity { get; set; }
         public decimal Price { get; set; }
+        public decimal Amount => Price * Quantity;
         public decimal Fee { get; set; }
         public decimal RealizedPnl { get; set; }
         public DateTime Time { get; set; }


### PR DESCRIPTION
## Summary
- compute executed order value in USDT via new `FilledAmount`
- expose trade notional via `Amount`
- bind order and trade history grids to USDT sizes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5792a6d308333a83a29bf3feab284