### PR TITLE
Preserve used balance during wallet reload

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -401,9 +401,24 @@ namespace BinanceUsdtTicker
             try
             {
                 var balances = await _api.GetAccountBalancesAsync();
-                _walletAssets.Clear();
-                foreach (var b in balances)
-                    _walletAssets.Add(b);
+                var map = balances.ToDictionary(b => b.Asset);
+                for (int i = _walletAssets.Count - 1; i >= 0; i--)
+                {
+                    var existing = _walletAssets[i];
+                    if (map.TryGetValue(existing.Asset, out var b))
+                    {
+                        existing.Balance = b.Balance;
+                        existing.Available = b.Available;
+                        map.Remove(existing.Asset);
+                    }
+                    else
+                    {
+                        _walletAssets.RemoveAt(i);
+                    }
+                }
+
+                foreach (var remaining in map.Values)
+                    _walletAssets.Add(remaining);
                 UpdateCostAndMax();
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- avoid resetting wallet `Used` balance by updating existing assets instead of clearing them

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ba7e2a088333b9c941d0393deb9f