### PR TITLE
Add generic symbol precision model using Binance exchange data

### DIFF
--- a/Models/SymbolPrecision.cs
+++ b/Models/SymbolPrecision.cs
@@ -1,0 +1,9 @@
+namespace BinanceUsdtTicker;
+
+/// <summary>
+/// Holds precision information for a trading symbol derived from Binance exchange data.
+/// </summary>
+public sealed record SymbolPrecision(
+    decimal TickSize,
+    decimal StepSize,
+    decimal MinNotional);

--- a/Tests/PrecisionHelperTests.cs
+++ b/Tests/PrecisionHelperTests.cs
@@ -13,7 +13,7 @@ public class PrecisionHelperTests
     public async Task QuantizePrice_RoundsDown()
     {
         var api = CreateApi();
-        var (_, _, _, price, _) = await api.ApplyOrderPrecisionAsync("BTCUSDT", 57432.1234m, 1m);
+        var (_, price, _) = await api.ApplyOrderPrecisionAsync("BTCUSDT", 57432.1234m, 1m);
         Assert.Equal(57432.1m, price);
     }
 
@@ -48,8 +48,8 @@ public class PrecisionHelperTests
     {
         var api = new BinanceApiService(new HttpClient());
         var field = typeof(BinanceApiService).GetField("_symbolFilters", BindingFlags.NonPublic | BindingFlags.Instance);
-        var dict = (Dictionary<string, (decimal, decimal, decimal)>)field!.GetValue(api)!;
-        dict["BTCUSDT"] = (0.1m, 0.001m, 5m);
+        var dict = (Dictionary<string, SymbolPrecision>)field!.GetValue(api)!;
+        dict["BTCUSDT"] = new SymbolPrecision(0.1m, 0.001m, 5m);
         return api;
     }
 }


### PR DESCRIPTION
## Summary
- Introduce `SymbolPrecision` record to capture tick, lot, and notional filters per symbol
- Use `SymbolPrecision` in `BinanceApiService` for cached precision data and order quantization
- Update tests to use the new precision model

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d0ccdaa08333b336531b4a7ccddb