### PR TITLE
Fix binding StringFormat syntax in CoinsGridView

### DIFF
--- a/Views/Coins/CoinsGridView.xaml
+++ b/Views/Coins/CoinsGridView.xaml
@@ -97,7 +97,7 @@
                                      ElementStyle="{StaticResource CenterCellStyle}"/>
 
                 <DataGridTextColumn Header="Fiyat"
-                                     Binding="{Binding Price, StringFormat=#,0.########}"
+                                     Binding="{Binding Price, StringFormat='#,0.########'}"
                                      Width="120"
                                      IsReadOnly="True"
                                      ElementStyle="{StaticResource RightCellStyle}"/>
@@ -109,7 +109,7 @@
                                      ElementStyle="{StaticResource RightCellStyle}"/>
 
                 <DataGridTextColumn Header="Hacim"
-                                     Binding="{Binding Volume, StringFormat=#,0.########}"
+                                     Binding="{Binding Volume, StringFormat='#,0.########'}"
                                      Width="130"
                                      IsReadOnly="True"
                                      ElementStyle="{StaticResource RightCellStyle}"/>


### PR DESCRIPTION
## Summary
- wrap DataGrid column bindings' custom numeric formats in quotes so commas are parsed correctly

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3781bc748333bfb8fc0dbf04e0bf