### PR TITLE
Store secrets encrypted and load to RAM cache

### DIFF
--- a/Data/SecretRepository.cs
+++ b/Data/SecretRepository.cs
@@ -1,0 +1,41 @@
+using Microsoft.Data.SqlClient;
+
+namespace BinanceUsdtTicker.Data
+{
+    /// <summary>
+    /// Repository for reading and writing encrypted secrets stored in the database.
+    /// </summary>
+    public class SecretRepository
+    {
+        private readonly string _cs;
+        public SecretRepository(string connectionString) => _cs = connectionString;
+
+        public virtual async Task UpsertAsync(string name, byte[] valueEnc, CancellationToken ct = default)
+        {
+            await using var conn = new SqlConnection(_cs);
+            await conn.OpenAsync(ct);
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = @"MERGE dbo.Secrets WITH (HOLDLOCK) AS t
+USING (VALUES (@n, @v)) AS s(Name, ValueEnc)
+   ON t.Name = s.Name
+WHEN MATCHED THEN UPDATE SET ValueEnc = s.ValueEnc, UpdatedAt = SYSUTCDATETIME(), Version = Version + 1
+WHEN NOT MATCHED THEN INSERT(Name, ValueEnc) VALUES(s.Name, s.ValueEnc);";
+            cmd.Parameters.AddWithValue("@n", name);
+            cmd.Parameters.AddWithValue("@v", valueEnc);
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+
+        public virtual async Task<Dictionary<string, byte[]>> GetAllAsync(CancellationToken ct = default)
+        {
+            var result = new Dictionary<string, byte[]>(StringComparer.OrdinalIgnoreCase);
+            await using var conn = new SqlConnection(_cs);
+            await conn.OpenAsync(ct);
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT Name, ValueEnc FROM dbo.Secrets";
+            await using var r = await cmd.ExecuteReaderAsync(ct);
+            while (await r.ReadAsync(ct))
+                result[r.GetString(0)] = (byte[])r.GetValue(1);
+            return result;
+        }
+    }
+}

--- a/ListingWatcherService/Program.cs
+++ b/ListingWatcherService/Program.cs
@@ -3,11 +3,16 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ListingWatcher;
+using BinanceUsdtTicker.Data;
+using BinanceUsdtTicker.Runtime;
 
 var builder = Host.CreateDefaultBuilder(args)
-    .ConfigureServices(services =>
+    .ConfigureServices((ctx, services) =>
     {
         services.AddSingleton<ISymbolExtractor, RegexSymbolExtractor>();
+        services.AddSingleton<ISecretCache, SecretCache>();
+        services.AddSingleton(sp => new SecretRepository(ctx.Configuration.GetConnectionString("Listings")!));
+        services.AddHostedService<SecretBootstrapper>();
         services.AddHostedService<ListingWatcherService>();
     })
     .ConfigureLogging(logging =>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -20,6 +20,8 @@ using System.Windows.Threading; // en üstte varsa gerekmez
 using WinForms = System.Windows.Forms;
 using BinanceUsdtTicker.Models;
 using Microsoft.Data.SqlClient;
+using BinanceUsdtTicker.Data;
+using BinanceUsdtTicker.Runtime;
 
 namespace BinanceUsdtTicker
 {
@@ -58,6 +60,8 @@ namespace BinanceUsdtTicker
 
         private UiSettings _ui = new();
         private ThemeKind _theme = ThemeKind.Light;
+
+        private readonly ISecretCache _secretCache = new SecretCache();
 
         private WinForms.NotifyIcon? _notifyIcon;
 
@@ -354,11 +358,11 @@ namespace BinanceUsdtTicker
 
         private async void SettingsButton_Click(object sender, RoutedEventArgs e)
         {
-            var win = new SettingsWindow(_ui) { Owner = this };
+            var repo = new SecretRepository(_ui.GetConnectionString());
+            var win = new SettingsWindow(_ui, repo, _secretCache) { Owner = this };
             if (win.ShowDialog() == true)
             {
                 ApplyCustomColors();
-                _api.SetApiCredentials(_ui.BinanceApiKey, _ui.BinanceApiSecret);
                 SaveUiSettingsFromUi();
                 if (Application.Current is App app)
                 {

--- a/Runtime/SecretBootstrapper.cs
+++ b/Runtime/SecretBootstrapper.cs
@@ -1,0 +1,40 @@
+using BinanceUsdtTicker.Data;
+using BinanceUsdtTicker.Security;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace BinanceUsdtTicker.Runtime
+{
+    /// <summary>
+    /// Loads encrypted secrets from the database on startup and stores them in memory cache.
+    /// </summary>
+    public sealed class SecretBootstrapper : IHostedService
+    {
+        private readonly ILogger<SecretBootstrapper> _log;
+        private readonly SecretRepository _repo;
+        private readonly ISecretCache _cache;
+
+        public SecretBootstrapper(ILogger<SecretBootstrapper> log, SecretRepository repo, ISecretCache cache)
+        {
+            _log = log;
+            _repo = repo;
+            _cache = cache;
+        }
+
+        public async Task StartAsync(CancellationToken ct)
+        {
+            var enc = await _repo.GetAllAsync(ct);
+            int count = 0;
+            foreach (var (name, valueEnc) in enc)
+            {
+                var plainBytes = DpapiProtector.Unprotect(valueEnc);
+                var value = System.Text.Encoding.UTF8.GetString(plainBytes);
+                _cache.Set(name, value);
+                count++;
+            }
+            _log.LogInformation("Secrets loaded to RAM: {Count}", count);
+        }
+
+        public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+    }
+}

--- a/Runtime/SecretCache.cs
+++ b/Runtime/SecretCache.cs
@@ -1,0 +1,25 @@
+using System.Collections.Concurrent;
+
+namespace BinanceUsdtTicker.Runtime
+{
+    public interface ISecretCache
+    {
+        string Get(string name);
+        void Set(string name, string value);
+    }
+
+    /// <summary>
+    /// In-memory thread safe cache for secrets.
+    /// </summary>
+    public sealed class SecretCache : ISecretCache
+    {
+        private readonly ConcurrentDictionary<string, string> _secrets = new(StringComparer.OrdinalIgnoreCase);
+
+        public string Get(string name) => _secrets[name];
+
+        public void Set(string name, string value)
+        {
+            _secrets[name] = value;
+        }
+    }
+}

--- a/Security/DpapiProtector.cs
+++ b/Security/DpapiProtector.cs
@@ -1,0 +1,21 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace BinanceUsdtTicker.Security
+{
+    /// <summary>
+    /// Helper for encrypting and decrypting values using Windows DPAPI.
+    /// </summary>
+    public static class DpapiProtector
+    {
+        // Application specific additional entropy. Even if leaked, it is
+        // useless without the DPAPI keys that are bound to the machine.
+        private static readonly byte[] Entropy = Encoding.UTF8.GetBytes("BinanceUsdtTicker.v1:7A4E2E7C-9A7D-4C2A-A4B1-5C3D1E9F");
+
+        public static byte[] Protect(ReadOnlySpan<byte> plain)
+            => ProtectedData.Protect(plain.ToArray(), Entropy, DataProtectionScope.LocalMachine);
+
+        public static byte[] Unprotect(ReadOnlySpan<byte> enc)
+            => ProtectedData.Unprotect(enc.ToArray(), Entropy, DataProtectionScope.LocalMachine);
+    }
+}

--- a/Security/SecretNames.cs
+++ b/Security/SecretNames.cs
@@ -1,0 +1,13 @@
+namespace BinanceUsdtTicker.Security
+{
+    /// <summary>
+    /// Well known secret names stored in the secret repository.
+    /// </summary>
+    public static class SecretNames
+    {
+        public const string BinanceApiKey = "BinanceApiKey";
+        public const string BinanceSecret = "BinanceSecret";
+        public const string AzureKey = "AzureKey";
+        public const string DbPassword = "DbPassword";
+    }
+}

--- a/Tests/DpapiProtectorTests.cs
+++ b/Tests/DpapiProtectorTests.cs
@@ -1,0 +1,18 @@
+using System.Text;
+using BinanceUsdtTicker.Security;
+using Xunit;
+
+namespace BinanceUsdtTicker.Tests
+{
+    public class DpapiProtectorTests
+    {
+        [Fact]
+        public void ProtectUnprotect_Roundtrip()
+        {
+            var original = "secret-value";
+            var enc = DpapiProtector.Protect(Encoding.UTF8.GetBytes(original));
+            var dec = Encoding.UTF8.GetString(DpapiProtector.Unprotect(enc));
+            Assert.Equal(original, dec);
+        }
+    }
+}

--- a/Tests/SecretBootstrapperTests.cs
+++ b/Tests/SecretBootstrapperTests.cs
@@ -1,0 +1,38 @@
+using BinanceUsdtTicker.Data;
+using BinanceUsdtTicker.Runtime;
+using BinanceUsdtTicker.Security;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace BinanceUsdtTicker.Tests
+{
+    public class SecretBootstrapperTests
+    {
+        private sealed class FakeRepo : SecretRepository
+        {
+            private readonly Dictionary<string, byte[]> _data;
+            public FakeRepo(Dictionary<string, byte[]> data) : base(string.Empty)
+            {
+                _data = data;
+            }
+            public override Task<Dictionary<string, byte[]>> GetAllAsync(CancellationToken ct = default)
+            {
+                return Task.FromResult(new Dictionary<string, byte[]>(_data));
+            }
+        }
+
+        [Fact]
+        public async Task LoadsSecretsIntoCache()
+        {
+            var encValue = DpapiProtector.Protect(Encoding.UTF8.GetBytes("abc"));
+            var repo = new FakeRepo(new Dictionary<string, byte[]> { { "k", encValue } });
+            var cache = new SecretCache();
+            var bootstrapper = new SecretBootstrapper(NullLogger<SecretBootstrapper>.Instance, repo, cache);
+            await bootstrapper.StartAsync(default);
+            Assert.Equal("abc", cache.Get("k"));
+        }
+    }
+}

--- a/Tests/SecretRepositoryTests.cs
+++ b/Tests/SecretRepositoryTests.cs
@@ -1,0 +1,18 @@
+using BinanceUsdtTicker.Data;
+using Xunit;
+using System.Threading.Tasks;
+
+namespace BinanceUsdtTicker.Tests
+{
+    public class SecretRepositoryTests
+    {
+        [Fact(Skip="Requires SQL Server instance")] 
+        public async Task UpsertAndGetAll_Roundtrip()
+        {
+            var repo = new SecretRepository("Server=.;Database=Secrets;Integrated Security=True;");
+            await repo.UpsertAsync("name", new byte[] { 1 });
+            var all = await repo.GetAllAsync();
+            Assert.True(all.ContainsKey("name"));
+        }
+    }
+}

--- a/Windows/ChangeSecretWindow.xaml
+++ b/Windows/ChangeSecretWindow.xaml
@@ -1,0 +1,22 @@
+<Window x:Class="BinanceUsdtTicker.ChangeSecretWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Secret" Height="180" Width="300"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <StackPanel Grid.Row="0" Margin="0,0,0,10">
+            <PasswordBox x:Name="NewValue" Margin="0,0,0,5"/>
+            <PasswordBox x:Name="ConfirmValue"/>
+        </StackPanel>
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="OK" Width="70" Margin="0,0,5,0" Click="Ok_Click"/>
+            <Button Content="Cancel" Width="70" Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Windows/ChangeSecretWindow.xaml.cs
+++ b/Windows/ChangeSecretWindow.xaml.cs
@@ -1,0 +1,28 @@
+using System.Windows;
+
+namespace BinanceUsdtTicker
+{
+    public partial class ChangeSecretWindow : Window
+    {
+        public string? SecretValue { get; private set; }
+
+        public ChangeSecretWindow(string caption)
+        {
+            InitializeComponent();
+            Title = caption;
+        }
+
+        private void Ok_Click(object sender, RoutedEventArgs e)
+        {
+            if (NewValue.Password != ConfirmValue.Password)
+            {
+                MessageBox.Show("Values do not match", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+            SecretValue = NewValue.Password;
+            DialogResult = true;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e) => DialogResult = false;
+    }
+}

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -107,7 +107,8 @@
                     </StackPanel>
                                         <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
                                                 <TextBlock Text="Translate Key:" Width="120" VerticalAlignment="Center"/>
-                                                <TextBox Text="{Binding TranslateKey}" Width="300"/>
+                                                <TextBox Width="180" IsReadOnly="True" Text="********"/>
+                                                <Button Content="Değiştir" Width="75" Margin="10,0,0,0" Click="ChangeTranslateKey_Click"/>
                                         </StackPanel>
                                         <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
                                                 <TextBlock Text="Translate Region:" Width="120" VerticalAlignment="Center"/>
@@ -127,7 +128,8 @@
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
                         <TextBlock Text="DB Password:" Width="120" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding DbPassword}" Width="300"/>
+                        <TextBox Width="180" IsReadOnly="True" Text="********"/>
+                        <Button Content="Değiştir" Width="75" Margin="10,0,0,0" Click="ChangeDbPassword_Click"/>
                     </StackPanel>
                 </StackPanel>
             </TabItem>
@@ -148,11 +150,13 @@
                 <StackPanel Margin="10">
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
                         <TextBlock Text="Binance API Key:" Width="120" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding BinanceApiKey}" Width="300" MaxLength="64"/>
+                        <TextBox Width="180" IsReadOnly="True" Text="********" MaxLength="64"/>
+                        <Button Content="Değiştir" Width="75" Margin="10,0,0,0" Click="ChangeBinanceApiKey_Click"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
                         <TextBlock Text="Binance Secret Key:" Width="120" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding BinanceApiSecret}" Width="300" MaxLength="64"/>
+                        <TextBox Width="180" IsReadOnly="True" Text="********" MaxLength="64"/>
+                        <Button Content="Değiştir" Width="75" Margin="10,0,0,0" Click="ChangeBinanceSecret_Click"/>
                     </StackPanel>
                 </StackPanel>
             </TabItem>


### PR DESCRIPTION
## Summary
- Add DPAPI helper and secret name constants
- Implement SecretRepository and in-memory SecretCache with startup bootstrapper
- Mask secrets in settings UI with change dialog and wire into main app and service

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d3e8cedc8333bb72e226043052a6