### PR TITLE
Handle comma decimal input for limit price

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1474,16 +1474,9 @@ namespace BinanceUsdtTicker
             if (sender is not TextBox tb)
                 return;
 
-            var digitsOnly = new string(tb.Text.Where(c => char.IsDigit(c) || c == '.').ToArray());
-            if (string.IsNullOrWhiteSpace(digitsOnly))
+            if (Helpers.InputParser.TryParseUserDecimal(tb.Text, out var price) && price > 0m)
             {
-                tb.Text = string.Empty;
-                return;
-            }
-
-            if (decimal.TryParse(digitsOnly, NumberStyles.Float, CultureInfo.InvariantCulture, out var price))
-            {
-                tb.Text = price.ToString("0.00", CultureInfo.InvariantCulture);
+                tb.Text = price.ToString("0.########", CultureInfo.InvariantCulture);
             }
             else
             {


### PR DESCRIPTION
## Summary
- fix limit price TextBox parsing to accept commas and preserve precision

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d53b70988333911966f9e3da13fa