### PR TITLE
Integrate DevExpress grid for coin list

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -13,6 +13,10 @@
                                 <ResourceDictionary Source="Themes/Styles.Toolbar.xaml"/>
                                 <ResourceDictionary Source="Themes/Styles.Base.xaml"/>
                                 <ResourceDictionary Source="Themes/Light.xaml"/>
+                                <!-- DevExpress theme resources -->
+                                <ResourceDictionary Source="pack://application:,,,/DevExpress.Xpf.Core.v25.1;component/Themes/Office2019Colorful.xaml"/>
+                                <ResourceDictionary Source="pack://application:,,,/DevExpress.Xpf.Grid.v25.1;component/Themes/Office2019Colorful.xaml"/>
+                                <ResourceDictionary Source="pack://application:,,,/DevExpress.Xpf.Editors.v25.1;component/Themes/Office2019Colorful.xaml"/>
                         </ResourceDictionary.MergedDictionaries>
                 </ResourceDictionary>
         </Application.Resources>

--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -14,6 +14,10 @@
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1823.32" />
     <PackageReference Include="MahApps.Metro" Version="2.4.9" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
+    <PackageReference Include="DevExpress.Data" Version="25.1.3" />
+    <PackageReference Include="DevExpress.Mvvm" Version="25.1.3" />
+    <PackageReference Include="DevExpress.Wpf.Editors" Version="25.1.3" />
+    <PackageReference Include="DevExpress.Wpf.Grid" Version="25.1.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:local="clr-namespace:BinanceUsdtTicker"
         xmlns:wallet="clr-namespace:BinanceUsdtTicker.Views.Wallet"
         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        xmlns:coins="clr-namespace:BinanceUsdtTicker.Views.Coins"
         Title="Binance USDT Canlı Fiyatlar"
         Height="680" Width="1100" MinHeight="500" MinWidth="900"
         Background="{DynamicResource Surface}"
@@ -415,50 +416,9 @@
                         <GroupBox Grid.Row="0" Grid.Column="1" Header="Coin" Margin="0,0,8,0"
                                   Background="{DynamicResource SurfaceAlt}" Foreground="{DynamicResource OnSurface}"
                                   BorderBrush="{DynamicResource Divider}" VerticalAlignment="Stretch">
-                                <DataGrid x:Name="Grid" AutoGenerateColumns="False" SelectionChanged="Grid_SelectionChanged">
-                                    <DataGrid.Columns>
-                                        <DataGridTemplateColumn Header="★" Width="35">
-                                            <DataGridTemplateColumn.CellTemplate>
-                                                <DataTemplate>
-                                                    <ToggleButton Style="{StaticResource StarToggleStyle}"
-                                                                 IsChecked="{Binding IsFavorite}"
-                                                                 Click="FavoriteToggle_Click">
-                                                        <materialDesign:PackIcon Width="16" Height="16">
-                                                            <materialDesign:PackIcon.Style>
-                                                                <Style TargetType="materialDesign:PackIcon">
-                                                                    <Setter Property="Kind" Value="StarOutline"/>
-                                                                    <Setter Property="Foreground" Value="Gray"/>
-                                                                    <Style.Triggers>
-                                                                        <DataTrigger Binding="{Binding IsChecked, RelativeSource={RelativeSource AncestorType=ToggleButton}}" Value="True">
-                                                                            <Setter Property="Kind" Value="Star"/>
-                                                                            <Setter Property="Foreground" Value="Gold"/>
-                                                                        </DataTrigger>
-                                                                    </Style.Triggers>
-                                                                </Style>
-                                                            </materialDesign:PackIcon.Style>
-                                                        </materialDesign:PackIcon>
-                                                    </ToggleButton>
-                                                </DataTemplate>
-                                            </DataGridTemplateColumn.CellTemplate>
-                                        </DataGridTemplateColumn>
-                                        <DataGridTextColumn Binding="{Binding BaseSymbol}" Header="Sembol" Width="100"/>
-                                        <DataGridTextColumn Binding="{Binding BaselinePrice}" Header="Başlangıç Fiyatı" Width="100"/>
-                                        <DataGridTextColumn Binding="{Binding Price}" Header="Fiyat" Width="100"/>
-                                        <DataGridTextColumn Binding="{Binding ChangeSinceStartPercent}" Header="Anlık Değişim" Width="100"/>
-                                        <DataGridTextColumn Binding="{Binding ChangePct}" Header="% 24s" Width="80"/>
-                                        <DataGridTextColumn Binding="{Binding Volume}" Header="Hacim" Width="120"/>
-                                        <DataGridTextColumn Binding="{Binding LastUpdateLocal}" Header="Son" Width="80"/>
-                                    </DataGrid.Columns>
-                                    <DataGrid.RowStyle>
-                                        <Style TargetType="DataGridRow">
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding IsFavorite}" Value="True">
-                                                    <Setter Property="Background" Value="{DynamicResource FavoriteRowBg}"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </DataGrid.RowStyle>
-                                </DataGrid>
+                                <!-- Coin listesi host -->
+                                <coins:CoinsGridView x:Name="CoinsGridHost"
+                                                     Visibility="Visible"/>
                         </GroupBox>
 
                         <!-- FUTURES INFO -->

