### PR TITLE
Replace DevExpress components with WPF controls

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -21,8 +21,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="DevExpress.Xpf.Core" Version="23.2.5" />
-    <PackageReference Include="DevExpress.Xpf.Grid" Version="23.2.5" />
   </ItemGroup>
 
   <!-- Prevent the worker service project from being compiled into the WPF application -->

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -5,8 +5,6 @@
         xmlns:local="clr-namespace:BinanceUsdtTicker"
         xmlns:wallet="clr-namespace:BinanceUsdtTicker.Views.Wallet"
         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-        xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
-        xmlns:dxg="http://schemas.devexpress.com/winfx/2008/xaml/grid"
         Title="Binance USDT Canlı Fiyatlar"
         Height="680" Width="1100" MinHeight="500" MinWidth="900"
         Background="{DynamicResource Surface}"
@@ -999,36 +997,20 @@
 
                                 <!-- EMIR VE POZISYONLAR -->
                                   <Expander Grid.Column="0" Header="Emirler" IsExpanded="True" Padding="6,4">
-                                        <dx:DXTabControl x:Name="AccountTab" Margin="0,6,0,0" SelectionChanged="AccountTab_SelectionChanged">
-                                                <dx:DXTabItem Header="Açık Pozisyonlar">
-                                                        <dxg:GridControl x:Name="PositionsList" AutoGenerateColumns="AddNew">
-                                                                <dxg:GridControl.View>
-                                                                        <dxg:TableView AutoWidth="True"/>
-                                                                </dxg:GridControl.View>
-                                                        </dxg:GridControl>
-                                                </dx:DXTabItem>
-                                                <dx:DXTabItem Header="Açık Emirler">
-                                                        <dxg:GridControl x:Name="OrdersList" AutoGenerateColumns="AddNew">
-                                                                <dxg:GridControl.View>
-                                                                        <dxg:TableView AutoWidth="True"/>
-                                                                </dxg:GridControl.View>
-                                                        </dxg:GridControl>
-                                                </dx:DXTabItem>
-                                                <dx:DXTabItem Header="Emir Geçmişi">
-                                                        <dxg:GridControl x:Name="OrderHistoryList" AutoGenerateColumns="AddNew">
-                                                                <dxg:GridControl.View>
-                                                                        <dxg:TableView AutoWidth="True"/>
-                                                                </dxg:GridControl.View>
-                                                        </dxg:GridControl>
-                                                </dx:DXTabItem>
-                                                <dx:DXTabItem Header="Trade Geçmişi">
-                                                        <dxg:GridControl x:Name="TradeHistoryList" AutoGenerateColumns="AddNew">
-                                                                <dxg:GridControl.View>
-                                                                        <dxg:TableView AutoWidth="True"/>
-                                                                </dxg:GridControl.View>
-                                                        </dxg:GridControl>
-                                                </dx:DXTabItem>
-                                        </dx:DXTabControl>
+                                        <TabControl x:Name="AccountTab" Margin="0,6,0,0" SelectionChanged="AccountTab_SelectionChanged">
+                                                <TabItem Header="Açık Pozisyonlar">
+                                                        <DataGrid x:Name="PositionsList" AutoGenerateColumns="True" IsReadOnly="True"/>
+                                                </TabItem>
+                                                <TabItem Header="Açık Emirler">
+                                                        <DataGrid x:Name="OrdersList" AutoGenerateColumns="True" IsReadOnly="True"/>
+                                                </TabItem>
+                                                <TabItem Header="Emir Geçmişi">
+                                                        <DataGrid x:Name="OrderHistoryList" AutoGenerateColumns="True" IsReadOnly="True"/>
+                                                </TabItem>
+                                                <TabItem Header="Trade Geçmişi">
+                                                        <DataGrid x:Name="TradeHistoryList" AutoGenerateColumns="True" IsReadOnly="True"/>
+                                                </TabItem>
+                                        </TabControl>
                                 </Expander>
 
                                 <!-- ALARM GEÇMİŞİ -->
@@ -1045,26 +1027,23 @@
                                                 </DockPanel>
                                         </Expander.Header>
 
-                                        <dxg:GridControl x:Name="AlertList" Margin="0,6,0,0" AutoGenerateColumns="None" IsReadOnly="True">
-            <dxg:GridControl.Columns>
-                <dxg:GridColumn FieldName="LocalTime" Header="Zaman" Width="80"/>
-                <dxg:GridColumn FieldName="BaseSymbol" Header="Sembol" Width="110">
-                    <dxg:GridColumn.CellTemplate>
+                                        <DataGrid x:Name="AlertList" Margin="0,6,0,0" AutoGenerateColumns="False" IsReadOnly="True">
+            <DataGrid.Columns>
+                <DataGridTextColumn Binding="{Binding LocalTime}" Header="Zaman" Width="80"/>
+                <DataGridTemplateColumn Header="Sembol" Width="110">
+                    <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <TextBlock>
                                 <Run Text="{Binding BaseSymbol, Mode=OneWay}"/>
                                 <Run Text="/USDT" Foreground="Gray"/>
                             </TextBlock>
                         </DataTemplate>
