### PR TITLE
Remove DevExpress theme dependency

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -321,10 +321,9 @@ namespace BinanceUsdtTicker
         {
             _theme = kind;
 
-            ApplicationThemeHelper.ApplicationThemeName =
-                kind == ThemeKind.Dark ? Theme.Win11Dark.Name : Theme.Win11Light.Name;
-
-            var name = (kind == ThemeKind.Dark) ? "Dark" : "Light";
+            // Removed dependency on DevExpress ApplicationThemeHelper/Theme.
+            // Theme switching now relies solely on resource dictionaries.
+            var name = kind == ThemeKind.Dark ? "Dark" : "Light";
             var uri = new Uri($"Themes/{name}.xaml", UriKind.Relative);
 
             void SwapThemes(Collection<ResourceDictionary> col, Uri newUri)


### PR DESCRIPTION
## Summary
- drop DevExpress ApplicationThemeHelper usage in theme switching
- rely solely on resource dictionaries for applying light/dark themes

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c744a7c2f883338c75cffe38b76ded