### PR TITLE
Fix min price parsing and add tests

### DIFF
--- a/Models/BinanceFuturesDtos.cs
+++ b/Models/BinanceFuturesDtos.cs
@@ -35,7 +35,9 @@ public sealed class SymbolInfo
                 case "PRICE_FILTER":
                     Filters.Add(new PriceFilter
                     {
-                        TickSize = f.TryGetDecimal("tickSize")
+                        TickSize = f.TryGetDecimal("tickSize"),
+                        MinPrice = f.TryGetDecimalOrNull("minPrice"),
+                        MaxPrice = f.TryGetDecimalOrNull("maxPrice")
                     });
                     break;
                 case "LOT_SIZE":
@@ -67,6 +69,8 @@ public interface IFilter { }
 public sealed class PriceFilter : IFilter
 {
     public decimal TickSize { get; set; }
+    public decimal? MinPrice { get; set; }
+    public decimal? MaxPrice { get; set; }
 }
 public sealed class LotSizeFilter : IFilter
 {
@@ -132,5 +136,12 @@ internal static class JsonExt
         if (!el.TryGetProperty(prop, out var p)) return 0m;
         var s = p.GetString();
         return string.IsNullOrWhiteSpace(s) ? 0m : decimal.Parse(s, NumberStyles.Float, CultureInfo.InvariantCulture);
+    }
+
+    public static decimal? TryGetDecimalOrNull(this JsonElement el, string prop)
+    {
+        if (!el.TryGetProperty(prop, out var p)) return null;
+        var s = p.GetString();
+        return string.IsNullOrWhiteSpace(s) ? null : decimal.Parse(s, NumberStyles.Float, CultureInfo.InvariantCulture);
     }
 }

--- a/Tests/BinanceApiServiceTests.cs
+++ b/Tests/BinanceApiServiceTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Reflection;
+using Xunit;
+
+namespace BinanceUsdtTicker.Tests;
+
+public class BinanceApiServiceTests
+{
+    private class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _response;
+        public StubHttpMessageHandler(string response) => _response = response;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var message = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_response)
+            };
+            return Task.FromResult(message);
+        }
+    }
+
+    [Fact]
+    public async Task GetSymbolRulesAsync_ParsesMinPrice()
+    {
+        const string json = @"{\"symbols\":[{\"filters\":[
+            {\"filterType\":\"PRICE_FILTER\",\"minPrice\":\"0.0001\",\"maxPrice\":\"1000\",\"tickSize\":\"0.0001\"},
+            {\"filterType\":\"LOT_SIZE\",\"minQty\":\"1\",\"stepSize\":\"1\"},
+            {\"filterType\":\"MIN_NOTIONAL\",\"notional\":\"5\"}
+        ]}]}";
+
+        var client = new HttpClient(new StubHttpMessageHandler(json))
+        {
+            BaseAddress = new Uri("https://example.com")
+        };
+
+        var svc = new BinanceApiService(client);
+
+        var method = typeof(BinanceApiService).GetMethod("GetSymbolRulesAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+        var task = (Task)method!.Invoke(svc, new object[] { "DOGEUSDT", CancellationToken.None })!;
+        await task.ConfigureAwait(false);
+        var rules = task.GetType().GetProperty("Result")!.GetValue(task)!;
+        var minPriceProp = rules.GetType().GetProperty("MinPrice")!;
+        var minPrice = (decimal?)minPriceProp.GetValue(rules);
+
+        Assert.Equal(0.0001m, minPrice);
+    }
+}
+


### PR DESCRIPTION
## Summary
- parse min and max price from Binance exchange info filters
- expose parsed values for price filter and utilize typed deserialization in rule lookup
- add unit test covering min price extraction

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a39c52e483339500b2a563a932e7