### PR TITLE
Fix hosting shutdown extension import

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Hosting;
 using System.Net.Http.Json;
 using System.Text.Json;
 using BinanceUsdtTicker.Models;


### PR DESCRIPTION
## Summary
- add the Microsoft.Extensions.Hosting namespace to resolve the WebApplication WaitForShutdownAsync extension method

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d70b7834d88333bda6f82b3a244ea9