### PR TITLE
Replace DevExpress coins grid with WPF DataGrid

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -13,10 +13,6 @@
                                 <ResourceDictionary Source="Themes/Styles.Toolbar.xaml"/>
                                 <ResourceDictionary Source="Themes/Styles.Base.xaml"/>
                                 <ResourceDictionary Source="Themes/Light.xaml"/>
-                                <!-- DevExpress theme resources -->
-                                <ResourceDictionary Source="pack://application:,,,/DevExpress.Xpf.Core.v25.1;component/Themes/Office2019Colorful.xaml"/>
-                                <ResourceDictionary Source="pack://application:,,,/DevExpress.Xpf.Grid.v25.1;component/Themes/Office2019Colorful.xaml"/>
-                                <ResourceDictionary Source="pack://application:,,,/DevExpress.Xpf.Editors.v25.1;component/Themes/Office2019Colorful.xaml"/>
                         </ResourceDictionary.MergedDictionaries>
                 </ResourceDictionary>
         </Application.Resources>

--- a/BinanceUsdtTicker.csproj
+++ b/BinanceUsdtTicker.csproj
@@ -14,10 +14,6 @@
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1823.32" />
     <PackageReference Include="MahApps.Metro" Version="2.4.9" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
-    <PackageReference Include="DevExpress.Data" Version="25.1.3" />
-    <PackageReference Include="DevExpress.Mvvm" Version="25.1.3" />
-    <PackageReference Include="DevExpress.Wpf.Editors" Version="25.1.3" />
-    <PackageReference Include="DevExpress.Wpf.Grid" Version="25.1.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -24,7 +24,6 @@ using Microsoft.Data.SqlClient;
 using BinanceUsdtTicker.Data;
 using BinanceUsdtTicker.Runtime;
 using BinanceUsdtTicker.Views.Coins;
-using DevExpress.Xpf.Grid;
 
 namespace BinanceUsdtTicker
 {
@@ -89,7 +88,7 @@ namespace BinanceUsdtTicker
                 searchBox.LostFocus += SearchBox_LostFocus;
             }
 
-            // DevExpress coin grid bağla
+            // Coin grid bağla
             if (CoinsGridHost != null)
             {
                 CoinsGridHost.BindItems(_rows);
@@ -852,8 +851,6 @@ namespace BinanceUsdtTicker
 
                     if (!row.BaselinePrice.HasValue)
                         row.BaselinePrice = row.Price;
-
-                    UpdateRowFixing(row);
                 }
             }
 
@@ -889,7 +886,6 @@ namespace BinanceUsdtTicker
                 SaveFavoritesSafe();
                 ApplySortForMode(_filterMode);
                 CollectionViewSource.GetDefaultView(_rows).Refresh();
-                UpdateRowFixing(row);
             }
         }
 
@@ -898,34 +894,6 @@ namespace BinanceUsdtTicker
             foreach (var row in _rows)
             {
                 row.IsFavorite = _favoriteSymbols.Contains(row.Symbol);
-                UpdateRowFixing(row);
-            }
-        }
-
-        private void UpdateRowFixing(TickerRow row)
-        {
-            if (row == null)
-                return;
-
-            if (CoinsGridHost == null)
-                return;
-
-            void ApplyFix()
-            {
-                if (CoinsGridHost.GridControl.View is TableView view)
-                {
-                    var position = row.IsFavorite ? FixedRowPosition.Top : FixedRowPosition.None;
-                    view.FixItem(row, position);
-                }
-            }
-
-            if (CoinsGridHost.IsLoaded)
-            {
-                ApplyFix();
-            }
-            else
-            {
-                CoinsGridHost.Dispatcher.BeginInvoke((Action)ApplyFix, DispatcherPriority.Loaded);
             }
         }
 
@@ -1177,12 +1145,12 @@ namespace BinanceUsdtTicker
             var grid = CoinsGridHost?.GridControl;
             if (grid?.Columns == null) return;
 