--- a/Models/TickerUpdate.cs
+++ b/Models/TickerUpdate.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace BinanceUsdtTicker
+{
+    public readonly struct TickerUpdate
+    {
+        public TickerUpdate(
+            string symbol,
+            decimal price,
+            double changePct,
+            decimal volume,
+            decimal? open = null,
+            decimal? high = null,
+            decimal? low = null,
+            DateTime? lastUpdate = null,
+            decimal? baselinePrice = null)
+        {
+            Symbol = symbol;
+            Price = price;
+            ChangePct = changePct;
+            Volume = volume;
+            Open = open;
+            High = high;
+            Low = low;
+            LastUpdate = lastUpdate;
+            BaselinePrice = baselinePrice;
+        }
+
+        public string Symbol { get; }
+        public decimal Price { get; }
+        public double ChangePct { get; }
+        public decimal Volume { get; }
+        public decimal? Open { get; }
+        public decimal? High { get; }
+        public decimal? Low { get; }
+        public DateTime? LastUpdate { get; }
+        public decimal? BaselinePrice { get; }
+    }
+}

--- a/Views/Coins/CoinsGridView.xaml
+++ b/Views/Coins/CoinsGridView.xaml
@@ -1,18 +1,69 @@
 <UserControl x:Class="BinanceUsdtTicker.Views.Coins.CoinsGridView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  <DataGrid x:Name="CoinsGrid" ItemsSource="{Binding Items}" AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="False">
-    <DataGrid.Columns>
-      <!-- Favori -->
-      <DataGridCheckBoxColumn Binding="{Binding IsFavorite}" Header="★" Width="44"/>
-      <!-- Sembol -->
-      <DataGridTextColumn Binding="{Binding Symbol}" Header="Sembol" Width="120"/>
-      <!-- Fiyat -->
-      <DataGridTextColumn Binding="{Binding Price, StringFormat={}{0:#,0.########}}" Header="Fiyat" Width="120"/>
-      <!-- %24s -->
-      <DataGridTextColumn Binding="{Binding ChangePct, StringFormat={}{0:+0.##%;-0.##%;0%}}" Header="%24s" Width="90"/>
-      <!-- Hacim (opsiyonel) -->
-      <DataGridTextColumn Binding="{Binding Volume, StringFormat={}{0:#,0.########}}" Header="Hacim" Width="130"/>
-    </DataGrid.Columns>
-  </DataGrid>
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:dxg="http://schemas.devexpress.com/winfx/2008/xaml/grid"
+             xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors">
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="*"/>
+    </Grid.RowDefinitions>
+
+    <!-- Görünürlük tanı etiketi -->
+    <Border Background="#1133AA" Padding="4" Margin="0,0,0,6">
+      <TextBlock Text="DevExpress CoinsGrid LOADED" Foreground="White" FontWeight="Bold"/>
+    </Border>
+
+    <dxg:GridControl x:Name="CoinsGrid"
+                     Grid.Row="1"
+                     ItemsSource="{Binding Items}"
+                     AutoGenerateColumns="None"
+                     Height="Auto">
+      <dxg:GridControl.View>
+        <dxg:TableView
+          AllowPerPixelScrolling="True"
+          NavigationStyle="Row"
+          AllowRowFixing="Top"
+          ShowFixRowButton="Always"/>
+      </dxg:GridControl.View>
+
+      <dxg:GridControl.Columns>
+        <dxg:GridColumn FieldName="IsFavorite" Header="★" Width="44" Fixed="Left" AllowSorting="False">
+          <dxg:GridColumn.EditSettings>
+            <dxe:CheckEditSettings/>
+          </dxg:GridColumn.EditSettings>
+        </dxg:GridColumn>
+
+        <dxg:GridColumn FieldName="Symbol" Header="Sembol" Width="120" Fixed="Left"/>
+
+        <dxg:GridColumn FieldName="Price" Header="Fiyat" Width="120">
+          <dxg:GridColumn.EditSettings>
+            <dxe:TextEditSettings DisplayFormatString="#,0.########" MaskUseAsDisplayFormat="True"/>
+          </dxg:GridColumn.EditSettings>
+        </dxg:GridColumn>
+
+        <dxg:GridColumn FieldName="ChangePct" Header="%24s" Width="90">
+          <dxg:GridColumn.EditSettings>
+            <dxe:TextEditSettings DisplayFormatString="+0.##%;-0.##%;0%"/>
+          </dxg:GridColumn.EditSettings>
+        </dxg:GridColumn>
+
+        <dxg:GridColumn FieldName="Volume" Header="Hacim" Width="130">
+          <dxg:GridColumn.EditSettings>
+            <dxe:TextEditSettings DisplayFormatString="#,0.########" MaskUseAsDisplayFormat="True"/>
+          </dxg:GridColumn.EditSettings>
+        </dxg:GridColumn>
+      </dxg:GridControl.Columns>
+
+      <!-- Anlık değişim vurgusu -->
+      <dxg:GridControl.ConditionalFormatting>
+        <dxg:ConditionalFormattingCollection>
+          <dxg:DataUpdateFormatCondition FieldName="Price" DataUpdateRule="Increased" Duration="0:0:02"/>
+          <dxg:DataUpdateFormatCondition FieldName="Price" DataUpdateRule="Decreased" Duration="0:0:02"/>
+          <dxg:DataUpdateFormatCondition FieldName="ChangePct" DataUpdateRule="Increased" Duration="0:0:02"/>
+          <dxg:DataUpdateFormatCondition FieldName="ChangePct" DataUpdateRule="Decreased" Duration="0:0:02"/>
+        </dxg:ConditionalFormattingCollection>
+      </dxg:GridControl.ConditionalFormatting>
+    </dxg:GridControl>
+  </Grid>
 </UserControl>