-                    </dxg:GridColumn.CellTemplate>
-                </dxg:GridColumn>
-                <dxg:GridColumn FieldName="TypeText" Header="Koşul" Width="160"/>
-                <dxg:GridColumn FieldName="Message" Header="Mesaj" Width="200"/>
-            </dxg:GridControl.Columns>
-            <dxg:GridControl.View>
-                <dxg:TableView AutoWidth="True"/>
-            </dxg:GridControl.View>
-        </dxg:GridControl>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTextColumn Binding="{Binding TypeText}" Header="Koşul" Width="160"/>
+                <DataGridTextColumn Binding="{Binding Message}" Header="Mesaj" Width="200"/>
+            </DataGrid.Columns>
+        </DataGrid>
 
                                 </Expander>
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -17,7 +17,6 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Controls.Primitives; // ToggleButton burada
 using System.Windows.Threading; // en üstte varsa gerekmez
-using DevExpress.Xpf.Grid;
 using WinForms = System.Windows.Forms;
 using BinanceUsdtTicker.Models;
 using Microsoft.Data.SqlClient;
@@ -94,7 +93,7 @@ namespace BinanceUsdtTicker
             var screenHeight = SystemParameters.PrimaryScreenHeight / 8;
 
             // alarm geçmişi bağla
-            var alertList = FindName("AlertList") as GridControl;
+            var alertList = FindName("AlertList") as DataGrid;
             if (alertList != null)
             {
                 alertList.ItemsSource = _alertLog;
@@ -108,19 +107,7 @@ namespace BinanceUsdtTicker
             void SetupList(string name, IEnumerable? source = null, bool useScreenHeight = true)
             {
                 var ctrl = FindName(name);
-                if (ctrl is GridControl gc)
-                {
-                    if (source != null)
-                        gc.ItemsSource = source;
-
-                    if (useScreenHeight)
-                    {
-                        gc.Height = screenHeight;
-                        gc.MinHeight = screenHeight;
-                        gc.MaxHeight = screenHeight;
-                    }
-                }
-                else if (ctrl is ItemsControl ic)
+                if (ctrl is ItemsControl ic)
                 {
                     if (source != null)
                         ic.ItemsSource = source;

--- a/Views/Wallet/WalletView.xaml
+++ b/Views/Wallet/WalletView.xaml
@@ -1,19 +1,15 @@
 <UserControl x:Class="BinanceUsdtTicker.Views.Wallet.WalletView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:dxg="http://schemas.devexpress.com/winfx/2008/xaml/grid">
-    <dxg:GridControl x:Name="WalletGrid"
-                     ItemsSource="{Binding Items}"
-                     AutoGenerateColumns="None"
-                     IsReadOnly="True">
-        <dxg:GridControl.Columns>
-            <dxg:GridColumn FieldName="Asset" Header="Varlık" Width="120"/>
-            <dxg:GridColumn FieldName="Balance" Header="Bakiye" Width="140" DisplayFormat="{}{0:#,0.########}"/>
-            <dxg:GridColumn FieldName="Available" Header="Kullanılabilir" Width="160" DisplayFormat="{}{0:#,0.########}"/>
-            <dxg:GridColumn FieldName="Used" Header="Kullanılan Bakiye" Width="170" DisplayFormat="{}{0:#,0.########}"/>
-        </dxg:GridControl.Columns>
-        <dxg:GridControl.View>
-            <dxg:TableView AutoWidth="True"/>
-        </dxg:GridControl.View>
-    </dxg:GridControl>
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <DataGrid x:Name="WalletGrid"
+              ItemsSource="{Binding Items}"
+              AutoGenerateColumns="False"
+              IsReadOnly="True">
+        <DataGrid.Columns>
+            <DataGridTextColumn Binding="{Binding Asset}" Header="Varlık" Width="120"/>
+            <DataGridTextColumn Binding="{Binding Balance, StringFormat={}{0:#,0.########}}" Header="Bakiye" Width="140"/>
+            <DataGridTextColumn Binding="{Binding Available, StringFormat={}{0:#,0.########}}" Header="Kullanılabilir" Width="160"/>
+            <DataGridTextColumn Binding="{Binding Used, StringFormat={}{0:#,0.########}}" Header="Kullanılan Bakiye" Width="170"/>
+        </DataGrid.Columns>
+    </DataGrid>
 </UserControl>


### PR DESCRIPTION
## Summary
- swap DevExpress tab and grid controls for built-in `TabControl` and `DataGrid`
- update wallet and alert views to use standard WPF grids
- remove DevExpress package references and adjust bindings

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c732701b5c8333959102d7a3767806