-            GridColumn? star = grid.Columns.FirstOrDefault(c => (c.Header?.ToString() ?? "") == "★");
-            GridColumn? symbol = grid.Columns.FirstOrDefault(c => (c.Header?.ToString() ?? "") == "Sembol");
+            var star = grid.Columns.FirstOrDefault(c => (c.Header?.ToString() ?? string.Empty) == "★");
+            var symbol = grid.Columns.FirstOrDefault(c => (c.Header?.ToString() ?? string.Empty) == "Sembol");
 
             int idx = 0;
-            if (star != null) star.VisibleIndex = idx++;
-            if (symbol != null) symbol.VisibleIndex = idx++;
+            if (star != null) star.DisplayIndex = idx++;
+            if (symbol != null) symbol.DisplayIndex = idx++;
         }
 
         // ---------- UI settings / favorites ----------
@@ -1255,7 +1223,7 @@ namespace BinanceUsdtTicker
                         .Select(c => new ColumnState
                         {
                             Header = c.Header?.ToString() ?? "",
-                            DisplayIndex = c.VisibleIndex,
+                            DisplayIndex = c.DisplayIndex,
                             Width = c.ActualWidth
                         })
                         .ToList();
@@ -1339,10 +1307,10 @@ namespace BinanceUsdtTicker
                 if (map.TryGetValue(key, out var st))
                 {
                     if (st.DisplayIndex >= 0 && st.DisplayIndex < grid.Columns.Count)
-                        col.VisibleIndex = st.DisplayIndex;
+                        col.DisplayIndex = st.DisplayIndex;
 
                     if (st.Width > 20)
-                        col.Width = st.Width;
+                        col.Width = new DataGridLength(st.Width);
                 }
             }
         }

--- a/Views/Coins/CoinsGridView.xaml
+++ b/Views/Coins/CoinsGridView.xaml
@@ -1,69 +1,119 @@
 <UserControl x:Class="BinanceUsdtTicker.Views.Coins.CoinsGridView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:dxg="http://schemas.devexpress.com/winfx/2008/xaml/grid"
-             xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors">
-  <Grid>
-    <Grid.RowDefinitions>
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="*"/>
-    </Grid.RowDefinitions>
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
 
-    <!-- Görünürlük tanı etiketi -->
-    <Border Background="#1133AA" Padding="4" Margin="0,0,0,6">
-      <TextBlock Text="DevExpress CoinsGrid LOADED" Foreground="White" FontWeight="Bold"/>
-    </Border>
+        <Border Background="#1133AA" Padding="4" Margin="0,0,0,6">
+            <TextBlock Text="CoinsGrid ready" Foreground="White" FontWeight="Bold"/>
+        </Border>
 
-    <dxg:GridControl x:Name="CoinsGrid"
-                     Grid.Row="1"
-                     ItemsSource="{Binding Items}"
-                     AutoGenerateColumns="None"
-                     Height="Auto">
-      <dxg:GridControl.View>
-        <dxg:TableView
-          AllowPerPixelScrolling="True"
-          NavigationStyle="Row"
-          AllowRowFixing="Top"
-          ShowFixRowButton="Always"/>
-      </dxg:GridControl.View>
+        <DataGrid x:Name="CoinsGrid"
+                  Grid.Row="1"
+                  ItemsSource="{Binding Items}"
+                  AutoGenerateColumns="False"
+                  CanUserAddRows="False"
+                  CanUserDeleteRows="False"
+                  SelectionMode="Single"
+                  SelectionUnit="FullRow"
+                  IsReadOnly="False"
+                  EnableRowVirtualization="True"
+                  EnableColumnVirtualization="True"
+                  VirtualizingPanel.IsVirtualizing="True"
+                  VirtualizingPanel.ScrollUnit="Pixel"
+                  RowHeaderWidth="0"
+                  HeadersVisibility="Column"
+                  Margin="0">
+            <DataGrid.Resources>
+                <Style x:Key="CenterCellStyle" TargetType="TextBlock">
+                    <Setter Property="HorizontalAlignment" Value="Center"/>
+                    <Setter Property="VerticalAlignment" Value="Center"/>
+                </Style>
+                <Style x:Key="RightCellStyle" TargetType="TextBlock">
+                    <Setter Property="HorizontalAlignment" Value="Right"/>
+                    <Setter Property="VerticalAlignment" Value="Center"/>
+                </Style>
+            </DataGrid.Resources>
 
