### PR TITLE
Replace DevExpress Grid with WPF DataGrid

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -16,10 +16,6 @@
     <PackageReference Include="MaterialDesignThemes" Version="4.9.0" />
     <PackageReference Include="MaterialDesignColors" Version="2.1.4" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
-    <PackageReference Include="DevExpress.Wpf.Grid" Version="25.1.3" />
-    <PackageReference Include="DevExpress.Wpf.Editors" Version="25.1.3" />
-    <PackageReference Include="DevExpress.Mvvm" Version="25.1.3" />
-    <PackageReference Include="DevExpress.Data" Version="25.1.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ViewModels/Wallet/WalletViewModel.cs
+++ b/ViewModels/Wallet/WalletViewModel.cs
@@ -3,7 +3,6 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Threading;
-using DevExpress.Xpf.Grid;
 using BinanceUsdtTicker.Models;
 using BinanceUsdtTicker;
 
@@ -12,16 +11,11 @@ namespace BinanceUsdtTicker.ViewModels.Wallet
     public class WalletViewModel
     {
         public ObservableCollection<WalletRow> Items { get; } = new();
-        private readonly GridControl _grid;
-        private readonly DispatcherTimer _refresh = new() { Interval = TimeSpan.FromMilliseconds(150) };
         private readonly DispatcherTimer _timer = new();
         private readonly BinanceApiService _api = new();
 
-        public WalletViewModel(GridControl grid)
+        public WalletViewModel()
         {
-            _grid = grid;
-            _refresh.Tick += (s, e) => { _grid.RefreshData(); _refresh.Stop(); };
-
             var apiKey = Environment.GetEnvironmentVariable("BINANCE_API_KEY") ?? string.Empty;
             var secret = Environment.GetEnvironmentVariable("BINANCE_API_SECRET") ?? string.Empty;
             if (!string.IsNullOrEmpty(apiKey) && !string.IsNullOrEmpty(secret))
@@ -61,14 +55,11 @@ namespace BinanceUsdtTicker.ViewModels.Wallet
         public void ApplySnapshot(decimal balance, decimal available, decimal used)
         {
             var row = Items.FirstOrDefault() ?? new WalletRow { Asset = "USDT" };
-            _grid.BeginDataUpdate();
             row.Balance = balance;
             row.Available = available;
             row.Used = used;
             if (!Items.Any())
                 Items.Add(row);
-            _grid.EndDataUpdate();
-            _refresh.Start();
         }
     }
 }

--- a/Views/Wallet/WalletView.xaml
+++ b/Views/Wallet/WalletView.xaml
@@ -1,29 +1,15 @@
 <UserControl x:Class="BinanceUsdtTicker.Views.Wallet.WalletView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:dxg="http://schemas.devexpress.com/winfx/2008/xaml/grid"
-             xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors">
-    <dxg:GridControl x:Name="WalletGrid" ItemsSource="{Binding Items}" AutoGenerateColumns="None">
-        <dxg:GridControl.View>
-            <dxg:TableView AllowPerPixelScrolling="True" AllowEditing="False" NavigationStyle="Row"/>
-        </dxg:GridControl.View>
-        <dxg:GridControl.Columns>
-            <dxg:GridColumn FieldName="Asset" Header="Varlık" Width="120"/>
-            <dxg:GridColumn FieldName="Balance" Header="Bakiye" Width="140">
-                <dxg:GridColumn.EditSettings>
-                    <dxe:TextEditSettings DisplayFormatString="#,0.########" MaskUseAsDisplayFormat="True"/>
-                </dxg:GridColumn.EditSettings>
-            </dxg:GridColumn>
-            <dxg:GridColumn FieldName="Available" Header="Kullanılabilir" Width="160">
-                <dxg:GridColumn.EditSettings>
-                    <dxe:TextEditSettings DisplayFormatString="#,0.########" MaskUseAsDisplayFormat="True"/>
-                </dxg:GridColumn.EditSettings>
-            </dxg:GridColumn>
-            <dxg:GridColumn FieldName="Used" Header="Kullanılan Bakiye" Width="170">
-                <dxg:GridColumn.EditSettings>
-                    <dxe:TextEditSettings DisplayFormatString="#,0.########" MaskUseAsDisplayFormat="True"/>
-                </dxg:GridColumn.EditSettings>
-            </dxg:GridColumn>
-        </dxg:GridControl.Columns>
-    </dxg:GridControl>
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <DataGrid x:Name="WalletGrid"
+              ItemsSource="{Binding Items}"
+              AutoGenerateColumns="False"
+              IsReadOnly="True">
+        <DataGrid.Columns>
+            <DataGridTextColumn Binding="{Binding Asset}" Header="Varlık" Width="120"/>
+            <DataGridTextColumn Binding="{Binding Balance, StringFormat=#,0.########}" Header="Bakiye" Width="140"/>
+            <DataGridTextColumn Binding="{Binding Available, StringFormat=#,0.########}" Header="Kullanılabilir" Width="160"/>
+            <DataGridTextColumn Binding="{Binding Used, StringFormat=#,0.########}" Header="Kullanılan Bakiye" Width="170"/>
+        </DataGrid.Columns>
+    </DataGrid>
 </UserControl>

--- a/Views/Wallet/WalletView.xaml.cs
+++ b/Views/Wallet/WalletView.xaml.cs
@@ -8,7 +8,7 @@ namespace BinanceUsdtTicker.Views.Wallet
         public WalletView()
         {
             InitializeComponent();
-            DataContext = new WalletViewModel(WalletGrid);
+            DataContext = new WalletViewModel();
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove DevExpress packages and switch wallet view to built-in WPF `DataGrid`
- simplify wallet view model to update bound collection directly

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c7282d5a908333a4447b43db168309