### PR TITLE
Improve toolbar buttons and prevent text truncation

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -338,7 +338,7 @@
                                 <Separator DockPanel.Dock="Right"/>
                                 <Button x:Name="SettingsButton" ToolBar.OverflowMode="Never"
                                         DockPanel.Dock="Right" Style="{StaticResource ToolbarButtonStyle}"
-                                        FontSize="16" Width="90" Click="SettingsButton_Click">
+                                        FontSize="16" Click="SettingsButton_Click">
                                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                                                 <TextBlock Text="⚙" Margin="0,0,4,0"/>
                                                 <TextBlock Text="Ayarlar" FontWeight="Bold"/>
@@ -614,15 +614,15 @@
 
                                         <!-- Hacim -->
                                         <DataGridTextColumn x:Name="ColVol" Header="Hacim"
-                                        Width="1*" MinWidth="100"
+                                        Width="Auto" MinWidth="120"
                                         Binding="{Binding Volume, StringFormat={}{0:#,0.##}}">
-						<DataGridTextColumn.ElementStyle>
-							<Style TargetType="TextBlock">
-								<Setter Property="TextAlignment" Value="Right"/>
-								<Setter Property="TextTrimming" Value="CharacterEllipsis"/>
-							</Style>
-						</DataGridTextColumn.ElementStyle>
-					</DataGridTextColumn>
+                                                <DataGridTextColumn.ElementStyle>
+                                                        <Style TargetType="TextBlock">
+                                                                <Setter Property="TextAlignment" Value="Right"/>
+                                                                <Setter Property="TextWrapping" Value="Wrap"/>
+                                                        </Style>
+                                                </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
 
 					<!-- Son -->
 					<DataGridTextColumn x:Name="ColLast" Header="Son"
@@ -1429,10 +1429,10 @@ StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}" TextAlignment="Center"/>
             </DataGridTemplateColumn.CellTemplate>
         </DataGridTemplateColumn>
         <DataGridTextColumn Header="Koşul" Width="160" Binding="{Binding TypeText}"/>
-        <DataGridTemplateColumn Header="Mesaj" Width="*">
+        <DataGridTemplateColumn Header="Mesaj" Width="*" MinWidth="200">
             <DataGridTemplateColumn.CellTemplate>
                 <DataTemplate>
-                    <TextBlock Text="{Binding Message}" TextTrimming="CharacterEllipsis" ToolTip="{Binding Message}"/>
+                    <TextBlock Text="{Binding Message}" TextWrapping="Wrap"/>
                 </DataTemplate>
             </DataGridTemplateColumn.CellTemplate>
         </DataGridTemplateColumn>

--- a/Themes/Styles.Toolbar.xaml
+++ b/Themes/Styles.Toolbar.xaml
@@ -4,10 +4,10 @@
 
 	<!-- Softer, more readable toolbar controls -->
 	<!-- Tuning knobs -->
-        <CornerRadius x:Key="TbRadius">5</CornerRadius>
-	<!-- daha yuvarlak -->
-        <Thickness    x:Key="TbPad">10,8</Thickness>
-	<!-- daha geniş iç boşluk -->
+        <CornerRadius x:Key="TbRadius">12</CornerRadius>
+        <!-- daha yuvarlak -->
+        <Thickness    x:Key="TbPad">12,8</Thickness>
+        <!-- daha geniş iç boşluk -->
 	<sys:Double   x:Key="TbFontSize">13</sys:Double>
 	<FontWeight   x:Key="TbFontWeight">SemiBold</FontWeight>
 


### PR DESCRIPTION
## Summary
- let the settings toolbar button size to its content
- widen and wrap volume cells to avoid truncation
- allow alert messages to wrap instead of ellipsis
- round toolbar buttons with larger padding for clearer text

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6be40ba888333891d5915d2e55e08