### PR TITLE
Adjust limit input and button heights

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1101,10 +1101,10 @@
                                                                                 <DataGridTemplateColumn.CellTemplate>
                                                                                         <DataTemplate>
                                                                                                 <StackPanel Orientation="Horizontal">
-                                                                                                        <TextBox Width="60" Margin="0,0,4,0"
+                                                                                                        <TextBox Width="80" Height="24" Margin="0,0,4,0"
                                                                                                                  Text="{Binding CloseLimitPrice, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource UserDecimalConverter}}"/>
-                                                                                                        <Button Content="Limit" Margin="0,0,4,0" Tag="{Binding}" Click="ClosePositionLimit_Click"/>
-                                                                                                        <Button Content="Market" Tag="{Binding}" Click="ClosePositionMarket_Click"/>
+                                                                                                        <Button Content="Limit" Height="24" Margin="0,0,4,0" Tag="{Binding}" Click="ClosePositionLimit_Click"/>
+                                                                                                        <Button Content="Market" Height="24" Tag="{Binding}" Click="ClosePositionMarket_Click"/>
                                                                                                 </StackPanel>
                                                                                         </DataTemplate>
                                                                                 </DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
## Summary
- Enlarge limit price input field for easier editing and reduce its height
- Reduce height of Limit and Market buttons for a more compact layout

## Testing
- `dotnet test` *(failed: command not found)*
- `apt-get update` *(failed: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b9e0de688333a6222c059a0e1d0e