### PR TITLE
Remove unused DevExpress dependencies

### DIFF
--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -14,8 +14,6 @@
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1823.32" />
     <PackageReference Include="MahApps.Metro" Version="2.4.9" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
-    <PackageReference Include="DevExpress.Xpf.Controls" Version="23.2.5" />
-    <PackageReference Include="DevExpress.Xpf.Themes.Win11" Version="23.2.5" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -22,7 +22,6 @@ using BinanceUsdtTicker.Models;
 using Microsoft.Data.SqlClient;
 using BinanceUsdtTicker.Data;
 using BinanceUsdtTicker.Runtime;
-using DevExpress.Xpf.Core;
 
 namespace BinanceUsdtTicker
 {


### PR DESCRIPTION
## Summary
- drop unused DevExpress package references
- remove leftover DevExpress using directive from MainWindow

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c742eef61883338f10b35cbec246b9