### PR TITLE
Fix price scaling for 1M instruments

### DIFF
--- a/Services/BinanceApiService.cs
+++ b/Services/BinanceApiService.cs
@@ -506,10 +506,7 @@ namespace BinanceUsdtTicker
             string? pStr = null;
             if (price.HasValue)
             {
-                var scaledPrice = symbol.StartsWith("1M", StringComparison.OrdinalIgnoreCase)
-                    ? price.Value * 1_000_000m
-                    : price.Value;
-                var p = r.TickSize > 0 ? QuantizeToTick(scaledPrice, r.TickSize) : scaledPrice;
+                var p = r.TickSize > 0 ? QuantizeToTick(price.Value, r.TickSize) : price.Value;
                 if (r.MinPrice is decimal minP && p < minP)
                     throw new InvalidOperationException($"Price {p} < minPrice {minP} for {symbol}.");
                 if (r.MaxPrice is decimal maxP && p > maxP)
@@ -520,10 +517,7 @@ namespace BinanceUsdtTicker
             string? spStr = null;
             if (stopPrice.HasValue)
             {
-                var scaledStopPrice = symbol.StartsWith("1M", StringComparison.OrdinalIgnoreCase)
-                    ? stopPrice.Value * 1_000_000m
-                    : stopPrice.Value;
-                var sp = r.TickSize > 0 ? QuantizeToTick(scaledStopPrice, r.TickSize) : scaledStopPrice;
+                var sp = r.TickSize > 0 ? QuantizeToTick(stopPrice.Value, r.TickSize) : stopPrice.Value;
                 spStr = ToInvariantString(sp);
             }
 
@@ -562,10 +556,7 @@ namespace BinanceUsdtTicker
             if (activationPrice.HasValue)
             {
                 var r = await GetSymbolRulesAsync(symbol);
-                var scaledActivationPrice = symbol.StartsWith("1M", StringComparison.OrdinalIgnoreCase)
-                    ? activationPrice.Value * 1_000_000m
-                    : activationPrice.Value;
-                var ap = r.TickSize > 0 ? QuantizeToTick(scaledActivationPrice, r.TickSize) : scaledActivationPrice;
+                var ap = r.TickSize > 0 ? QuantizeToTick(activationPrice.Value, r.TickSize) : activationPrice.Value;
                 parameters["activationPrice"] = ToInvariantString(ap);
             }
 


### PR DESCRIPTION
## Summary
- handle 1M-prefixed symbols without multiplying price values
- stop price and activation price now use raw values before tick quantization

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5dc954fc88333b87092a531606062