-      <dxg:GridControl.Columns>
-        <dxg:GridColumn FieldName="IsFavorite" Header="★" Width="44" Fixed="Left" AllowSorting="False">
-          <dxg:GridColumn.EditSettings>
-            <dxe:CheckEditSettings/>
-          </dxg:GridColumn.EditSettings>
-        </dxg:GridColumn>
+            <DataGrid.RowStyle>
+                <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsFavorite}" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource FavoriteRowBg}"/>
+                        </DataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMove3Plus}" Value="True"/>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="False"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Background" Value="#3328A745"/>
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMove1Plus}" Value="True"/>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="False"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Background" Value="#3317A05E"/>
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMoveMinus3}" Value="True"/>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="False"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Background" Value="#33B91C1C"/>
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMoveMinus1}" Value="True"/>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="False"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Background" Value="#33D66A6A"/>
+                        </MultiDataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </DataGrid.RowStyle>
 
-        <dxg:GridColumn FieldName="Symbol" Header="Sembol" Width="120" Fixed="Left"/>
+            <DataGrid.Columns>
+                <DataGridTemplateColumn Header="★" Width="44" IsReadOnly="False">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <CheckBox IsChecked="{Binding IsFavorite, Mode=TwoWay}"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      Focusable="False"
+                                      Checked="FavoriteCheckChanged"
+                                      Unchecked="FavoriteCheckChanged"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
 
-        <dxg:GridColumn FieldName="Price" Header="Fiyat" Width="120">
-          <dxg:GridColumn.EditSettings>
-            <dxe:TextEditSettings DisplayFormatString="#,0.########" MaskUseAsDisplayFormat="True"/>
-          </dxg:GridColumn.EditSettings>
-        </dxg:GridColumn>
+                <DataGridTextColumn Header="Sembol"
+                                     Binding="{Binding Symbol}"
+                                     Width="120"
+                                     IsReadOnly="True"
+                                     ElementStyle="{StaticResource CenterCellStyle}"/>
 
-        <dxg:GridColumn FieldName="ChangePct" Header="%24s" Width="90">
-          <dxg:GridColumn.EditSettings>
-            <dxe:TextEditSettings DisplayFormatString="+0.##%;-0.##%;0%"/>
-          </dxg:GridColumn.EditSettings>
-        </dxg:GridColumn>
+                <DataGridTextColumn Header="Fiyat"
+                                     Binding="{Binding Price, StringFormat=#,0.########}"
+                                     Width="120"
+                                     IsReadOnly="True"
+                                     ElementStyle="{StaticResource RightCellStyle}"/>
 
-        <dxg:GridColumn FieldName="Volume" Header="Hacim" Width="130">
-          <dxg:GridColumn.EditSettings>
-            <dxe:TextEditSettings DisplayFormatString="#,0.########" MaskUseAsDisplayFormat="True"/>
-          </dxg:GridColumn.EditSettings>
-        </dxg:GridColumn>
-      </dxg:GridControl.Columns>
+                <DataGridTextColumn Header="%24s"
+                                     Binding="{Binding ChangePct, StringFormat=+0.##%;-0.##%;0%}"
+                                     Width="90"
+                                     IsReadOnly="True"
+                                     ElementStyle="{StaticResource RightCellStyle}"/>
 
