### PR TITLE
Handle nullable return for user decimal converter

### DIFF
--- a/Converters/UserDecimalConverter.cs
+++ b/Converters/UserDecimalConverter.cs
@@ -11,14 +11,14 @@ namespace BinanceUsdtTicker
     /// </summary>
     public class UserDecimalConverter : IValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (value is decimal d)
                 return d.ToString("0.####################", CultureInfo.CurrentCulture);
             return string.Empty;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public object? ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var s = value?.ToString();
             if (string.IsNullOrWhiteSpace(s))


### PR DESCRIPTION
## Summary
- allow UserDecimalConverter methods to return nullable objects, avoiding CS8603 warnings

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ce16643083338fbd3820467d7051