### PR TITLE
Use light gray row hover background

### DIFF
--- a/Themes/Dark.xaml
+++ b/Themes/Dark.xaml
@@ -36,7 +36,7 @@
     <SolidColorBrush x:Key="BtnPressed" Color="#FF2B3139"/>
 
     <!-- Hover color for list rows -->
-    <SolidColorBrush x:Key="RowHoverBg"      Color="#FF20252C"/>
+    <SolidColorBrush x:Key="RowHoverBg"      Color="#FF2B2F36"/>
 
     <!-- Top Movers tokens (dark) -->
     <SolidColorBrush x:Key="Up1Bg"          Color="#FF0E9C6A"/>

--- a/Themes/Light.xaml
+++ b/Themes/Light.xaml
@@ -36,7 +36,7 @@
     <SolidColorBrush x:Key="BtnPressed" Color="#FFDFE3EA"/>
 
     <!-- Hover color for list rows -->
-    <SolidColorBrush x:Key="RowHoverBg"      Color="#FFEFF1F5"/>
+    <SolidColorBrush x:Key="RowHoverBg"      Color="#FFF0F0F0"/>
 
     <!-- Top Movers tokens (light) -->
     <SolidColorBrush x:Key="Up1Bg"          Color="#FF90EE90"/>


### PR DESCRIPTION
## Summary
- Lighten row hover background in dark theme to avoid black highlight
- Adjust light theme hover color to consistent light gray

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c734939aa88333ab2648119be4f7a4