### PR TITLE
Add missing System namespace for StringComparer

### DIFF
--- a/Runtime/SecretCache.cs
+++ b/Runtime/SecretCache.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 
 namespace BinanceUsdtTicker.Runtime


### PR DESCRIPTION
## Summary
- fix compile error by importing `System` namespace in `SecretCache`

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c6e0e02e08833395a4bf252a1981b3