### PR TITLE
Replace DevExpress theme helper with internal resource manager

### DIFF
--- a/Helpers/ThemeResourceManager.cs
+++ b/Helpers/ThemeResourceManager.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+
+namespace BinanceUsdtTicker.Helpers;
+
+/// <summary>
+///     Lightweight alternative to the removed DevExpress theme helper.
+///     Handles swapping theme dictionaries in the application resources.
+/// </summary>
+public static class ThemeResourceManager
+{
+    private static readonly string[] ThemeSuffixes =
+    {
+        "/Light.xaml",
+        "/Dark.xaml",
+        "Themes/Light.xaml",
+        "Themes/Dark.xaml"
+    };
+
+    public static void ApplyTheme(ResourceDictionary resources, ThemeKind theme)
+    {
+        if (resources == null) return;
+
+        var uri = new Uri($"Themes/{(theme == ThemeKind.Dark ? "Dark" : "Light")}.xaml", UriKind.Relative);
+        SwapThemeDictionary(resources.MergedDictionaries, uri);
+    }
+
+    public static void ApplyApplicationTheme(ThemeKind theme, Window? excludeWindow = null)
+    {
+        if (Application.Current == null) return;
+
+        ApplyTheme(Application.Current.Resources, theme);
+
+        foreach (Window window in Application.Current.Windows)
+        {
+            if (ReferenceEquals(window, excludeWindow))
+                continue;
+
+            if (window?.Resources != null)
+            {
+                ApplyTheme(window.Resources, theme);
+            }
+        }
+    }
+
+    private static void SwapThemeDictionary(IList<ResourceDictionary> dictionaries, Uri newTheme)
+    {
+        if (dictionaries == null) return;
+
+        for (var i = dictionaries.Count - 1; i >= 0; i--)
+        {
+            if (IsThemeDictionary(dictionaries[i]))
+            {
+                dictionaries.RemoveAt(i);
+            }
+        }
+
+        dictionaries.Add(new ResourceDictionary { Source = newTheme });
+    }
+
+    private static bool IsThemeDictionary(ResourceDictionary dictionary)
+    {
+        var source = dictionary.Source?.OriginalString;
+        if (string.IsNullOrWhiteSpace(source)) return false;
+
+        return ThemeSuffixes.Any(suffix => source.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -23,6 +23,7 @@ using BinanceUsdtTicker.Models;
 using Microsoft.Data.SqlClient;
 using BinanceUsdtTicker.Data;
 using BinanceUsdtTicker.Runtime;
+using BinanceUsdtTicker.Helpers;
 using BinanceUsdtTicker.Views.Coins;
 
 namespace BinanceUsdtTicker
@@ -338,28 +339,8 @@ namespace BinanceUsdtTicker
         {
             _theme = kind;
 
-            // Removed dependency on DevExpress ApplicationThemeHelper/Theme.
-            // Theme switching now relies solely on resource dictionaries.
-            var name = kind == ThemeKind.Dark ? "Dark" : "Light";
-            var uri = new Uri($"Themes/{name}.xaml", UriKind.Relative);
-
-            void SwapThemes(Collection<ResourceDictionary> col, Uri newUri)
-            {
-                for (int i = col.Count - 1; i >= 0; i--)
-                {
-                    var src = col[i].Source?.OriginalString ?? string.Empty;
-                    if (src.EndsWith("/Dark.xaml", StringComparison.OrdinalIgnoreCase) ||
-                        src.EndsWith("/Light.xaml", StringComparison.OrdinalIgnoreCase))
-                    {
-                        col.RemoveAt(i);
-                    }
-                }
-                col.Add(new ResourceDictionary { Source = newUri });
-            }
-
-            SwapThemes(this.Resources.MergedDictionaries, uri);
-            if (Application.Current != null)
-                SwapThemes(Application.Current.Resources.MergedDictionaries, uri);
+            ThemeResourceManager.ApplyTheme(Resources, kind);
+            ThemeResourceManager.ApplyApplicationTheme(kind, this);
 
             ApplyCustomColors();
         }


### PR DESCRIPTION
## Summary
- add a lightweight `ThemeResourceManager` to swap theme resource dictionaries without relying on DevExpress helpers
- update the main window to use the new helper when applying themes so all open windows refresh their resources

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7b697c6048333abc1946fc1c1675e