### PR TITLE
feat: add DevExpress Win11 theme

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -9,12 +9,6 @@
                                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml"/>
                                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.DataGrid.xaml"/>
 
-                                <!-- Material Design styles -->
-                                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml"/>
-                                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml"/>
-                                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.Blue.xaml"/>
-                                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml"/>
-
                                 <!-- Styles first (uses DynamicResource), then default theme -->
                                 <ResourceDictionary Source="Themes/Styles.Toolbar.xaml"/>
                                 <ResourceDictionary Source="Themes/Styles.Base.xaml"/>

--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -13,9 +13,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1823.32" />
     <PackageReference Include="MahApps.Metro" Version="2.4.9" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.9.0" />
-    <PackageReference Include="MaterialDesignColors" Version="2.1.4" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
+    <PackageReference Include="DevExpress.Xpf.Controls" Version="23.2.5" />
+    <PackageReference Include="DevExpress.Xpf.Themes.Win11" Version="23.2.5" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -68,7 +68,7 @@
                 </Style>
 
                 <!-- DataGrid başlığı -->
-                <Style TargetType="DataGridColumnHeader" BasedOn="{StaticResource MaterialDesignDataGridColumnHeader}">
+                <Style TargetType="DataGridColumnHeader">
                         <Setter Property="Background"  Value="{DynamicResource HeaderBg}"/>
                         <Setter Property="Foreground"  Value="Black"/>
                         <Setter Property="BorderBrush" Value="{DynamicResource HeaderBorder}"/>
@@ -166,7 +166,7 @@
                 </Style>
 
 		<!-- DataGrid hücre -->
-                <Style TargetType="DataGridCell" BasedOn="{StaticResource MaterialDesignDataGridCell}">
+                <Style TargetType="DataGridCell">
                         <Setter Property="BorderBrush" Value="{DynamicResource Divider}"/>
                         <Style.Triggers>
                                 <Trigger Property="IsSelected" Value="True">
@@ -176,7 +176,7 @@
                         </Style.Triggers>
                 </Style>
 
-                <Style TargetType="DataGridRowHeader" BasedOn="{StaticResource MaterialDesignDataGridRowHeader}">
+                <Style TargetType="DataGridRowHeader">
                         <Setter Property="Background"  Value="{DynamicResource SurfaceAlt}"/>
                         <Setter Property="Foreground"  Value="{DynamicResource OnSurface}"/>
                         <Setter Property="BorderBrush" Value="{DynamicResource Divider}"/>
@@ -450,7 +450,7 @@
                                         <DataGridTextColumn Binding="{Binding LastUpdateLocal}" Header="Son" Width="80"/>
                                     </DataGrid.Columns>
                                     <DataGrid.RowStyle>
-                                        <Style TargetType="DataGridRow" BasedOn="{StaticResource MaterialDesignDataGridRow}">
+                                        <Style TargetType="DataGridRow">
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding IsFavorite}" Value="True">
                                                     <Setter Property="Background" Value="{DynamicResource FavoriteRowBg}"/>
@@ -696,13 +696,12 @@
 
                                         <TextBlock Grid.Row="1" Text="Yükselenler" FontWeight="Bold" Margin="0,0,0,4"/>
                                         <DataGrid Grid.Row="2" x:Name="TopGainersList"
-                             Style="{DynamicResource MaterialDesignDataGrid}"
                              AutoGenerateColumns="False" IsReadOnly="True"
                              HeadersVisibility="Column" GridLinesVisibility="None"
                              Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
                              RowHeight="30" FontSize="12">
                                                <DataGrid.RowStyle>
-                                                       <Style TargetType="DataGridRow" BasedOn="{StaticResource MaterialDesignDataGridRow}">
+                                                       <Style TargetType="DataGridRow">
                                                                <Style.Triggers>
                                                                        <!-- 3%+ moves: dark green with white text -->
                                                                        <DataTrigger Binding="{Binding IsMove3Plus}" Value="True">
@@ -719,7 +718,7 @@
                                                        </Style>
                                                </DataGrid.RowStyle>
                                                <DataGrid.CellStyle>
-                                                       <Style TargetType="DataGridCell" BasedOn="{StaticResource MaterialDesignDataGridCell}">
+                                                       <Style TargetType="DataGridCell">
                                                                <Style.Triggers>
                                                                        <DataTrigger Binding="{Binding IsMove3Plus}" Value="True">
                                                                                <Setter Property="Foreground" Value="{DynamicResource Up3Fg}"/>
