### PR TITLE
Fix wallet balance display using saved API credentials

### DIFF
--- a/ViewModels/Wallet/WalletViewModel.cs
+++ b/ViewModels/Wallet/WalletViewModel.cs
@@ -14,12 +14,21 @@ namespace BinanceUsdtTicker.ViewModels.Wallet
         private readonly DispatcherTimer _timer = new();
         private readonly BinanceApiService _api = new();
 
-        public WalletViewModel()
+        public WalletViewModel(UiSettings? settings = null)
         {
-            var apiKey = Environment.GetEnvironmentVariable("BINANCE_API_KEY") ?? string.Empty;
-            var secret = Environment.GetEnvironmentVariable("BINANCE_API_SECRET") ?? string.Empty;
-            if (!string.IsNullOrEmpty(apiKey) && !string.IsNullOrEmpty(secret))
-                _api.SetApiCredentials(apiKey, secret);
+            if (settings != null &&
+                !string.IsNullOrEmpty(settings.BinanceApiKey) &&
+                !string.IsNullOrEmpty(settings.BinanceApiSecret))
+            {
+                _api.SetApiCredentials(settings.BinanceApiKey, settings.BinanceApiSecret);
+            }
+            else
+            {
+                var apiKey = Environment.GetEnvironmentVariable("BINANCE_API_KEY") ?? string.Empty;
+                var secret = Environment.GetEnvironmentVariable("BINANCE_API_SECRET") ?? string.Empty;
+                if (!string.IsNullOrEmpty(apiKey) && !string.IsNullOrEmpty(secret))
+                    _api.SetApiCredentials(apiKey, secret);
+            }
 
             _timer.Interval = TimeSpan.FromMilliseconds(1000);
             _timer.Tick += async (s, e) => await UpdateFromFuturesAsync();

--- a/Views/Wallet/WalletView.xaml.cs
+++ b/Views/Wallet/WalletView.xaml.cs
@@ -1,5 +1,7 @@
 using System.Windows.Controls;
 using BinanceUsdtTicker.ViewModels.Wallet;
+using BinanceUsdtTicker.Models;
+using BinanceUsdtTicker;
 
 namespace BinanceUsdtTicker.Views.Wallet
 {
@@ -8,7 +10,8 @@ namespace BinanceUsdtTicker.Views.Wallet
         public WalletView()
         {
             InitializeComponent();
-            DataContext = new WalletViewModel();
+            UiSettings settings = MainWindow.LoadDefaultUiSettings();
+            DataContext = new WalletViewModel(settings);
         }
     }
 }


### PR DESCRIPTION
## Summary
- pass saved Binance API credentials to WalletViewModel so it can load account balances
- allow WalletViewModel to fall back to environment variables if settings are missing

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c72cd9cb5483339aab7cdce8655abc