### PR TITLE
Fix limit price input handling for decimals

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -681,7 +681,6 @@
                                                         <StackPanel Margin="4">
                                                                 <TextBlock Text="Price" Margin="0,0,0,4"/>
                                                                 <TextBox x:Name="LimitPriceTextBox" Margin="0,0,0,8" Height="40" FontSize="18" FontWeight="Bold"
-                                                                         PreviewTextInput="LimitPrice_PreviewTextInput"
                                                                          LostFocus="LimitPriceTextBox_LostFocus"/>
                                                                 <TextBlock Text="Size" Margin="0,0,0,4"/>
                                                                 <Slider x:Name="LimitSizeSlider" Minimum="0" Maximum="100" TickPlacement="BottomRight" Ticks="0,25,50,75,100" IsSnapToTickEnabled="False" ValueChanged="SizeSlider_ValueChanged"/>
@@ -1103,7 +1102,6 @@
                                                                                         <DataTemplate>
                                                                                                 <StackPanel Orientation="Horizontal">
                                                                                                         <TextBox Width="60" Margin="0,0,4,0"
-                                                                                                                 PreviewTextInput="LimitPrice_PreviewTextInput"
                                                                                                                  Text="{Binding CloseLimitPrice, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource UserDecimalConverter}}"/>
                                                                                                         <Button Content="Limit" Margin="0,0,4,0" Tag="{Binding}" Click="ClosePositionLimit_Click"/>
                                                                                                         <Button Content="Market" Tag="{Binding}" Click="ClosePositionMarket_Click"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1455,20 +1455,6 @@ namespace BinanceUsdtTicker
                 priceBox.Text = _selectedTicker.Price.ToString("0.########", CultureInfo.CurrentCulture);
         }
 
-        private void LimitPrice_PreviewTextInput(object sender, TextCompositionEventArgs e)
-        {
-            if (e.Text == ",")
-            {
-                if (sender is TextBox tb)
-                {
-                    int caret = tb.CaretIndex;
-                    tb.Text = tb.Text.Insert(caret, ".");
-                    tb.CaretIndex = caret + 1;
-                }
-                e.Handled = true;
-            }
-        }
-
         private void LimitPriceTextBox_LostFocus(object sender, RoutedEventArgs e)
         {
             if (sender is not TextBox tb)


### PR DESCRIPTION
## Summary
- Allow decimal entry in limit price boxes by removing custom PreviewTextInput filtering
- Rely on standard decimal parsing when text boxes lose focus

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b392c1ec8333b6432cf708bae271