### PR TITLE
Use Microsoft.Data.SqlClient in ListingWatcherService

### DIFF
--- a/ListingWatcherService/ListingWatcherService.cs
+++ b/ListingWatcherService/ListingWatcherService.cs
@@ -13,7 +13,7 @@ using BinanceUsdtTicker;
 using BinanceUsdtTicker.Runtime;
 using BinanceUsdtTicker.Security;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Net.Http.Headers;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;


### PR DESCRIPTION
## Summary
- Fix build errors by switching to `Microsoft.Data.SqlClient`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6eaaf1798833390f9449188a981b5