-      <!-- Anlık değişim vurgusu -->
-      <dxg:GridControl.ConditionalFormatting>
-        <dxg:ConditionalFormattingCollection>
-          <dxg:DataUpdateFormatCondition FieldName="Price" DataUpdateRule="Increased" Duration="0:0:02"/>
-          <dxg:DataUpdateFormatCondition FieldName="Price" DataUpdateRule="Decreased" Duration="0:0:02"/>
-          <dxg:DataUpdateFormatCondition FieldName="ChangePct" DataUpdateRule="Increased" Duration="0:0:02"/>
-          <dxg:DataUpdateFormatCondition FieldName="ChangePct" DataUpdateRule="Decreased" Duration="0:0:02"/>
-        </dxg:ConditionalFormattingCollection>
-      </dxg:GridControl.ConditionalFormatting>
-    </dxg:GridControl>
-  </Grid>
+                <DataGridTextColumn Header="Hacim"
+                                     Binding="{Binding Volume, StringFormat=#,0.########}"
+                                     Width="130"
+                                     IsReadOnly="True"
+                                     ElementStyle="{StaticResource RightCellStyle}"/>
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
 </UserControl>

--- a/Views/Coins/CoinsGridView.xaml.cs
+++ b/Views/Coins/CoinsGridView.xaml.cs
@@ -1,11 +1,10 @@
 using System;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using BinanceUsdtTicker.ViewModels.Coins;
 using BinanceUsdtTicker;
-using DevExpress.Xpf.Grid;
 
 namespace BinanceUsdtTicker.Views.Coins
 {
@@ -15,31 +14,16 @@ namespace BinanceUsdtTicker.Views.Coins
         {
             InitializeComponent();
 
-            ViewModel = new CoinsGridViewModel(CoinsGrid);
+            ViewModel = new CoinsGridViewModel();
             DataContext = ViewModel;
 
-            var view = (TableView)CoinsGrid.View;
-            view.CellValueChanged += (_, e) =>
-            {
-                if (e.Column.FieldName == nameof(TickerRow.IsFavorite))
-                {
-                    var item = CoinsGrid.GetRow(e.RowHandle);
-                    var fix = (bool?)e.Value == true ? FixedRowPosition.Top : FixedRowPosition.None;
-                    view.FixItem(item, fix);
-                }
-            };
-            view.FocusedRowChanged += (_, __) => SelectedItemChanged?.Invoke(this, SelectedItem);
-
-            Loaded += (_, __) =>
-            {
-                Debug.WriteLine($"[DEVEXPRESS] CoinsGrid loaded. Columns={CoinsGrid.Columns.Count}");
-                SelectedItemChanged?.Invoke(this, SelectedItem);
-            };
+            CoinsGrid.SelectionChanged += (_, __) => SelectedItemChanged?.Invoke(this, SelectedItem);
+            Loaded += (_, __) => SelectedItemChanged?.Invoke(this, SelectedItem);
         }
 
         public CoinsGridViewModel ViewModel { get; }
 
-        public GridControl GridControl => CoinsGrid;
+        public DataGrid GridControl => CoinsGrid;
 
         public event EventHandler<TickerRow?>? SelectedItemChanged;
 
@@ -48,6 +32,19 @@ namespace BinanceUsdtTicker.Views.Coins
         public void BindItems(ObservableCollection<TickerRow> items)
         {
             ViewModel.SetItems(items);
+            RefreshSort();
+        }
+
+        private void FavoriteCheckChanged(object sender, RoutedEventArgs e)
+        {
+            RefreshSort();
+        }
+
+        private void RefreshSort()
+        {
+            var source = CoinsGrid.ItemsSource ?? ViewModel.Items;
+            var view = CollectionViewSource.GetDefaultView(source);
+            view?.Refresh();
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the DevExpress-based coins grid with a native WPF DataGrid including styling and favorite handling
- remove DevExpress package dependencies and resource dictionaries from the application
- update view models and main window logic to work with the new grid and persist column settings

## Testing
- `dotnet build` *(fails: dotnet command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb305f4f9c8333a2ab95a8d164d99f