--- a/Views/Coins/CoinsGridView.xaml.cs
+++ b/Views/Coins/CoinsGridView.xaml.cs
@@ -1,5 +1,11 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Windows;
 using System.Windows.Controls;
 using BinanceUsdtTicker.ViewModels.Coins;
+using BinanceUsdtTicker;
+using DevExpress.Xpf.Grid;
 
 namespace BinanceUsdtTicker.Views.Coins
 {
@@ -8,7 +14,40 @@ namespace BinanceUsdtTicker.Views.Coins
         public CoinsGridView()
         {
             InitializeComponent();
-            DataContext = new CoinsGridViewModel();
+
+            ViewModel = new CoinsGridViewModel(CoinsGrid);
+            DataContext = ViewModel;
+
+            var view = (TableView)CoinsGrid.View;
+            view.CellValueChanged += (_, e) =>
+            {
+                if (e.Column.FieldName == nameof(TickerRow.IsFavorite))
+                {
+                    var item = CoinsGrid.GetRow(e.RowHandle);
+                    var fix = (bool?)e.Value == true ? FixedRowPosition.Top : FixedRowPosition.None;
+                    view.FixItem(item, fix);
+                }
+            };
+            view.FocusedRowChanged += (_, __) => SelectedItemChanged?.Invoke(this, SelectedItem);
+
+            Loaded += (_, __) =>
+            {
+                Debug.WriteLine($"[DEVEXPRESS] CoinsGrid loaded. Columns={CoinsGrid.Columns.Count}");
+                SelectedItemChanged?.Invoke(this, SelectedItem);
+            };
+        }
+
+        public CoinsGridViewModel ViewModel { get; }
+
+        public GridControl GridControl => CoinsGrid;
+
+        public event EventHandler<TickerRow?>? SelectedItemChanged;
+
+        public TickerRow? SelectedItem => CoinsGrid.SelectedItem as TickerRow;
+
+        public void BindItems(ObservableCollection<TickerRow> items)
+        {
+            ViewModel.SetItems(items);
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the legacy coins DataGrid with a DevExpress GridControl view that pins favourites, formats live updates, and exposes a dedicated view model
- extend the coins grid view model to throttle RefreshData calls, reuse the shared ticker collection, and seed debug rows when empty
- update the main window to host the new control, keep favourites/top sorting behaviour, and persist column layouts while wiring data updates through the new TickerUpdate flow
- add DevExpress theme resources and package references required for the grid/editors assemblies

## Testing
- `dotnet build` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb29073eec833387f1698a0b001c42