### PR TITLE
Include secret caching in ListingWatcherService

### DIFF
--- a/ListingWatcherService/ListingWatcherService.csproj
+++ b/ListingWatcherService/ListingWatcherService.csproj
@@ -16,6 +16,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Services\SymbolExtractor.cs" Link="SymbolExtractor.cs" />
+    <Compile Include="..\Data\SecretRepository.cs" Link="SecretRepository.cs" />
+    <Compile Include="..\Runtime\SecretCache.cs" Link="SecretCache.cs" />
+    <Compile Include="..\Runtime\SecretBootstrapper.cs" Link="SecretBootstrapper.cs" />
+    <Compile Include="..\Security\DpapiProtector.cs" Link="DpapiProtector.cs" />
+    <Compile Include="..\Security\SecretNames.cs" Link="SecretNames.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">


### PR DESCRIPTION
## Summary
- Include data, runtime, and security source files so ListingWatcherService can access encrypted secrets
- Inject ISecretCache and load Azure translator key from the cached secret repository at startup

## Testing
- ⚠️ `dotnet build ListingWatcherService/ListingWatcherService.csproj` (dotnet CLI not installed)
- ⚠️ `apt-get install -y dotnet-sdk-8.0` (package repository unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68c6e8fa4c848333a16e6113148e1aae