### PR TITLE
Ensure baseline price is captured for new ticker rows

### DIFF
--- a/Tests/CoinsGridViewModelTests.cs
+++ b/Tests/CoinsGridViewModelTests.cs
@@ -1,0 +1,21 @@
+using System.Linq;
+using BinanceUsdtTicker.ViewModels.Coins;
+using Xunit;
+
+namespace BinanceUsdtTicker.Tests;
+
+public class CoinsGridViewModelTests
+{
+    [Fact]
+    public void ApplyTick_AssignsBaselinePriceWhenMissing()
+    {
+        var vm = new CoinsGridViewModel();
+        var update = new TickerUpdate("BTCUSDT", 100m, 0.0, 10m);
+
+        vm.ApplyTick(update);
+
+        var row = Assert.Single(vm.Items);
+        Assert.Equal(100m, row.Price);
+        Assert.Equal(100m, row.BaselinePrice);
+    }
+}

--- a/ViewModels/Coins/CoinsGridViewModel.cs
+++ b/ViewModels/Coins/CoinsGridViewModel.cs
@@ -71,6 +71,8 @@ namespace BinanceUsdtTicker.ViewModels.Coins
                 row.LastUpdate = update.LastUpdate.Value;
             if (update.BaselinePrice.HasValue && !row.BaselinePrice.HasValue)
                 row.BaselinePrice = update.BaselinePrice.Value;
+            if (!row.BaselinePrice.HasValue && update.Price > 0m)
+                row.BaselinePrice = update.Price;
         }
 
         private TickerRow Add(string symbol)


### PR DESCRIPTION
## Summary
- set a fallback baseline price to the first received ticker price so the positive/negative filters keep showing rows on launch
- add a unit test that verifies the baseline is initialized when applying the first tick to a new symbol

## Testing
- not run (dotnet CLI not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d7159de4608333958fe38b5070f00a