### PR TITLE
Improve close button text visibility

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1103,17 +1103,15 @@
                                                                                                 <StackPanel Orientation="Horizontal">
                                                                                                         <TextBox Width="80" Height="24" Margin="0,0,4,0"
                                                                                                                  Text="{Binding CloseLimitPrice, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource UserDecimalConverter}}"/>
-                                                                                                         <Button Width="60" Height="24" Margin="0,0,4,0" Tag="{Binding}" Click="ClosePositionLimit_Click">
-                                                                                                                 <TextBlock Text="Limit" FontSize="10" TextWrapping="Wrap" TextAlignment="Center"/>
-                                                                                                         </Button>
-                                                                                                         <Button Width="60" Height="24" Tag="{Binding}" Click="ClosePositionMarket_Click">
-                                                                                                                 <TextBlock Text="Market" FontSize="10" TextWrapping="Wrap" TextAlignment="Center"/>
-                                                                                                         </Button>
+                                                                                                        <Button Width="60" Height="24" Margin="0,0,4,0" Padding="4" Tag="{Binding}" Click="ClosePositionLimit_Click"
+                                                                                                                Foreground="{DynamicResource OnSurface}" FontSize="12" FontWeight="SemiBold" Content="Limit"/>
+                                                                                                         <Button Width="60" Height="24" Padding="4" Tag="{Binding}" Click="ClosePositionMarket_Click"
+                                                                                                                Foreground="{DynamicResource OnSurface}" FontSize="12" FontWeight="SemiBold" Content="Market"/>
                                                                                                 </StackPanel>
-                                                                                        </DataTemplate>
-                                                                                </DataGridTemplateColumn.CellTemplate>
-                                                                        </DataGridTemplateColumn>
-                                                                </DataGrid.Columns>
+                                                                                       </DataTemplate>
+                                                                               </DataGridTemplateColumn.CellTemplate>
+                                                                       </DataGridTemplateColumn>
+                                                               </DataGrid.Columns>
                                                         </DataGrid>
                                                 </TabItem>
                                                 <TabItem Header="Açık Emirler">


### PR DESCRIPTION
## Summary
- refine close position buttons to show clear "Limit" and "Market" labels

## Testing
- `dotnet test` *(fails: command not found; package installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bf55c4a88333bf58acc3d7707330