### PR TITLE
Ensure Secrets table exists before queries

### DIFF
--- a/Data/SecretRepository.cs
+++ b/Data/SecretRepository.cs
@@ -18,6 +18,9 @@ namespace BinanceUsdtTicker.Data
         {
             await using var conn = new SqlConnection(_cs);
             await conn.OpenAsync(ct);
+
+            await EnsureTableAsync(conn, ct);
+
             var cmd = conn.CreateCommand();
             cmd.CommandText = @"MERGE dbo.Secrets WITH (HOLDLOCK) AS t
 USING (VALUES (@n, @v)) AS s(Name, ValueEnc)
@@ -34,12 +37,30 @@ WHEN NOT MATCHED THEN INSERT(Name, ValueEnc) VALUES(s.Name, s.ValueEnc);";
             var result = new Dictionary<string, byte[]>(StringComparer.OrdinalIgnoreCase);
             await using var conn = new SqlConnection(_cs);
             await conn.OpenAsync(ct);
+
+            await EnsureTableAsync(conn, ct);
+
             var cmd = conn.CreateCommand();
             cmd.CommandText = "SELECT Name, ValueEnc FROM dbo.Secrets";
             await using var r = await cmd.ExecuteReaderAsync(ct);
             while (await r.ReadAsync(ct))
                 result[r.GetString(0)] = (byte[])r.GetValue(1);
             return result;
+        }
+
+        private static async Task EnsureTableAsync(SqlConnection conn, CancellationToken ct)
+        {
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = @"IF OBJECT_ID(N'dbo.Secrets', N'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.Secrets (
+        Name NVARCHAR(450) NOT NULL PRIMARY KEY,
+        ValueEnc VARBINARY(MAX) NOT NULL,
+        UpdatedAt DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+        Version INT NOT NULL DEFAULT 1
+    );
+END";
+            await cmd.ExecuteNonQueryAsync(ct);
         }
     }
 }


### PR DESCRIPTION
## Summary
- create dbo.Secrets table on demand to avoid runtime failures

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f5d700488333a252eafd26142fad