### PR TITLE
Show used balance from open futures positions

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1470,6 +1470,13 @@ StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}" TextAlignment="Center"/>
                 </Style>
             </DataGridTextColumn.ElementStyle>
         </DataGridTextColumn>
+        <DataGridTextColumn Header="Kullanılan Bakiye" Width="110" Binding="{Binding Used, StringFormat={}{0:#,0.00}}">
+            <DataGridTextColumn.ElementStyle>
+                <Style TargetType="TextBlock">
+                    <Setter Property="TextAlignment" Value="Right"/>
+                </Style>
+            </DataGridTextColumn.ElementStyle>
+        </DataGridTextColumn>
     </DataGrid.Columns>
 </DataGrid>
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -466,6 +466,7 @@ namespace BinanceUsdtTicker
                 LoadWalletAsync(),
                 LoadOpenPositionsAsync(),
                 LoadOpenOrdersAsync());
+            UpdateUsedBalance();
         }
 
         private async void RefreshTimer_Tick(object? sender, EventArgs e)
@@ -1777,6 +1778,15 @@ namespace BinanceUsdtTicker
                 LoadOpenOrdersAsync(),
                 LoadOrderHistoryAsync(),
                 LoadTradeHistoryAsync());
+            UpdateUsedBalance();
+        }
+
+        private void UpdateUsedBalance()
+        {
+            var total = _positions.Sum(p => p.EntryAmount);
+            var usdt = _walletAssets.FirstOrDefault(a => a.Asset.Equals("USDT", StringComparison.OrdinalIgnoreCase));
+            if (usdt != null)
+                usdt.Used = total;
         }
 
     }

--- a/Models/WalletAsset.cs
+++ b/Models/WalletAsset.cs
@@ -23,5 +23,12 @@ namespace BinanceUsdtTicker.Models
             set { if (_available != value) { _available = value; OnPropertyChanged(); } }
         }
 
+        private decimal _used;
+        public decimal Used
+        {
+            get => _used;
+            set { if (_used != value) { _used = value; OnPropertyChanged(); } }
+        }
+
     }
 }


### PR DESCRIPTION
## Summary
- Add `Used` property to wallet assets and show it in the wallet grid
- Compute total entry amounts of open positions and update wallet's used balance

## Testing
- ⚠️ `dotnet test` *(dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b8ed78008333974ae492565136d2