### PR TITLE
Reduce font size for position close buttons

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1103,8 +1103,8 @@
                                                                                                 <StackPanel Orientation="Horizontal">
                                                                                                         <TextBox Width="80" Height="24" Margin="0,0,4,0"
                                                                                                                  Text="{Binding CloseLimitPrice, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource UserDecimalConverter}}"/>
-                                                                                                        <Button Content="Limit" Height="24" Margin="0,0,4,0" Tag="{Binding}" Click="ClosePositionLimit_Click"/>
-                                                                                                        <Button Content="Market" Height="24" Tag="{Binding}" Click="ClosePositionMarket_Click"/>
+                                                                                                          <Button Content="Limit" Height="24" Margin="0,0,4,0" FontSize="10" Tag="{Binding}" Click="ClosePositionLimit_Click"/>
+                                                                                                          <Button Content="Market" Height="24" FontSize="10" Tag="{Binding}" Click="ClosePositionMarket_Click"/>
                                                                                                 </StackPanel>
                                                                                         </DataTemplate>
                                                                                 </DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
## Summary
- shrink Limit and Market buttons in the Açık Pozisyonlar tab by setting explicit smaller font size

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bb35a1848333ae566ecc561d1967