@@ -755,13 +754,12 @@
 
                                         <TextBlock Grid.Row="3" Text="Düşenler" FontWeight="Bold" Margin="0,0,0,4"/>
                                         <DataGrid Grid.Row="4" x:Name="TopLosersList"
-                             Style="{DynamicResource MaterialDesignDataGrid}"
                              AutoGenerateColumns="False" IsReadOnly="True"
                              HeadersVisibility="Column" GridLinesVisibility="None"
                              Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
                              RowHeight="30" FontSize="12">
                                                <DataGrid.RowStyle>
-                                                       <Style TargetType="DataGridRow" BasedOn="{StaticResource MaterialDesignDataGridRow}">
+                                                       <Style TargetType="DataGridRow">
                                                                <Style.Triggers>
                                                                        <!-- -3% or worse: dark red with white text -->
                                                                        <DataTrigger Binding="{Binding IsMoveMinus3}" Value="True">
@@ -778,7 +776,7 @@
                                                        </Style>
                                                </DataGrid.RowStyle>
                                                <DataGrid.CellStyle>
-                                                       <Style TargetType="DataGridCell" BasedOn="{StaticResource MaterialDesignDataGridCell}">
+                                                       <Style TargetType="DataGridCell">
                                                                <Style.Triggers>
                                                                        <DataTrigger Binding="{Binding IsMoveMinus3}" Value="True">
                                                                                <Setter Property="Foreground" Value="{DynamicResource Down3Fg}"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -22,6 +22,7 @@ using BinanceUsdtTicker.Models;
 using Microsoft.Data.SqlClient;
 using BinanceUsdtTicker.Data;
 using BinanceUsdtTicker.Runtime;
+using DevExpress.Xpf.Core;
 
 namespace BinanceUsdtTicker
 {
@@ -320,6 +321,10 @@ namespace BinanceUsdtTicker
         private void ApplyTheme(ThemeKind kind)
         {
             _theme = kind;
+
+            ApplicationThemeHelper.ApplicationThemeName =
+                kind == ThemeKind.Dark ? Theme.Win11Dark.Name : Theme.Win11Light.Name;
+
             var name = (kind == ThemeKind.Dark) ? "Dark" : "Light";
             var uri = new Uri($"Themes/{name}.xaml", UriKind.Relative);
 
@@ -328,14 +333,12 @@ namespace BinanceUsdtTicker
                 for (int i = col.Count - 1; i >= 0; i--)
                 {
                     var src = col[i].Source?.OriginalString ?? string.Empty;
-                    // only remove theme files; DO NOT remove other dictionaries in Themes/
                     if (src.EndsWith("/Dark.xaml", StringComparison.OrdinalIgnoreCase) ||
                         src.EndsWith("/Light.xaml", StringComparison.OrdinalIgnoreCase))
                     {
                         col.RemoveAt(i);
                     }
                 }
-                // Insert after base styles so theme overrides colors
                 col.Add(new ResourceDictionary { Source = newUri });
             }
 

--- a/Windows/ManageAlertsWindow.xaml
+++ b/Windows/ManageAlertsWindow.xaml
@@ -3,7 +3,6 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:BinanceUsdtTicker"
-        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
         Title="Alarmları Yönet"
         Width="760" Height="420"
         WindowStartupLocation="CenterOwner"
@@ -24,7 +23,6 @@
 
         <!-- ALARM LİSTESİ -->
         <DataGrid x:Name="Grid"
-                  Style="{DynamicResource MaterialDesignDataGrid}"
                   Grid.Row="0"
                   ItemsSource="{Binding WorkingAlerts}"
                   AutoGenerateColumns="False"
@@ -43,11 +41,11 @@
 
             <DataGrid.Resources>
                 <!-- Single-click edit -->
-                <Style TargetType="DataGridCell" BasedOn="{StaticResource MaterialDesignDataGridCell}">
+                <Style TargetType="DataGridCell">
                     <EventSetter Event="PreviewMouseLeftButtonDown" Handler="Grid_CellPreviewMouseLeftButtonDown"/>
                 </Style>
                 <!-- Extra spacing between rows -->
-                <Style TargetType="DataGridRow" BasedOn="{StaticResource MaterialDesignDataGridRow}">
+                <Style TargetType="DataGridRow">
                     <Setter Property="Margin" Value="0,3"/>
                 </Style>
             </DataGrid.Resources>


### PR DESCRIPTION
## Summary
- add DevExpress Win11 theme packages
- remove MaterialDesign styles and apply theme with ApplicationThemeHelper

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c73f31c7448333ad9d00223d05b632