### PR TITLE
Prevent listing listener startup from blocking UI

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
@@ -33,6 +34,8 @@ public partial class App : Application
     private readonly ISymbolExtractor _symbolExtractor = new RegexSymbolExtractor();
     private readonly HashSet<string> _usdtSymbols = new(StringComparer.OrdinalIgnoreCase);
     private WebApplication? _listingApp;
+    private CancellationTokenSource? _listingCts;
+    private Task? _listingLifetimeTask;
     private static readonly string SymbolsFile = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
         "BinanceUsdtTicker", "usdt_symbols.txt");
@@ -54,47 +57,73 @@ public partial class App : Application
 
     private async Task StartListingListenerAsync()
     {
-        var builder = WebApplication.CreateBuilder(Array.Empty<string>());
-        builder.Logging.ClearProviders();
+        await StopListingListenerAsync();
 
-        var listenUrl = Environment.GetEnvironmentVariable("NEWS_LISTEN_URL")
-            ?? "http://localhost:5005";
-        builder.WebHost.UseUrls(listenUrl);
-        var app = builder.Build();
-
-        app.MapPost("/news", async (HttpContext ctx) =>
+        try
         {
-            ListingNotification? payload;
-            try
-            {
-                payload = await ctx.Request.ReadFromJsonAsync<ListingNotification>();
-            }
-            catch (JsonException ex)
-            {
-                return Results.BadRequest(new { error = ex.Message });
-            }
+            var builder = WebApplication.CreateBuilder(Array.Empty<string>());
+            builder.Logging.ClearProviders();
 
-            if (payload != null)
+            var listenUrl = Environment.GetEnvironmentVariable("NEWS_LISTEN_URL")
+                ?? "http://localhost:5005";
+            builder.WebHost.UseUrls(listenUrl);
+            var app = builder.Build();
+
+            app.MapPost("/news", async (HttpContext ctx) =>
             {
-                var item = new NewsItem(
-                    id: payload.Id,
-                    source: payload.Source,
-                    timestamp: DateTime.UtcNow,
-                    title: payload.Title,
-                    titleTranslate: null,
-                    body: null,
-                    link: payload.Url ?? string.Empty,
-                    type: NewsType.Listing,
-                    symbols: payload.Symbols ?? Array.Empty<string>());
+                ListingNotification? payload;
+                try
+                {
+                    payload = await ctx.Request.ReadFromJsonAsync<ListingNotification>();
+                }
+                catch (JsonException ex)
+                {
+                    return Results.BadRequest(new { error = ex.Message });
+                }
 
-                if (Current.MainWindow is MainWindow mw)
-                    mw.AddNewsItem(item);
-            }
-            return Results.Ok();
-        });
+                if (payload != null)
+                {
+                    var item = new NewsItem(
+                        id: payload.Id,
+                        source: payload.Source,
+                        timestamp: DateTime.UtcNow,
+                        title: payload.Title,
+                        titleTranslate: null,
+                        body: null,
+                        link: payload.Url ?? string.Empty,
+                        type: NewsType.Listing,
+                        symbols: payload.Symbols ?? Array.Empty<string>());
 
-        _listingApp = app;
-        await app.StartAsync();
+                    if (Current.MainWindow is MainWindow mw)
+                        mw.AddNewsItem(item);
+                }
+                return Results.Ok();
+            });
+
+            _listingApp = app;
+            await app.StartAsync().ConfigureAwait(false);
+
+            _listingCts = new CancellationTokenSource();
+            _listingLifetimeTask = Task.Run(async () =>
+            {
+                try
+                {
+                    await app.WaitForShutdownAsync(_listingCts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    // ignore shutdown cancellation
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Listing listener stopped unexpectedly: {ex}");
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to start listing listener: {ex}");
+        }
     }
 
     internal async Task UpdateNewsBaseUrl(string? baseUrl)
@@ -210,14 +239,66 @@ public partial class App : Application
         }
     }
 
-    protected override async void OnExit(ExitEventArgs e)
+    private async Task StopListingListenerAsync()
     {
+        try
+        {
+            _listingCts?.Cancel();
+            if (_listingLifetimeTask != null)
+            {
+                try { await _listingLifetimeTask.ConfigureAwait(false); }
+                catch (OperationCanceledException) { }
+            }
+
+            if (_listingApp != null)
+            {
+                await _listingApp.StopAsync().ConfigureAwait(false);
+                await _listingApp.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to stop listing listener: {ex}");
+        }
+        finally
+        {
+            _listingLifetimeTask = null;
+            if (_listingCts != null)
+            {
+                _listingCts.Dispose();
+                _listingCts = null;
+            }
+            _listingApp = null;
+        }
+    }
+
+    protected override void OnExit(ExitEventArgs e)
+    {
+        StopListingListenerAsync().GetAwaiter().GetResult();
         if (_freeNewsHub != null)
-            await _freeNewsHub.DisposeAsync();
+        {
+            try
+            {
+                _freeNewsHub.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Failed to dispose news hub: {ex}");
+            }
+            _freeNewsHub = null;
+        }
         if (_newsHub != null)
-            await _newsHub.DisposeAsync();
-        if (_listingApp != null)
-            await _listingApp.StopAsync();
+        {
+            try
+            {
+                _newsHub.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Failed to dispose DB hub: {ex}");
+            }
+            _newsHub = null;
+        }
         base.OnExit(e);
     }
 


### PR DESCRIPTION
## Summary
- start the internal listing listener on a background task after cancelling any existing instance so startup no longer blocks the UI
- add graceful shutdown handling for the listing listener and dispose news services safely during application exit

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d702c6d2e883338aafd0ab02c7984e