### PR TITLE
Display trade fees as negative

### DIFF
--- a/Converters/NegativeValueConverter.cs
+++ b/Converters/NegativeValueConverter.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace BinanceUsdtTicker
+{
+    /// <summary>
+    /// Multiplies numeric values by -1 to ensure negative display.
+    /// </summary>
+    public class NegativeValueConverter : IValueConverter
+    {
+        public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+                return null;
+            try
+            {
+                var dec = System.Convert.ToDecimal(value, CultureInfo.InvariantCulture);
+                return dec * -1;
+            }
+            catch
+            {
+                return value;
+            }
+        }
+
+        public object? ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+                return null;
+            try
+            {
+                var dec = System.Convert.ToDecimal(value, CultureInfo.InvariantCulture);
+                return dec * -1;
+            }
+            catch
+            {
+                return value;
+            }
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -15,6 +15,7 @@
                 <local:SideToBrushConverter x:Key="SideToBrush"/>
                 <local:SourceToLogoConverter x:Key="SourceToLogo"/>
                 <local:UserDecimalConverter x:Key="UserDecimalConverter"/>
+                <local:NegativeValueConverter x:Key="NegativeValueConverter"/>
                 <!-- Şeffaf yıldız -->
                 <Style x:Key="StarToggleStyle" TargetType="ToggleButton">
 			<Setter Property="OverridesDefaultStyle" Value="True"/>
@@ -1352,7 +1353,7 @@ StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}" TextAlignment="Center"/>
                                                                         <DataGridTemplateColumn Header="Vergi" Width="80">
                                                                                 <DataGridTemplateColumn.CellTemplate>
                                                                                         <DataTemplate>
-                                                                                                <TextBlock Text="{Binding Fee, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
+                                                                                                <TextBlock Text="{Binding Fee, Converter={StaticResource NegativeValueConverter}, StringFormat={}{0:#,0.####}}" TextAlignment="Right"/>
                                                                                         </DataTemplate>
                                                                                 </DataGridTemplateColumn.CellTemplate>
                                                                         </DataGridTemplateColumn>

--- a/Tests/NegativeValueConverterTests.cs
+++ b/Tests/NegativeValueConverterTests.cs
@@ -1,0 +1,28 @@
+using System.Globalization;
+using BinanceUsdtTicker;
+using Xunit;
+
+public class NegativeValueConverterTests
+{
+    [Theory]
+    [InlineData(1, -1)]
+    [InlineData(-2.5, -2.5)]
+    [InlineData(0, 0)]
+    public void Convert_ReturnsNegative(decimal input, decimal expected)
+    {
+        var conv = new NegativeValueConverter();
+        var result = conv.Convert(input, typeof(decimal), null, CultureInfo.InvariantCulture);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(1, -1)]
+    [InlineData(-2.5, -2.5)]
+    [InlineData(0, 0)]
+    public void ConvertBack_ReturnsNegative(decimal input, decimal expected)
+    {
+        var conv = new NegativeValueConverter();
+        var result = conv.ConvertBack(input, typeof(decimal), null, CultureInfo.InvariantCulture);
+        Assert.Equal(expected, result);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure Vergi (fee) column shows negative values in trade history
- add NegativeValueConverter and accompanying tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d197403c833390e44e98bbad8341