### PR TITLE
Add missing system usings for secrets

### DIFF
--- a/Data/SecretRepository.cs
+++ b/Data/SecretRepository.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 
 namespace BinanceUsdtTicker.Data

--- a/Runtime/SecretBootstrapper.cs
+++ b/Runtime/SecretBootstrapper.cs
@@ -2,6 +2,8 @@ using BinanceUsdtTicker.Data;
 using BinanceUsdtTicker.Security;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace BinanceUsdtTicker.Runtime
 {

--- a/Security/DpapiProtector.cs
+++ b/Security/DpapiProtector.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Security.Cryptography;
 using System.Text;
 


### PR DESCRIPTION
## Summary
- add System usings for Task, CancellationToken, Dictionary and ReadOnlySpan
- wire bootstrapper and repository with System.Threading Tasks
- import System namespace for DPAPI helper

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: bash: command not found: dotnet)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d6bc4038833388fd40052ba82a7d