### PR TITLE
Rename fee column header to tax in trade history

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1348,7 +1348,7 @@ StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}" TextAlignment="Center"/>
                                                                                 </DataTemplate>
                                                                         </DataGridTemplateColumn.CellTemplate>
                                                                         </DataGridTemplateColumn>
-                                                                        <DataGridTemplateColumn Header="Ücret" Width="80">
+                                                                        <DataGridTemplateColumn Header="Vergi" Width="80">
                                                                                 <DataGridTemplateColumn.CellTemplate>
                                                                                         <DataTemplate>
                                                                                                 <TextBlock Text="{Binding Fee, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>


### PR DESCRIPTION
## Summary
- Rename trade history fee column header from "Ücret" to "Vergi"

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures invalid, 403)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ccdec8008333b833cf22978cf88f