### PR TITLE
Fix DateTimeOffset handling when loading news

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -234,9 +234,9 @@ namespace BinanceUsdtTicker
                     var titleTranslate = reader.IsDBNull(3) ? null : reader.GetString(3);
                     var url = reader.IsDBNull(4) ? string.Empty : reader.GetString(4);
                     var symbolsStr = reader.IsDBNull(5) ? string.Empty : reader.GetString(5);
-                    var created = reader.GetDateTime(6);
+                    var created = reader.GetFieldValue<DateTimeOffset>(6);
                     var symbols = symbolsStr.Split(',', StringSplitOptions.RemoveEmptyEntries);
-                    var createdUtc = DateTime.SpecifyKind(created, DateTimeKind.Utc);
+                    var createdUtc = created.UtcDateTime;
                     items.Add(new NewsItem(id, source, createdUtc, title, titleTranslate, null, url, NewsType.Listing, symbols));
                 }
 


### PR DESCRIPTION
## Summary
- read CreatedAt values as DateTimeOffset when loading news items
- convert DateTimeOffset values to UTC before creating NewsItem instances

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7b51da1a88333bb13ef36063a1417